### PR TITLE
fix(skills): add engineering to README and improve cross-skill references

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ Dives deep into your project to investigate any question using layered search st
 
 **Use when:** You want to investigate "how does X work", "what is Y", "where is Z", or dive into features, APIs, configuration, architecture, or any technical implementation details.
 
+### 🏗️ engineering
+
+Guides technical decisions, architecture, and implementation for building robust software systems.
+
+**Features:**
+- Technical decision frameworks (evaluate options, weigh trade-offs)
+- Architecture patterns (layered, modular, event-driven)
+- Module boundary design and data flow planning
+- API design principles (REST, error handling, versioning)
+- Refactoring strategies (when, how, safely)
+- Performance optimization guidance
+
+**Use when:** Making tech choices, designing systems, evaluating trade-offs, planning refactoring, optimizing performance, or asking "how should I build this?"
+
 ### 🧹 housekeeping
 
 Manages project housekeeping including documentation organization, dependency management, directory structure, code cleanup, technical debt tracking, and infrastructure configuration.

--- a/skills/authoring-skills/anti-patterns.md
+++ b/skills/authoring-skills/anti-patterns.md
@@ -30,6 +30,8 @@ For each anti-pattern, we explain:
 15. [Vague Workflow Steps](#15-vague-workflow-steps)
 16. [No Verification Before Critical Ops](#16-no-verification-before-critical-ops)
 17. [Mixed Naming Patterns](#17-mixed-naming-patterns)
+18. [Relative Paths to Other Skills](#18-relative-paths-to-other-skills)
+19. [Missing Boundary Guidance](#19-missing-boundary-guidance)
 - [Quick Reference Checklist](#quick-reference-checklist)
 
 ## 1. Windows-Style Paths
@@ -337,9 +339,76 @@ Assume Claude knows: file formats, programming concepts, standard tools, common 
 
 ## 17. Mixed Naming Patterns
 
-**Bad**: Mixing gerund, noun, verb forms  
-**Good**: All gerund (processing-pdfs, analyzing-excel) OR all noun  
+**Bad**: Mixing gerund, noun, verb forms
+**Good**: All gerund (processing-pdfs, analyzing-excel) OR all noun
 **Rule**: Pick one pattern, use consistently.
+
+---
+
+## 18. Relative Paths to Other Skills
+
+**Bad**:
+```markdown
+For cleanup tasks, use [housekeeping](../housekeeping/SKILL.md).
+```
+
+**Good**:
+```markdown
+For cleanup tasks, use `housekeeping`.
+```
+
+### Why It's Problematic
+
+Skills can be installed independently via `npx skills add repo/skills`. When a user installs only one skill, relative paths like `../other-skill/SKILL.md` break because the referenced skill doesn't exist in their installation.
+
+### Violates: Enable Discovery
+
+Broken links frustrate users and break the skill discovery mechanism. The skill name alone is sufficient—the system resolves skill references automatically.
+
+### Real Impact
+
+- Broken links when skills installed separately
+- Confusing error messages
+- Users can't follow suggested skill references
+- Defeats the purpose of modular skill installation
+
+### The Fix
+
+Reference other skills by name only using inline code format: `` `skill-name` ``. The system handles resolution. This works whether skills are installed together or separately.
+
+---
+
+## 19. Missing Boundary Guidance
+
+**Bad**: Related skills with overlapping domains, no guidance on which to use
+
+**Good**:
+```markdown
+# engineering
+**Not this skill**: For cleanup tasks, use `housekeeping`.
+
+# housekeeping
+**Not this skill**: For technical decisions, use `engineering`.
+```
+
+### Why It's Problematic
+
+When multiple skills could potentially handle a request, Claude must guess which one is more appropriate. Without explicit boundary guidance, the wrong skill may trigger, or Claude may hesitate between options. Clear boundaries help both Claude and users.
+
+### Violates: Enable Discovery
+
+Discovery isn't just about finding *a* skill—it's about finding the *right* skill. Boundary guidance is part of discovery, telling Claude when NOT to use this skill.
+
+### Real Impact
+
+- Wrong skill triggered for task
+- User gets suboptimal guidance
+- Inconsistent behavior across sessions
+- Skill creators duplicate effort
+
+### The Fix
+
+Add "Not this skill" guidance at the top of SKILL.md for skills with related domains. Make boundaries bidirectional—if A points to B, B should point back to A. Use skill names (not paths) for the reference.
 
 ---
 

--- a/skills/engineering/SKILL.md
+++ b/skills/engineering/SKILL.md
@@ -16,7 +16,7 @@ Technical leadership for projects - making sound technical decisions, designing 
 - **Planning refactoring** - Code needs structural improvement
 - **Optimizing performance** - System doesn't meet requirements
 
-**Not this skill**: For cleanup tasks (removing dead code, updating deps), use [housekeeping](../housekeeping/SKILL.md).
+**Not this skill**: For cleanup tasks (removing dead code, updating deps), use `housekeeping`.
 
 ## Quick Navigation
 

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -7,6 +7,8 @@ description: Manages project housekeeping including documentation organization (
 
 Maintains project infrastructure, organization, and cleanliness - the "home management" that keeps projects healthy as they grow. While feature development focuses on external value ("building the business"), housekeeping focuses on internal quality ("managing the home").
 
+**Not this skill**: For technical decisions (architecture, API design, tech choices), use `engineering`.
+
 ## Quick Start
 
 ### Common Housekeeping Tasks

--- a/skills/housekeeping/documentation/lifecycle.md
+++ b/skills/housekeeping/documentation/lifecycle.md
@@ -358,6 +358,7 @@ Define clear rules for your project:
    - Delete obsolete content
    - Fix broken links
    - Update index files (README, AGENTS.md)
+   - **Sync check**: Verify README reflects actual project structure
 
 4. **Document** (Week 4)
    - Log what was archived/deleted


### PR DESCRIPTION
## Summary

Housekeeping review 发现并修复了 skills 间引用问题，同时沉淀了最佳实践到 authoring-skills。

## Changes

- **README.md**: 添加缺失的 engineering skill 介绍
- **engineering ↔ housekeeping**: 添加双向边界指引 ("Not this skill")
- **路径引用**: 相对路径 `../skill/SKILL.md` → skill name `` `skill` ``
- **anti-patterns.md**: 新增 #18 (Relative Paths) 和 #19 (Missing Boundaries)
- **lifecycle.md**: 审计流程添加 README 同步检查

## Architecture

```
Before:                          After:
engineering ──────→ housekeeping  engineering ←────→ housekeeping
           (one-way path)                    (bidirectional names)
```

## Testing

- [x] 验证所有 SKILL.md 文件格式正确
- [x] 确认无相对路径引用其他 skills

## Reviewer Notes

- Skills 可被独立安装 (`npx skills add`)，相对路径会失效
- 边界指引帮助 Claude 选择正确的 skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)