### PR TITLE
feat(skills): add orientation skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ A collection of reusable skills (plugins) for AI agents. Skills provide procedur
 ## Dogfooding
 
 Most skills in this repository are dogfooded - used to develop the project itself:
+- **orientation**: initial project/session orientation
 - **refining**: commits and PRs for this repo
 - **authoring-skills**: guides skill creation
 - **dive**: investigates skill implementations
@@ -53,19 +54,21 @@ Constraints:
 
 | Skill | Purpose |
 |-------|---------|
-| **refining** | Code review workflow: commit → review → PR/MR creation |
-| **authoring-skills** | Meta-skill for creating effective Agent Skills |
+| **orientation** | Project/session entry point: scan docs, discover skills, suggest direction |
 | **dive** | Evidence-based investigation with file:line citations |
 | **engineering** | Technical decisions, architecture, implementation guidance |
 | **housekeeping** | Project maintenance: docs, deps, structure, tech debt |
+| **refining** | Code review workflow: commit → review → PR/MR creation |
+| **authoring-skills** | Meta-skill for creating effective Agent Skills |
 | **frontend-init** | Bootstrap modern frontend projects (Bun, Oxlint, tsdown) |
 
 ### Skill Boundaries
 
+- **Orientation** orients (entry point: scan project, discover skills, suggest direction)
+- **Dive** investigates (evidence-based answers about code)
 - **Engineering** designs capability (architecture, tech choices, refactoring strategies)
 - **Housekeeping** maintains health (cleanup, organization, tracking)
 - **Refining** ensures quality (commits, reviews, PRs)
-- **Dive** investigates (evidence-based answers about code)
 
 ## Contributing Skills
 

--- a/skills/authoring-skills/SKILL.md
+++ b/skills/authoring-skills/SKILL.md
@@ -68,7 +68,7 @@ When creating a skill, apply these principles:
 2. **Draft metadata** - Name (lowercase-with-hyphens) and description (WHAT + WHEN)
 3. **Design for disclosure** - What goes in SKILL.md vs. reference files?
 4. **Write concisely** - Assume Claude is smart. Skip the obvious.
