### PR TITLE
feat(skills): add memory skill for cross-session context persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Most skills in this repository are dogfooded - used to develop the project itsel
 - **dive**: investigates skill implementations
 - **engineering**: architectural decisions
 - **housekeeping**: project organization
+- **memory**: cross-session context and decision tracking
 
 **Not dogfooded**: frontend-init (project bootstrapping, not applicable to this repo)
 
@@ -60,6 +61,7 @@ Constraints:
 | **housekeeping** | Project maintenance: docs, deps, structure, tech debt |
 | **refining** | Code review workflow: commit → review → PR/MR creation |
 | **authoring-skills** | Meta-skill for creating effective Agent Skills |
+| **memory** | Local filesystem memory: notes, decisions, todos, session summaries |
 | **frontend-init** | Bootstrap modern frontend projects (Bun, Oxlint, tsdown) |
 
 ### Skill Boundaries

--- a/README.md
+++ b/README.md
@@ -95,6 +95,44 @@ Manages project housekeeping including documentation organization, dependency ma
 
 **Use when:** Organizing documentation, cleaning up dependencies (package.json, requirements.txt), reorganizing folders, removing dead code, addressing tech debt, or maintaining project structure and configuration.
 
+### 🧭 orientation
+
+Orients agents in new projects by scanning entry documents and discovering available skills.
+
+**Features:**
+- Scans CLAUDE.md, AGENTS.md, README for project context
+- Discovers skills at project and user level
+- Assesses project type and tech stack
+- Diagnoses documentation health
+- Generates orientation report with suggested starting points
+
+**Use when:** Starting a new session, entering unfamiliar projects, asking "what can you do", "where do I start", or needing a project overview.
+
+### 🧠 memory
+
+Manages project-level memory using local filesystem with optional GitHub/GitLab Issues sync.
+
+**Features:**
+- Store notes, decisions, todos, session summaries in `.memory/`
+- Cross-device sync via GitHub/GitLab Issues (MCP or CLI)
+- Hook integration for auto-init on session start
+- context.md as sync anchor with Issue references
+
+**Use when:** Need to remember context across sessions, track decisions, manage todos, build project knowledge base, or mention "remember", "recall", "save this".
+
+### 🚀 frontend-init
+
+Initialize frontend projects with opinionated modern toolchain.
+
+**Features:**
+- Bun as package manager
+- Oxlint for linting, Oxfmt for formatting
+- tsdown for npm bundler
+- tsgo for type checking
+- Minimal, fast, modern defaults
+
+**Use when:** Creating new frontend/TypeScript projects, setting up project tooling, or mentions "init project", "new frontend", "setup tooling".
+
 ## Skill Structure
 
 Each skill follows a consistent structure:

--- a/skills/housekeeping/SKILL.md
+++ b/skills/housekeeping/SKILL.md
@@ -46,12 +46,14 @@ Maintains project infrastructure, organization, and cleanliness - the "home mana
 - Create navigation files (AGENTS.md) for AI agents
 - Implement lifecycle management (cleanup temporary docs)
 - Use RFC process for significant decisions
+- **Verify index consistency** (README lists vs actual directories)
 
 **Common problems addressed**:
 - Can't find documentation
 - Docs outdated or conflicting
 - No clear place for new docs
 - Documentation not used by team or agents
+- Index documents (README, CLAUDE.md) don't reflect actual content
 
 **Links**:
 - [Organization Strategies](documentation/organization-strategies.md) - How to structure documentation
@@ -228,6 +230,9 @@ Maintains project infrastructure, organization, and cleanliness - the "home mana
    - Check for outdated content (last modified >6 months)
    - Verify AGENTS.md is current
    - Clean up temporary docs
+   - **Index consistency**: Compare index docs (README, CLAUDE.md) against actual directories
+     - Do listed items match existing directories/files?
+     - Are new directories missing from indexes?
 
 2. **Dependency check**
    - List outdated: `npm outdated` or `pip list --outdated`
@@ -289,10 +294,14 @@ Maintains project infrastructure, organization, and cleanliness - the "home mana
 3. Check for outdated: `find . -name "*.md" -mtime +180` (>6 months old)
 4. Clean up temporary docs (docs/notes/ or similar)
 5. Verify AGENTS.md reflects current structure
