### PR TITLE
fix: add repo config for changesets changelog-github

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": "@changesets/changelog-github",
+  "changelog": ["@changesets/changelog-github", { "repo": "lidessen/skills" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
The @changesets/changelog-github package requires the repo option
to be specified in the config. Without it, changeset version fails.

https://claude.ai/code/session_014Zu9ZtHPeDMadTJJBSai9h