-5. **Test discoverability** - Would Claude pick this skill for the right tasks?
+5. **Test with sub-agent** - Dry-run discovery, execution, and boundary tests (see [Testing](#testing-with-sub-agent))
 
 ## Essential Constraints
 
@@ -150,6 +150,54 @@ Before finalizing, ask yourself:
 - Consistent terminology?
 - Concrete examples over abstract descriptions?
 - No time-sensitive information?
+
+## Testing with Sub-Agent
+
+Use Task tool to dry-run test your skill before finalizing.
+
+### 1. Discovery Test
+
+Verify the description triggers correctly:
+
+```
+Task tool → Explore agent:
+"Given this user request: '[typical trigger phrase]',
+which skill would you recommend and why?"
+```
+
+**Pass criteria**: Agent identifies your skill for the right scenarios.
+
+### 2. Execution Test
+
+Verify the skill content is actionable:
+
+```
+Task tool → General-purpose agent:
+"Using the [skill-name] skill located at [path],
+perform this task: [realistic task]"
+```
+
+**Pass criteria**: Agent follows the workflow without confusion or asking for clarification on skill instructions.
+
+### 3. Boundary Test
+
+Verify the skill doesn't over-trigger:
+
+```
+Task tool → Explore agent:
+"Given this user request: '[edge case that should NOT trigger]',
+which skill would you recommend?"
+```
+
+**Pass criteria**: Agent recommends a different skill or no skill.
+
+### Quick Test Checklist
+
+| Test | Prompt Example | Expected |
+|------|----------------|----------|
+| Discovery | "How do I [trigger phrase]?" | Recommends this skill |
+| Execution | "[Realistic task]" | Completes using skill workflow |
+| Boundary | "[Similar but different task]" | Recommends other skill |
 
 ## Storage Locations
 

--- a/skills/orientation/SKILL.md
+++ b/skills/orientation/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: orientation
+description: Orients agents in new projects by scanning entry documents (CLAUDE.md, AGENTS.md, README) and discovering available skills. Use at session start, when entering unfamiliar projects, when asking "what can you do", "where do I start", or needing project overview.
+---
+
+# Orientation
+
+Helps agents quickly orient themselves in a project - understanding context, available capabilities, and where to start. This is the "look around before diving in" skill.
+
+## When to Use
+
+- **Session start**: First interaction with a project
+- **New project**: Unfamiliar codebase, need overview
+- **Capability discovery**: "What skills are available?", "What can you help with?"
+- **Direction needed**: "Where should I start?", "How is this organized?"
+
+**Not this skill**:
+- Deep investigation → use `dive`
+- Technical decisions → use `engineering`
+- Project maintenance → use `housekeeping`
+
+## Core Workflow
+
+### 1. Scan Entry Documents
+
+Check for project entry points in order:
+
+```
+Priority 1 (Agent-specific):
+  CLAUDE.md          → Claude Code instructions
+  AGENTS.md          → General agent guidance
+  .claude/           → Claude-specific config
+
+Priority 2 (Project docs):
+  README.md          → Project overview
+  CONTRIBUTING.md    → Contribution guidelines
+  docs/              → Documentation directory
+
+Priority 3 (Structure):
+  package.json       → Node.js project metadata
+  pyproject.toml     → Python project metadata
+  Cargo.toml         → Rust project metadata
+  go.mod             → Go project metadata
+```
+
+### 2. Discover Available Skills
+
+Skills can be installed at multiple locations:
+
+```
+Project-level:
+  .claude/skills/           → Claude Code skills
+  .cursor/skills/           → Cursor skills
+  .agents/skills/           → Generic agent skills
+
+Personal (user home):
+  ~/.claude/skills/         → User Claude skills
+  ~/.cursor/skills/         → User Cursor skills
+  ~/.agents/skills/         → User generic skills
+```
+
+For each skill found, extract from SKILL.md frontmatter:
+- `name`: Skill identifier
+- `description`: What it does and when to use
+
+### 3. Assess Project Type
+
+Identify project characteristics:
+
+| Signal | Indicates |
+|--------|-----------|
+| `package.json` | Node.js/JavaScript |
+| `pyproject.toml` / `requirements.txt` | Python |
+| `Cargo.toml` | Rust |
+| `go.mod` | Go |
+| `pom.xml` / `build.gradle` | Java |
+| `.github/workflows/` | CI/CD configured |
+| `docker-compose.yml` | Containerized |
+| `terraform/` / `*.tf` | Infrastructure as Code |
+
+### 4. Diagnose Documentation Health
+
+Check agent documentation status and report issues:
+
+| Check | Status | Action |
+|-------|--------|--------|
+| CLAUDE.md missing | ⚠️ Warning | Suggest `housekeeping` to create |
+| AGENTS.md missing | ⚠️ Warning | Suggest `housekeeping` to create |
+| Both missing | 🔴 Issue | Recommend creating agent docs |
+| Docs outdated (>6 months) | ⚠️ Warning | Suggest `housekeeping` to update |
+| Docs incomplete (no structure) | ⚠️ Warning | Suggest `housekeeping` to improve |
+
+**Include in report** if issues found:
+```markdown
+## Documentation Health
+
+⚠️ **Issues detected:**
+- No AGENTS.md found - consider creating one for agent guidance
+- CLAUDE.md last updated 8 months ago - may need refresh
+
+**Recommendation:** Use `housekeeping` skill to maintain agent documentation.
+```
+
+### 5. Generate Orientation Report
+
+Output format:
+
+```markdown
+## Project Overview
+
+[Summary from README/CLAUDE.md - 2-3 sentences]
+
+## Key Entry Points
+
+- **CLAUDE.md**: [brief description if exists]
+- **README.md**: [brief description if exists]
+- [other relevant docs]
+
+## Available Skills
+
+| Skill | Purpose | Trigger |
+|-------|---------|---------|
+| [name] | [what it does] | [when to use] |
+
+## Project Type
+
+- **Stack**: [detected technologies]
+- **Structure**: [monorepo/single-package/etc]
+- **Notable**: [CI/CD, Docker, etc]
+
+## Suggested Starting Points
+
+Based on [project type/context], consider:
+1. [Relevant suggestion]
+2. [Relevant suggestion]
+```
+
+## Integration with Other Skills
+
+Orientation is the **entry point** that routes to specialized skills:
+
+```
+┌─────────────────┐
+│   orientation   │  ← Start here (read-only)
+└────────┬────────┘
+         │
+         ▼
+┌────────────────────────────────────────────┐
+│  dive        → Investigation questions     │
+│  engineering → Build/design questions      │
+│  housekeeping → Maintenance, agent docs    │
+│  refining    → Commits, PRs                │
+│  authoring-skills → Create new skills      │
+└────────────────────────────────────────────┘
+```
+
+**Key collaboration**: Orientation diagnoses, housekeeping treats.
+- Orientation finds missing/outdated agent docs → recommend `housekeeping`
+- Orientation is read-only; never modifies files
+
+## Anti-Patterns
+
+- ❌ Deep diving into code (use `dive` instead)
+- ❌ Making architectural decisions (use `engineering`)
+- ❌ Modifying documentation (use `housekeeping`)
+- ❌ Executing project tasks without understanding context first
+- ❌ Assuming project structure without scanning
+
+## Example Outputs
+
+### Example 1: Node.js Project (Healthy Docs)
+
+```markdown
+## Project Overview
+
+A CLI tool for managing cloud infrastructure, built with TypeScript and Commander.js.
+
+## Key Entry Points
+
+- **CLAUDE.md**: Project conventions, testing requirements
+- **README.md**: Installation, usage examples
+- **docs/architecture.md**: System design
+
+## Documentation Health
+
+✅ Agent documentation is healthy.
+
+## Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| dive | Investigate codebase questions |
+| engineering | Technical decisions |
+| refining | Commits and PRs |
+
+## Project Type
+
+- **Stack**: TypeScript, Node.js, Commander.js
+- **Structure**: Single package
+- **Notable**: GitHub Actions CI, Jest tests
+
+## Suggested Starting Points
+
+1. Review `src/index.ts` for CLI entry point
+2. Check `docs/architecture.md` for system design
+3. Use `dive` skill to investigate specific features
+```
+
+### Example 2: Monorepo (Docs Need Attention)
+
+```markdown
+## Project Overview
+
+Monorepo containing frontend (React), backend (Python), and shared infrastructure.
+
+## Key Entry Points
+
+- **README.md**: Basic project overview
+- **packages/frontend/README.md**: React app docs
+- **packages/backend/README.md**: API docs
+
+## Documentation Health
+
+⚠️ **Issues detected:**
+- No AGENTS.md or CLAUDE.md found
+- README.md lacks agent-specific guidance
+
+**Recommendation:** Use `housekeeping` skill to create AGENTS.md with:
+- Cross-package conventions
+- Navigation for monorepo structure
+- Common workflows
+
+## Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| dive | Investigate any package |
+| housekeeping | Maintain dependencies, create agent docs |
+| engineering | Cross-package decisions |
+
+## Project Type
+
+- **Stack**: React, Python, PostgreSQL
+- **Structure**: Monorepo (pnpm workspaces)
+- **Notable**: Docker Compose, Turborepo
+
+## Suggested Starting Points
+
+1. Review root `package.json` for workspace config
+2. Check `docker-compose.yml` for local dev setup
+3. Consider creating AGENTS.md for better agent guidance
+```


### PR DESCRIPTION
## Summary

- Add new `orientation` skill as the entry point for agent sessions
- Scans project entry documents and discovers available skills
- Diagnoses documentation health and collaborates with `housekeeping`
- Updates CLAUDE.md with new skill in boundaries and dogfooding list
- **Bonus**: Add sub-agent testing workflow to `authoring-skills`

## Design

```
┌─────────────────┐
│   orientation   │  ← Entry point (read-only)
└────────┬────────┘
         │
         ▼
┌────────────────────────────────────────────┐
│  dive        → Investigation questions     │
│  engineering → Build/design questions      │
│  housekeeping → Maintenance, agent docs    │
│  refining    → Commits, PRs                │
└────────────────────────────────────────────┘
```

**Key principle**: Orientation diagnoses, housekeeping treats.

## Test Results (Dry-run with Sub-Agent)

| Test | Status | Notes |
|------|--------|-------|
| Discovery | ✅ Pass | Correctly triggers on "where should I start" |
| Boundary | ✅ Pass | Does not trigger on investigation questions |
| Execution | ✅ Pass | Generates complete orientation report |

## Changes

| File | Change |
|------|--------|
| `skills/orientation/SKILL.md` | New skill (252 lines) |
| `CLAUDE.md` | Add orientation to skills table |
| `skills/authoring-skills/SKILL.md` | Add sub-agent testing workflow |

🤖 Generated with [Claude Code](https://claude.com/claude-code)