-6. Fix broken links: check manually or with tool
-7. Update navigation in README
-8. Archive or delete obsolete content
-9. Commit changes
+6. **Index consistency check**:
+   - Identify index documents (README, CLAUDE.md, docs/index.md)
+   - Compare listed items against actual directories/files
+   - Add missing items, remove stale references
+7. Fix broken links: check manually or with tool
+8. Update navigation in README
+9. Archive or delete obsolete content
+10. Commit changes
 
 **Time**: 2-4 hours quarterly
 

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: memory
+description: Manages project-level memory using local filesystem (.memory/) with optional GitHub/GitLab Issues sync (via MCP tools or CLI). Stores notes, decisions, todos, sessions locally; uses Issues for cross-device task tracking. Triggers on "remember", "recall", "what did we", "save this", "todo", "decision", "sync memory".
+---
+
+# Memory
+
+Local filesystem memory for cross-session knowledge persistence. Zero dependencies for local use; optional GitHub/GitLab sync for cross-device.
+
+## When to Use
+
+- **Persist knowledge**: "Remember this", "Save this decision"
+- **Recall context**: "What did we discuss about X?"
+- **Track tasks**: "Add todo", "What's pending?"
+- **Record decisions**: "We decided X because..."
+- **Session handoff**: Summarize for next session
+
+**Not this skill**: Project docs (edit directly), code comments, git history.
+
+## Storage Structure
+
+```
+.memory/
+├── context.md          # Current context + Issue references
+├── notes/              # Knowledge, learnings
+├── decisions/          # Architecture Decision Records
+├── todos/              # Local task tracking (or use Issues)
+└── sessions/           # Session summaries
+```
+
+File naming: `YYYY-MM-DD-kebab-slug.md` (natural sort, grep-friendly).
+
+## Record Format
+
+```markdown
+---
+type: note | decision | todo | session
+status: active | completed | archived
+tags: [tag1, tag2]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Title
+
+Content...
+```
+
+See [templates/](templates/) for type-specific formats.
+
+## Core Operations
+
+| Operation | Action |
+|-----------|--------|
+| Create | Write to appropriate subdirectory with template |
+| Search | `grep -ri "term" .memory/` |
+| Update | Modify file, update `updated:` date |
+| List active | `grep -l "status: active" .memory/**/*.md` |
+
+## Workflows
+
+**Remember decision**: Create `.memory/decisions/YYYY-MM-DD-slug.md` with rationale.
+
+**Recall context**: Search `.memory/`, summarize findings with file references.
+
+**Track task**: Create `.memory/todos/YYYY-MM-DD-slug.md` or create GitHub/GitLab Issue.
+
+**Session summary**: Create `.memory/sessions/YYYY-MM-DD-summary.md` at session end.
+
+## Integration
+
+```
+Memory provides context for:
+├── dive        → Past learnings inform investigation
+├── engineering → Past decisions inform new ones
+├── refining    → Session history helps PR descriptions
+└── orientation → Memory supplements project docs
+```
+
+## Anti-Patterns
+
+- Storing code snippets (use gists or project files)
+- Duplicating documentation (link instead)
+- Large files (split into focused records)
+- Sensitive data (credentials, API keys)
+- Binary files (text-only)
+
+## Setup
+
+See [reference/setup.md](reference/setup.md) for initialization options:
+- Automatic via hooks (Claude Code, Cursor)
+- Manual setup
+- Git configuration
+
+## Remote Sync (Optional)
+
+Use GitHub/GitLab Issues for cross-device task tracking. See [reference/remote-sync.md](reference/remote-sync.md) for:
+- MCP tools vs CLI usage
+- context.md format
+- Sync workflow and conflict handling

