### PR TITLE
fix: add write permissions for GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The changesets action needs contents:write and pull-requests:write
permissions to create release PRs and push version updates.

https://claude.ai/code/session_01UzhdR132wcFrJdYCgCeXru