--- a/skills/memory/reference/remote-sync.md
+++ b/skills/memory/reference/remote-sync.md
@@ -1,0 +1,158 @@
+# Remote Sync
+
+Use GitHub/GitLab Issues as cross-device memory layer. Issues ARE the memory, not a copy.
+
+## Philosophy
+
+```
+.memory/context.md ←──references──→ GitHub/GitLab Issues
+       │                                    │
+   Local details                     Shared tasks
+   Agent notes                       Tracking issue
+   Session history                   Work issues
+```
+
+- **Issues = Tasks**: Use real Issues for cross-device todos
+- **Tracking Issue = Roadmap**: One Issue links all active work
+- **context.md = Index**: References Issues + local-only notes
+- **Local todos/**: Fallback when offline or no remote configured
+
+## Access Methods
+
+| Method | Best For | Priority |
+|--------|----------|----------|
+| MCP Tools | Agent operations | 1st (if available) |
+| CLI (gh/glab) | Hooks, scripts | 2nd |
+| Local-only | Offline work | Fallback |
+
+### MCP Tools
+
+```
+mcp__github__get_issue(owner, repo, issue_number)
+mcp__github__create_issue(owner, repo, title, body)
+mcp__github__update_issue(owner, repo, issue_number, body)
+mcp__github__list_issues(owner, repo, labels)
+```
+
+### CLI Detection
+
+```bash
+if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+  echo "github"
+elif command -v glab &>/dev/null && glab auth status &>/dev/null 2>&1; then
+  echo "gitlab"
+else
+  echo "none"
+fi
+```
+
+## context.md Format
+
+```markdown
+---
+tracking: "#99"
+active_issues: ["#42", "#43"]
+synced: YYYY-MM-DDTHH:MM:SSZ
+---
+
+# Project Context
+
+## Active Work
+<!-- Cache of Issue states - may be stale if synced > 1 hour ago -->
+- #42 Implement auth - open
+- #43 Add rate limiting - open
+
+## Local Context
+<!-- Agent-specific notes not in Issues -->
+- Auth: JWT + refresh tokens
+- Stack: Node.js, TypeScript
+
+## Key Decisions
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| YYYY-MM-DD | PostgreSQL | JSONB + relational joins |
+```
+
+## Sync Workflow
+
+```
+Session Start:
+├── Read .memory/context.md
+├── Fetch Issues (MCP or CLI)
+└── Update Active Work section
+
+Working:
+├── Create Issue → add to active_issues
+├── Update local notes in context.md
+└── Write to .memory/notes/, decisions/
+
+Session End:
+├── Update tracking Issue with summary
+├── Update synced timestamp
+└── Create .memory/sessions/ record
+```
+
+## Conflict Handling
+
+**Principle**: Remote (Issues) is source of truth for task state.
+
+| Scenario | Resolution |
+|----------|------------|
+| Issue closed remotely | sync-pull removes from Active Work |
+| Local edits while offline | sync-push appends, doesn't overwrite |
+| Concurrent edits | Remote wins on pull; push is additive |
+
+**sync-push strategy**: Append session summary to tracking Issue rather than replacing body. Use HTML comments to mark agent-managed sections:
+
+```markdown
+<!-- AGENT-MEMORY-START -->
+## Current State
+...
+<!-- AGENT-MEMORY-END -->
+```
+
+## Hook Integration
+
+### Claude Code
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [{ "type": "command", "command": "memory-sync-pull.sh" }]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [{ "type": "command", "command": "memory-sync-push.sh" }]
+      }
+    ]
+  }
+}
+```
+
+### Cursor
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [{ "command": "memory-sync-pull.sh" }],
+    "sessionEnd": [{ "command": "memory-sync-push.sh" }]
+  }
+}
+```
+
+## What Goes Where
+
+| Content | Location | Why |
+|---------|----------|-----|
+| Cross-device tasks | GitHub/GitLab Issues | Notifications, assignees |
+| Tracking/Roadmap | Tracking Issue | Single source of truth |
+| Local-only tasks | .memory/todos/ | Offline, no remote |
+| Context cache | context.md | Fast local access |
+| Decisions | .memory/decisions/ | Detailed rationale |
+| Sessions | .memory/sessions/ | Local continuity |
+| Notes | .memory/notes/ | Learnings, references |

--- a/skills/memory/reference/setup.md
+++ b/skills/memory/reference/setup.md
@@ -1,0 +1,88 @@
+# Setup
+
+## Automatic (Hook-based)
+
+### Claude Code
+
+Add to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'DIR=\"${CLAUDE_PROJECT_DIR:-.}/.memory\"; [ -d \"$DIR\" ] || mkdir -p \"$DIR\"/{notes,decisions,todos,sessions}'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/hooks.json`:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "bash -c 'DIR=\"$(pwd)/.memory\"; [ -d \"$DIR\" ] || mkdir -p \"$DIR\"/{notes,decisions,todos,sessions}'"
+      }
+    ]
+  }
+}
+```
+
+## Manual
+
+```bash
+mkdir -p .memory/{notes,decisions,todos,sessions}
+```
+
+## Git Configuration
+
+**Personal memory** (not shared):
+```gitignore
+.memory/
+```
+
+**Team memory** (shared): Commit `.memory/` to repository.
+
+**Hybrid approach**:
+```gitignore
+# Share decisions and notes, keep sessions personal
+.memory/sessions/
+.memory/context.md
+```
+
+## Initial context.md
+
+After creating directories, optionally create `.memory/context.md`:
+
+```markdown
+---
+tracking: ""
+active_issues: []
+synced: ""
+---
+
+# Project Context
+
+## Active Work
+
+## Local Context
+
+## Key Decisions
+| Date | Decision | Rationale |
+|------|----------|-----------|
+```
+
+This file becomes the anchor for remote sync if configured.

--- a/skills/memory/scripts/init.sh
+++ b/skills/memory/scripts/init.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Memory initialization hook
+# Run on SessionStart to ensure .memory/ structure exists
+
+MEMORY_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}/.memory"
+
+# Only initialize if directory doesn't exist
+if [ ! -d "$MEMORY_DIR" ]; then
+  mkdir -p "$MEMORY_DIR"/{notes,decisions,todos,sessions}
+
+  # Create initial context.md
+  cat > "$MEMORY_DIR/context.md" << 'EOF'
+---
+tracking: ""
+active_issues: []
+synced: ""
+---
+
+# Project Context
+
+## Active Work
+
+## Local Context
+
+## Key Decisions
+| Date | Decision | Rationale |
+|------|----------|-----------|
+EOF
+
+  # Create README
+  cat > "$MEMORY_DIR/README.md" << 'EOF'
+# Project Memory
+
+Local memory storage for cross-session context.
+
+## Structure
+
+- `context.md` - Current context + Issue references
+- `notes/` - Knowledge, learnings, references
+- `decisions/` - Architecture Decision Records
+- `todos/` - Local task tracking
+- `sessions/` - Session summaries
+
+## Search
+
+```bash
+grep -ri "keyword" .memory/
+```
+EOF
+
+  echo "Initialized .memory/ directory"
+fi
+
+exit 0

--- a/skills/memory/scripts/sync-pull.sh
+++ b/skills/memory/scripts/sync-pull.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Pull Issue states from GitHub/GitLab into context.md
+set -e
+
+MEMORY_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}/.memory"
+CONTEXT_FILE="$MEMORY_DIR/context.md"
+
+detect_remote() {
+  if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+    if git remote get-url origin 2>/dev/null | grep -qE "github|gh"; then
+      echo "github"
+      return
+    fi
+  fi
+  if command -v glab &>/dev/null && glab auth status &>/dev/null 2>&1; then
+    if git remote get-url origin 2>/dev/null | grep -q "gitlab"; then
+      echo "gitlab"
+      return
+    fi
+  fi
+  echo "none"
+}
+
+gh_issue_info() {
+  local num="${1#\#}"
+  gh issue view "$num" --json number,title,state,assignees -q \
+    '"- #\(.number) \(.title) - \(.state | ascii_downcase)\(if .assignees | length > 0 then " @" + (.assignees[0].login) else "" end)"' 2>/dev/null || echo "- #$num (fetch failed)"
+}
+
+glab_issue_info() {
+  local num="${1#\#}"
+  glab issue view "$num" -F json 2>/dev/null | jq -r \
+    '"- #\(.iid) \(.title) - \(.state)\(if .assignee then " @" + .assignee.username else "" end)"' || echo "- #$num (fetch failed)"
+}
+
+if [ ! -f "$CONTEXT_FILE" ]; then
+  echo "No context.md found. Run init.sh first."
+  exit 1
+fi
+
+REMOTE=$(detect_remote)
+if [ "$REMOTE" = "none" ]; then
+  echo "No remote CLI available, skipping sync"
+  exit 0
+fi
+
+# Extract active issues from frontmatter
+ACTIVE=$(grep "^active_issues:" "$CONTEXT_FILE" | sed 's/active_issues: *\[\(.*\)\]/\1/' | tr -d '"' | tr -d "'" | tr ',' '\n' | tr -d ' ')
+
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+echo "Syncing from $REMOTE..."
+
+# Build new Active Work section
+ACTIVE_WORK="## Active Work
+<!-- Last sync: $TIMESTAMP -->"
+
+for issue in $ACTIVE; do
+  [ -z "$issue" ] && continue
+
+  case "$REMOTE" in
+    github)
+      info=$(gh_issue_info "$issue")
+      ;;
+    gitlab)
+      info=$(glab_issue_info "$issue")
+      ;;
+  esac
+  ACTIVE_WORK="$ACTIVE_WORK
+$info"
+  echo "  $info"
+done
+
+# Update synced timestamp in frontmatter
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/^synced:.*/synced: $TIMESTAMP/" "$CONTEXT_FILE"
+else
+  sed -i "s/^synced:.*/synced: $TIMESTAMP/" "$CONTEXT_FILE"
+fi
+
+echo ""
+echo "Active Work section to update in context.md:"
+echo "$ACTIVE_WORK"
+echo ""
+echo "Sync complete - update context.md manually or use agent"

--- a/skills/memory/scripts/sync-push.sh
+++ b/skills/memory/scripts/sync-push.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Push memory summary to tracking Issue (append mode)
+set -e
+
+MEMORY_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}/.memory"
+CONTEXT_FILE="$MEMORY_DIR/context.md"
+
+# Marker comments for agent-managed section
+START_MARKER="<!-- AGENT-MEMORY-START -->"
+END_MARKER="<!-- AGENT-MEMORY-END -->"
+
+detect_remote() {
+  if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+    if git remote get-url origin 2>/dev/null | grep -qE "github|gh"; then
+      echo "github"
+      return
+    fi
+  fi
+  if command -v glab &>/dev/null && glab auth status &>/dev/null 2>&1; then
+    if git remote get-url origin 2>/dev/null | grep -q "gitlab"; then
+      echo "gitlab"
+      return
+    fi
+  fi
+  echo "none"
+}
+
+if [ ! -f "$CONTEXT_FILE" ]; then
+  echo "No context.md found. Run init.sh first."
+  exit 1
+fi
+
+REMOTE=$(detect_remote)
+if [ "$REMOTE" = "none" ]; then
+  echo "No remote CLI available, skipping sync"
+  exit 0
+fi
+
+# Extract tracking issue from frontmatter
+TRACKING=$(grep "^tracking:" "$CONTEXT_FILE" | sed 's/tracking: *"\{0,1\}\([^"]*\)"\{0,1\}/\1/' | tr -d '#' | tr -d ' ')
+
+if [ -z "$TRACKING" ]; then
+  echo "No tracking issue configured in context.md"
+  echo "To setup: create a tracking Issue and add 'tracking: \"#N\"' to frontmatter"
+  exit 0
+fi
+
+# Validate tracking is numeric
+if ! [[ "$TRACKING" =~ ^[0-9]+$ ]]; then
+  echo "Invalid tracking issue format: $TRACKING (expected numeric)"
+  exit 1
+fi
+
+echo "Syncing to $REMOTE tracking issue #$TRACKING..."
+
+# Generate summary from context.md (extract content after frontmatter)
+SUMMARY=$(awk '/^---$/{if(++c==2)found=1;next}found' "$CONTEXT_FILE")
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Build the agent-managed section
+AGENT_SECTION="$START_MARKER
+## Agent Memory Sync
+_Last updated: $TIMESTAMP_
+
+$SUMMARY
+$END_MARKER"
+
+# Get current issue body
+case "$REMOTE" in
+  github)
+    CURRENT_BODY=$(gh issue view "$TRACKING" --json body -q '.body' 2>/dev/null || echo "")
+    ;;
+  gitlab)
+    CURRENT_BODY=$(glab issue view "$TRACKING" -F json 2>/dev/null | jq -r '.description // ""' || echo "")
+    ;;
+esac
+
+# Check if agent section exists
+if echo "$CURRENT_BODY" | grep -q "$START_MARKER"; then
+  # Replace existing agent section
+  NEW_BODY=$(echo "$CURRENT_BODY" | awk -v new="$AGENT_SECTION" '
+    /<!-- AGENT-MEMORY-START -->/{skip=1; print new; next}
+    /<!-- AGENT-MEMORY-END -->/{skip=0; next}
+    !skip{print}
+  ')
+else
+  # Append agent section
+  NEW_BODY="$CURRENT_BODY
+
+$AGENT_SECTION"
+fi
+
+# Update the issue
+case "$REMOTE" in
+  github)
+    echo "$NEW_BODY" | gh issue edit "$TRACKING" --body-file -
+    echo "Updated GitHub issue #$TRACKING"
+    ;;
+  gitlab)
+    echo "$NEW_BODY" | glab issue update "$TRACKING" --description "$(cat)"
+    echo "Updated GitLab issue #$TRACKING"
+    ;;
+esac
+
+# Update synced timestamp in context.md
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/^synced:.*/synced: $TIMESTAMP/" "$CONTEXT_FILE"
+else
+  sed -i "s/^synced:.*/synced: $TIMESTAMP/" "$CONTEXT_FILE"
+fi
+
+echo "Sync complete"

--- a/skills/memory/templates/context.md
+++ b/skills/memory/templates/context.md
@@ -1,0 +1,58 @@
+# Context Template
+
+```markdown
+---
+tracking: ""                       # Tracking Issue number, e.g., "#99"
+active_issues: []                  # Active work Issues, e.g., ["#42", "#43"]
+synced: YYYY-MM-DDTHH:MM:SSZ       # Last sync timestamp
+---
+
+# Project Context
+
+## Active Work
+<!-- sync-pull updates this section automatically -->
+<!-- Format: - #N Title - status -->
+
+## Local Context
+<!-- Agent-specific notes not suitable for Issues -->
+- Tech stack:
+- Key constraints:
+- Current focus:
+
+## Key Decisions
+<!-- Summary of important decisions with dates -->
+<!-- Link to .memory/decisions/ for full ADRs -->
+| Date | Decision | Rationale |
+|------|----------|-----------|
+
+## Recent Sessions
+<!-- Last 3-5 sessions for continuity -->
+| Date | Summary |
+|------|---------|
+```
+
+## Usage
+
+context.md is the **anchor point** for memory sync:
+
+1. **First time**: Create with empty tracking/active_issues
+2. **Setup sync**: Create tracking Issue, add number to frontmatter
+3. **During work**: Agent updates Local Context and Key Decisions
+4. **sync-pull**: Updates Active Work section from Issues
+5. **sync-push**: Updates tracking Issue with current state
+
+## Sections
+
+| Section | Updated by | Purpose |
+|---------|------------|---------|
+| Active Work | sync-pull (auto) | Current Issues status |
+| Local Context | Agent (manual) | Quick reference, not in Issues |
+| Key Decisions | Agent (manual) | Decision index, links to ADRs |
+| Recent Sessions | Agent (manual) | Session continuity |
+
+## Without Remote
+
+If no `gh`/`glab` CLI available:
+- Leave `tracking` empty
+- Use `active_issues` as local todo list
+- Agent manually updates Active Work section

--- a/skills/memory/templates/decision.md
+++ b/skills/memory/templates/decision.md
@@ -1,0 +1,64 @@
+# Decision Template (ADR)
+
+```markdown
+---
+type: decision
+status: active | superseded
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+superseded_by: YYYY-MM-DD-new-decision-slug  # if superseded
+---
+
+# {Decision Title}
+
+## Context
+
+What situation prompted this decision?
+
+## Decision
+
+What did we decide?
+
+## Rationale
+
+Why this choice over alternatives?
+
+## Alternatives Considered
+
+1. **Option A**: [pros/cons]
+2. **Option B**: [pros/cons]
+
+## Consequences
+
+- Positive: ...
+- Negative: ...
+- Risks: ...
+
+## References
+
+- file:path/to/implementation.ts
+- Related: [[previous-decision]]
+```
+
+## Usage
+
+Record architectural and technical decisions that:
+- Affect multiple components
+- Are hard to reverse
+- Team members might question later
+- Have significant trade-offs
+
+## Status Lifecycle
+
+1. `active` - Current decision in effect
+2. `superseded` - Replaced by newer decision (set `superseded_by`)
+
+## Tags
+
+Common decision tags:
+- `database` - Data storage choices
+- `api` - API design decisions
+- `security` - Security-related choices
+- `infrastructure` - Deployment/ops decisions
+- `library` - Third-party dependency choices

--- a/skills/memory/templates/note.md
+++ b/skills/memory/templates/note.md
@@ -1,0 +1,43 @@
+# Note Template
+
+```markdown
+---
+type: note
+status: active
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# {Title}
+
+## Context
+
+Why this is worth remembering.
+
+## Content
+
+The actual knowledge/information.
+
+## References
+
+- file:path/to/relevant/code.ts:42
+- Related: [[other-note-slug]]
+```
+
+## Usage
+
+Notes capture knowledge that doesn't fit other categories:
+- Learnings from debugging sessions
+- External references and resources
+- Project-specific patterns discovered
+- Meeting notes and discussions
+
+## Tags
+
+Common note tags:
+- `architecture` - System design insights
+- `debugging` - Solutions to tricky problems
+- `external` - Third-party documentation/APIs
+- `pattern` - Reusable patterns discovered
+- `reference` - Quick reference material

--- a/skills/memory/templates/session.md
+++ b/skills/memory/templates/session.md
@@ -1,0 +1,63 @@
+# Session Template
+
+```markdown
+---
+type: session
+status: active
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Session: {Date} - {Brief Topic}
+
+## Summary
+
+2-3 sentence overview of what was accomplished.
+
+## Key Discussions
+
+- Topic 1: [outcome]
+- Topic 2: [outcome]
+
+## Decisions Made
+
+- [[decision-slug]]: Brief description
+
+## Tasks Created/Updated
+
+- [[todo-slug]]: status
+- [[todo-slug]]: status
+
+## Next Steps
+
+1. Priority item for next session
+2. Follow-up needed
+
+## Open Questions
+
+- Unresolved question 1
+- Need to investigate: ...
+```
+
+## Usage
+
+Create session summaries to:
+- Hand off context to future sessions
+- Track progress over time
+- Remember open threads
+- Document what was tried (even if failed)
+
+## When to Create
+
+- End of significant work session
+- Before context switch
+- When user requests summary
+- When session has important outcomes
+
+## Tips
+
+- Link to created records, don't duplicate content
+- Focus on outcomes, not process
+- Note what didn't work (saves future time)
+- Be specific about next steps

--- a/skills/memory/templates/todo.md
+++ b/skills/memory/templates/todo.md
@@ -1,0 +1,47 @@
+# Todo Template
+
+```markdown
+---
+type: todo
+status: active | completed | blocked
+priority: high | medium | low
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+completed: YYYY-MM-DD
+blocked_by: ""
+---
+
+# {Task Title}
+
+## Description
+
+What needs to be done and why.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Notes
+
+Progress notes, blockers, related context.
+
+## References
+
+- file:path/to/code.ts
+- Related: [[decision-slug]]
+```
+
+## When to Use Local Todos
+
+Use `.memory/todos/` when:
+- Working offline
+- No GitHub/GitLab configured
+- Quick personal tasks
+- Project doesn't use Issues
+
+Use GitHub/GitLab Issues when:
+- Cross-device sync needed
+- Team visibility required
+- Want notifications/assignees


### PR DESCRIPTION
## Summary

Add a memory skill for persisting project knowledge across sessions. Local-first with optional GitHub/GitLab Issues sync for cross-device access.

## Changes

- **SKILL.md** (100 lines): Hub with core operations, workflows, integration points
- **reference/setup.md**: Hook configs for Claude Code and Cursor
- **reference/remote-sync.md**: MCP/CLI usage, conflict handling, sync workflow
- **templates/**: Formats for context, notes, decisions, todos, sessions
- **scripts/**: init.sh, sync-pull.sh, sync-push.sh

## Architecture

```
.memory/                          GitHub/GitLab Issues
├── context.md ◄──references───► Tracking Issue (#N)
├── notes/                        Work Issues (#42, #43)
├── decisions/                    
├── todos/      (local fallback)
└── sessions/
```

**Design decisions**:
- Issues = source of truth for cross-device tasks
- context.md = local index + cache
- todos/ retained for offline/no-remote scenarios
- sync-push appends (doesn't overwrite) via HTML markers

## Testing

Sub-agent tests passed:
- Discovery: triggers on "remember", "recall", "save this", "todo"
- Boundary: does NOT trigger for dive/engineering/housekeeping queries
- Execution: correctly follows workflow to create decision records

## Reviewer Notes

- SKILL.md kept to 100 lines via progressive disclosure
- Scripts handle macOS/Linux sed differences
- MCP tools preferred over CLI when available

---

🤖 Generated with [Claude Code](https://claude.ai/code)