### PR TITLE
feat(agent-worker): add Context lifecycle management and instance isolation

### DIFF
--- a/packages/agent-worker/src/workflow/context/file-provider.ts
+++ b/packages/agent-worker/src/workflow/context/file-provider.ts
@@ -4,7 +4,7 @@
  * Includes instance lock to prevent concurrent access to the same context directory.
  */
 
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { ContextProviderImpl } from "./provider.ts";
 import { FileStorage } from "./storage.ts";
@@ -76,7 +76,6 @@ export class FileContextProvider extends ContextProviderImpl {
     // Ensure _state directory exists (FileStorage may not have created it yet)
     const stateDir = join(this.contextDir, "_state");
     if (!existsSync(stateDir)) {
-      const { mkdirSync } = require("node:fs");
       mkdirSync(stateDir, { recursive: true });
     }
     writeFileSync(this.lockPath, JSON.stringify(lock, null, 2));

--- a/packages/agent-worker/src/workflow/context/file-provider.ts
+++ b/packages/agent-worker/src/workflow/context/file-provider.ts
@@ -1,19 +1,111 @@
 /**
  * File Context Provider
  * Thin wrapper around ContextProviderImpl + FileStorage.
+ * Includes instance lock to prevent concurrent access to the same context directory.
  */
 
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
 import { ContextProviderImpl } from "./provider.ts";
 import { FileStorage } from "./storage.ts";
+
+/** Lock file name within context directory */
+const LOCK_FILE = "_state/instance.lock";
+
+/** Lock file content */
+interface LockInfo {
+  pid: number;
+  startedAt: string;
+}
 
 /**
  * File-based ContextProvider.
  * All domain logic is in ContextProviderImpl;
  * FileStorage handles I/O.
+ *
+ * Adds instance locking: only one process can hold the lock at a time.
+ * Stale locks (from crashed processes) are automatically cleaned up.
  */
 export class FileContextProvider extends ContextProviderImpl {
-  constructor(storage: FileStorage, validAgents: string[]) {
+  private lockPath: string;
+
+  constructor(
+    storage: FileStorage,
+    validAgents: string[],
+    private contextDir: string,
+  ) {
     super(storage, validAgents);
+    this.lockPath = join(contextDir, LOCK_FILE);
+  }
+
+  /**
+   * Acquire instance lock.
+   * Throws if another live process holds the lock.
+   * Automatically cleans up stale locks from dead processes.
+   */
+  acquireLock(): void {
+    if (existsSync(this.lockPath)) {
+      try {
+        const existing: LockInfo = JSON.parse(readFileSync(this.lockPath, "utf-8"));
+        // Check if the process is still alive
+        try {
+          process.kill(existing.pid, 0);
+          // Process is alive — lock is held
+          throw new Error(
+            `Context directory is locked by another process (PID ${existing.pid}, started ${existing.startedAt}). ` +
+              `If the process is no longer running, delete ${this.lockPath}`,
+          );
+        } catch (e) {
+          if (e instanceof Error && e.message.includes("Context directory is locked")) {
+            throw e;
+          }
+          // process.kill threw — process is dead, clean up stale lock
+        }
+      } catch (e) {
+        if (e instanceof Error && e.message.includes("Context directory is locked")) {
+          throw e;
+        }
+        // Malformed lock file, clean up
+      }
+    }
+
+    const lock: LockInfo = {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    };
+    // Ensure _state directory exists (FileStorage may not have created it yet)
+    const stateDir = join(this.contextDir, "_state");
+    if (!existsSync(stateDir)) {
+      const { mkdirSync } = require("node:fs");
+      mkdirSync(stateDir, { recursive: true });
+    }
+    writeFileSync(this.lockPath, JSON.stringify(lock, null, 2));
+  }
+
+  /**
+   * Release instance lock.
+   * Safe to call even if lock is not held (no-op).
+   */
+  releaseLock(): void {
+    try {
+      if (existsSync(this.lockPath)) {
+        const existing: LockInfo = JSON.parse(readFileSync(this.lockPath, "utf-8"));
+        // Only release if we own it
+        if (existing.pid === process.pid) {
+          unlinkSync(this.lockPath);
+        }
+      }
+    } catch {
+      // Ignore errors during cleanup
+    }
+  }
+
+  /**
+   * Override destroy to release lock and clean up transient state.
+   */
+  override async destroy(): Promise<void> {
+    await super.destroy();
+    this.releaseLock();
   }
 }
 
@@ -28,6 +120,7 @@ export class FileContextProvider extends ContextProviderImpl {
  *   ├── resources/           # Resource blobs
  *   ├── _state/
  *   │   ├── inbox.json       # Inbox read cursors
+ *   │   ├── instance.lock    # Instance lock (PID-based)
  *   │   └── proposals.json   # Proposal state
  *   └── ...
  */
@@ -36,5 +129,5 @@ export function createFileContextProvider(
   validAgents: string[],
 ): FileContextProvider {
   const storage = new FileStorage(contextDir);
-  return new FileContextProvider(storage, validAgents);
+  return new FileContextProvider(storage, validAgents, contextDir);
 }

--- a/packages/agent-worker/src/workflow/context/memory-provider.ts
+++ b/packages/agent-worker/src/workflow/context/memory-provider.ts
@@ -77,6 +77,12 @@ export class MemoryContextProvider extends ContextProviderImpl {
     }
     return map;
   }
+
+  /** Override destroy to also clear all in-memory data */
+  override async destroy(): Promise<void> {
+    await super.destroy();
+    this.memoryStorage.clear();
+  }
 }
 
 /**

--- a/packages/agent-worker/src/workflow/context/memory-provider.ts
+++ b/packages/agent-worker/src/workflow/context/memory-provider.ts
@@ -78,10 +78,13 @@ export class MemoryContextProvider extends ContextProviderImpl {
     return map;
   }
 
-  /** Override destroy to also clear all in-memory data */
+  /**
+   * Destroy: cleans up transient state (inbox cursors) only.
+   * Channel log, documents, and resources are preserved — matching FileContextProvider behavior.
+   * Use clear() for full reset in tests.
+   */
   override async destroy(): Promise<void> {
     await super.destroy();
-    this.memoryStorage.clear();
   }
 }
 

--- a/packages/agent-worker/src/workflow/context/memory-provider.ts
+++ b/packages/agent-worker/src/workflow/context/memory-provider.ts
@@ -78,14 +78,6 @@ export class MemoryContextProvider extends ContextProviderImpl {
     return map;
   }
 
-  /**
-   * Destroy: cleans up transient state (inbox cursors) only.
-   * Channel log, documents, and resources are preserved — matching FileContextProvider behavior.
-   * Use clear() for full reset in tests.
-   */
-  override async destroy(): Promise<void> {
-    await super.destroy();
-  }
 }
 
 /**

--- a/packages/agent-worker/src/workflow/context/provider.ts
+++ b/packages/agent-worker/src/workflow/context/provider.ts
@@ -254,9 +254,6 @@ export class ContextProviderImpl implements ContextProvider {
   // ==================== Lifecycle ====================
 
   async destroy(): Promise<void> {
-    // Reset in-memory sequence counter
-    this.sequence = 0;
-    // Clean up inbox read cursors (transient state)
     await this.storage.delete(KEYS.inboxState);
   }
 }

--- a/packages/agent-worker/src/workflow/context/provider.ts
+++ b/packages/agent-worker/src/workflow/context/provider.ts
@@ -57,6 +57,10 @@ export interface ContextProvider {
   // Resources
   createResource(content: string, createdBy: string, type?: ResourceType): Promise<ResourceResult>;
   readResource(id: string): Promise<string | null>;
+
+  // Lifecycle
+  /** Clean up transient state (inbox cursors). Channel log and documents are preserved. */
+  destroy(): Promise<void>;
 }
 
 // ==================== Storage Keys ====================
@@ -245,6 +249,15 @@ export class ContextProviderImpl implements ContextProvider {
       if (content !== null) return content;
     }
     return null;
+  }
+
+  // ==================== Lifecycle ====================
+
+  async destroy(): Promise<void> {
+    // Reset in-memory sequence counter
+    this.sequence = 0;
+    // Clean up inbox read cursors (transient state)
+    await this.storage.delete(KEYS.inboxState);
   }
 }
 

--- a/packages/agent-worker/src/workflow/context/types.ts
+++ b/packages/agent-worker/src/workflow/context/types.ts
@@ -115,8 +115,9 @@ export interface InboxState {
  * - false: explicitly disabled
  * - { provider: 'file', config?: {...} }: file provider with optional config
  * - { provider: 'memory' }: memory provider (for testing)
+ * - { bind: './path' }: shorthand for persistent file provider (like docker compose volumes)
  */
-export type ContextConfig = false | FileContextConfig | MemoryContextConfig;
+export type ContextConfig = false | FileContextConfig | MemoryContextConfig | BindContextConfig;
 
 /** File-based context provider configuration */
 export interface FileContextConfig {
@@ -129,6 +130,24 @@ export interface FileContextConfig {
 /** Memory-based context provider configuration (for testing) */
 export interface MemoryContextConfig {
   provider: "memory";
+  /** Document owner (single-writer model, optional) */
+  documentOwner?: string;
+}
+
+/**
+ * Bind context configuration — persistent file provider.
+ * Like Docker Compose volumes: binds a directory for cross-run persistence.
+ *
+ * Key difference from `provider: 'file'`:
+ * - Shutdown preserves ALL state (inbox cursors, channel, documents)
+ * - Next run resumes where the previous left off
+ * - Path is relative to the workflow file (like docker-compose.yml)
+ *
+ * Supports ${{ instance }} template for per-instance directories.
+ */
+export interface BindContextConfig {
+  /** Directory path to bind (relative to workflow file, or absolute) */
+  bind: string;
   /** Document owner (single-writer model, optional) */
   documentOwner?: string;
 }

--- a/packages/agent-worker/src/workflow/context/types.ts
+++ b/packages/agent-worker/src/workflow/context/types.ts
@@ -115,9 +115,8 @@ export interface InboxState {
  * - false: explicitly disabled
  * - { provider: 'file', config?: {...} }: file provider with optional config
  * - { provider: 'memory' }: memory provider (for testing)
- * - { bind: './path' }: shorthand for persistent file provider (like docker compose volumes)
  */
-export type ContextConfig = false | FileContextConfig | MemoryContextConfig | BindContextConfig;
+export type ContextConfig = false | FileContextConfig | MemoryContextConfig;
 
 /** File-based context provider configuration */
 export interface FileContextConfig {
@@ -135,27 +134,21 @@ export interface MemoryContextConfig {
 }
 
 /**
- * Bind context configuration — persistent file provider.
- * Like Docker Compose volumes: binds a directory for cross-run persistence.
+ * Configuration for file provider.
  *
- * Key difference from `provider: 'file'`:
- * - Shutdown preserves ALL state (inbox cursors, channel, documents)
- * - Next run resumes where the previous left off
- * - Path is relative to the workflow file (like docker-compose.yml)
- *
- * Supports ${{ instance }} template for per-instance directories.
+ * Use `dir` for ephemeral context (transient state cleaned on shutdown).
+ * Use `bind` for persistent context (all state preserved across runs, like Docker Compose volumes).
+ * `dir` and `bind` are mutually exclusive — specify one or the other (not both).
  */
-export interface BindContextConfig {
-  /** Directory path to bind (relative to workflow file, or absolute) */
-  bind: string;
-  /** Document owner (single-writer model, optional) */
-  documentOwner?: string;
-}
-
-/** Configuration for file provider */
 export interface FileProviderConfig {
-  /** Context directory (default: ~/.agent-worker/workflows/${{ workflow.name }}/${{ instance }}/) */
+  /** Context directory — ephemeral (default: ~/.agent-worker/workflows/${{ workflow.name }}/${{ instance }}/) */
   dir?: string;
+  /**
+   * Bind directory — persistent across runs.
+   * Shutdown preserves ALL state (inbox cursors, channel, documents).
+   * Path is relative to workflow file, supports ${{ instance }} template.
+   */
+  bind?: string;
 }
 
 /** Default context configuration values */

--- a/packages/agent-worker/src/workflow/runner.ts
+++ b/packages/agent-worker/src/workflow/runner.ts
@@ -209,6 +209,10 @@ export async function initWorkflow(config: RunConfig): Promise<WorkflowRuntime> 
           context[task.as] = result;
         }
       } catch (error) {
+        // Release lock before propagating error
+        if (contextProvider instanceof FileContextProvider) {
+          contextProvider.releaseLock();
+        }
         await httpMcpServer.close();
         throw new Error(`Setup failed: ${error instanceof Error ? error.message : String(error)}`);
       }

--- a/packages/agent-worker/src/workflow/runner.ts
+++ b/packages/agent-worker/src/workflow/runner.ts
@@ -49,7 +49,7 @@ export interface RunConfig {
   /** Agent startup function */
   startAgent: (agentName: string, config: ResolvedAgent, mcpUrl: string) => Promise<void>;
   /** Callback when an agent @mentions another agent */
-  onMention?: (from: string, target: string, msg: import("../context/types.ts").Message) => void;
+  onMention?: (from: string, target: string, msg: import("./context/types.ts").Message) => void;
   /** Debug log function for MCP tool calls */
   debugLog?: (message: string) => void;
 }

--- a/packages/agent-worker/src/workflow/runner.ts
+++ b/packages/agent-worker/src/workflow/runner.ts
@@ -159,7 +159,9 @@ export async function initWorkflow(config: RunConfig): Promise<WorkflowRuntime> 
 
     if (verbose) log(`Context directory: ${contextDir}`);
 
-    contextProvider = createFileContextProvider(contextDir, agentNames);
+    const fileProvider = createFileContextProvider(contextDir, agentNames);
+    fileProvider.acquireLock();
+    contextProvider = fileProvider;
   }
 
   // Create MCP server (HTTP)
@@ -235,6 +237,7 @@ export async function initWorkflow(config: RunConfig): Promise<WorkflowRuntime> 
 
     async shutdown() {
       if (verbose) log("\nShutting down workflow...");
+      await contextProvider.destroy();
       await httpMcpServer.close();
     },
   };

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -5,12 +5,7 @@
 import type { ContextConfig } from "./context/types.ts";
 
 // Re-export context types for convenience
-export type {
-  ContextConfig,
-  FileContextConfig,
-  MemoryContextConfig,
-  BindContextConfig,
-} from "./context/types.ts";
+export type { ContextConfig, FileContextConfig, MemoryContextConfig } from "./context/types.ts";
 
 // ==================== Workflow File ====================
 
@@ -28,8 +23,7 @@ export interface WorkflowFile {
    * Shared context configuration
    * - undefined (not set): default file provider enabled
    * - false: explicitly disabled
-   * - { bind: './path' }: persistent file provider (like Docker Compose volumes)
-   * - { provider: 'file', config?: {...} }: file provider with config
+   * - { provider: 'file', config?: { dir | bind } }: file provider (ephemeral or persistent)
    * - { provider: 'memory' }: memory provider (for testing)
    */
   context?: ContextConfig;

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -28,6 +28,7 @@ export interface WorkflowFile {
    * Shared context configuration
    * - undefined (not set): default file provider enabled
    * - false: explicitly disabled
+   * - { bind: './path' }: persistent file provider (like Docker Compose volumes)
    * - { provider: 'file', config?: {...} }: file provider with config
    * - { provider: 'memory' }: memory provider (for testing)
    */

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -5,7 +5,12 @@
 import type { ContextConfig } from "./context/types.ts";
 
 // Re-export context types for convenience
-export type { ContextConfig, FileContextConfig, MemoryContextConfig } from "./context/types.ts";
+export type {
+  ContextConfig,
+  FileContextConfig,
+  MemoryContextConfig,
+  BindContextConfig,
+} from "./context/types.ts";
 
 // ==================== Workflow File ====================
 
@@ -105,6 +110,12 @@ export interface ResolvedFileContext {
   dir: string;
   /** Document owner (single-writer model, optional) */
   documentOwner?: string;
+  /**
+   * Whether this context is persistent (bound).
+   * When true, shutdown preserves ALL state (inbox, channel, docs).
+   * When false (default), shutdown clears transient state (inbox cursors).
+   */
+  persistent?: boolean;
 }
 
 /** Resolved memory context (for testing) */

--- a/packages/agent-worker/test/context-lifecycle.test.ts
+++ b/packages/agent-worker/test/context-lifecycle.test.ts
@@ -23,7 +23,7 @@ import {
 
 describe("ContextProvider.destroy()", () => {
   describe("MemoryContextProvider", () => {
-    test("destroy clears all data", async () => {
+    test("destroy clears transient state but preserves persistent data", async () => {
       const provider = new MemoryContextProvider(["agent1", "agent2"]);
 
       // Write some data
@@ -34,9 +34,11 @@ describe("ContextProvider.destroy()", () => {
       // Destroy
       await provider.destroy();
 
-      // All data should be cleared
-      expect(await provider.readChannel()).toEqual([]);
-      expect(await provider.readDocument()).toBe("");
+      // Channel and documents should be preserved
+      expect(await provider.readChannel()).toHaveLength(1);
+      expect(await provider.readDocument()).toBe("some content");
+
+      // Inbox state (transient) should be cleared
       expect(await provider.getInboxState("agent2")).toBeUndefined();
     });
   });

--- a/packages/agent-worker/test/context-lifecycle.test.ts
+++ b/packages/agent-worker/test/context-lifecycle.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Context Lifecycle Tests
+ *
+ * Tests for:
+ * 1. ContextProvider.destroy() lifecycle
+ * 2. Cross-instance data isolation (FileContextProvider)
+ * 3. Resume semantics (reconnecting to existing context directory)
+ * 4. Instance lock mechanism
+ * 5. Concurrent write safety (single-process)
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  MemoryContextProvider,
+  FileContextProvider,
+  createFileContextProvider,
+} from "../src/workflow/context/index.ts";
+
+// ==================== destroy() Lifecycle Tests ====================
+
+describe("ContextProvider.destroy()", () => {
+  describe("MemoryContextProvider", () => {
+    test("destroy clears all data", async () => {
+      const provider = new MemoryContextProvider(["agent1", "agent2"]);
+
+      // Write some data
+      await provider.appendChannel("agent1", "@agent2 hello");
+      await provider.writeDocument("some content");
+      await provider.ackInbox("agent2", new Date().toISOString());
+
+      // Destroy
+      await provider.destroy();
+
+      // All data should be cleared
+      expect(await provider.readChannel()).toEqual([]);
+      expect(await provider.readDocument()).toBe("");
+      expect(await provider.getInboxState("agent2")).toBeUndefined();
+    });
+  });
+
+  describe("FileContextProvider", () => {
+    let testDir: string;
+
+    beforeEach(() => {
+      testDir = join(
+        tmpdir(),
+        `lifecycle-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(testDir, { recursive: true, force: true });
+    });
+
+    test("destroy cleans up inbox state but preserves channel and documents", async () => {
+      const provider = createFileContextProvider(testDir, ["agent1", "agent2"]);
+
+      // Write data
+      await provider.appendChannel("agent1", "@agent2 hello");
+      await provider.writeDocument("important notes");
+      await provider.ackInbox("agent2", new Date().toISOString());
+
+      // Verify inbox state exists before destroy
+      expect(existsSync(join(testDir, "_state", "inbox.json"))).toBe(true);
+
+      // Destroy
+      await provider.destroy();
+
+      // Channel log should be preserved (it's a persistent log)
+      expect(existsSync(join(testDir, "channel.jsonl"))).toBe(true);
+      const channelContent = readFileSync(join(testDir, "channel.jsonl"), "utf-8");
+      expect(channelContent).toContain("hello");
+
+      // Documents should be preserved
+      expect(await provider.readDocument()).toBe("important notes");
+
+      // Inbox state should be cleaned up (transient state)
+      expect(existsSync(join(testDir, "_state", "inbox.json"))).toBe(false);
+    });
+
+    test("destroy releases instance lock", async () => {
+      const provider = createFileContextProvider(testDir, ["agent1"]);
+      provider.acquireLock();
+
+      expect(existsSync(join(testDir, "_state", "instance.lock"))).toBe(true);
+
+      await provider.destroy();
+
+      expect(existsSync(join(testDir, "_state", "instance.lock"))).toBe(false);
+    });
+  });
+});
+
+// ==================== Cross-Instance Isolation Tests ====================
+
+describe("Cross-Instance Isolation", () => {
+  let baseDir: string;
+  let instanceADir: string;
+  let instanceBDir: string;
+
+  beforeEach(() => {
+    baseDir = join(
+      tmpdir(),
+      `isolation-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    instanceADir = join(baseDir, "instance-a");
+    instanceBDir = join(baseDir, "instance-b");
+    mkdirSync(instanceADir, { recursive: true });
+    mkdirSync(instanceBDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  test("messages in instance A do not appear in instance B", async () => {
+    const providerA = createFileContextProvider(instanceADir, ["alice", "bob"]);
+    const providerB = createFileContextProvider(instanceBDir, ["alice", "bob"]);
+
+    await providerA.appendChannel("alice", "Hello from instance A");
+    await providerB.appendChannel("bob", "Hello from instance B");
+
+    const messagesA = await providerA.readChannel();
+    const messagesB = await providerB.readChannel();
+
+    expect(messagesA).toHaveLength(1);
+    expect(messagesA[0].content).toBe("Hello from instance A");
+
+    expect(messagesB).toHaveLength(1);
+    expect(messagesB[0].content).toBe("Hello from instance B");
+  });
+
+  test("inbox state in instance A does not affect instance B", async () => {
+    const providerA = createFileContextProvider(instanceADir, ["alice", "bob"]);
+    const providerB = createFileContextProvider(instanceBDir, ["alice", "bob"]);
+
+    // Send mentions in both instances
+    await providerA.appendChannel("alice", "@bob check this");
+    await providerB.appendChannel("alice", "@bob different task");
+
+    // Acknowledge in instance A
+    const inboxA = await providerA.getInbox("bob");
+    await providerA.ackInbox("bob", inboxA[0].entry.timestamp);
+
+    // Instance B should still have unread messages
+    const inboxB = await providerB.getInbox("bob");
+    expect(inboxB).toHaveLength(1);
+    expect(inboxB[0].entry.content).toBe("@bob different task");
+  });
+
+  test("documents in instance A do not appear in instance B", async () => {
+    const providerA = createFileContextProvider(instanceADir, ["alice"]);
+    const providerB = createFileContextProvider(instanceBDir, ["alice"]);
+
+    await providerA.writeDocument("Instance A notes");
+    await providerB.writeDocument("Instance B notes");
+
+    expect(await providerA.readDocument()).toBe("Instance A notes");
+    expect(await providerB.readDocument()).toBe("Instance B notes");
+  });
+
+  test("resources in instance A do not appear in instance B", async () => {
+    const providerA = createFileContextProvider(instanceADir, ["alice"]);
+    const providerB = createFileContextProvider(instanceBDir, ["alice"]);
+
+    const resA = await providerA.createResource("Resource A content", "alice");
+    const resB = await providerB.createResource("Resource B content", "alice");
+
+    // Each instance can only read its own resources
+    expect(await providerA.readResource(resA.id)).toBe("Resource A content");
+    expect(await providerA.readResource(resB.id)).toBeNull();
+
+    expect(await providerB.readResource(resB.id)).toBe("Resource B content");
+    expect(await providerB.readResource(resA.id)).toBeNull();
+  });
+
+  test("destroy of instance A does not affect instance B", async () => {
+    const providerA = createFileContextProvider(instanceADir, ["alice", "bob"]);
+    const providerB = createFileContextProvider(instanceBDir, ["alice", "bob"]);
+
+    await providerA.appendChannel("alice", "@bob task A");
+    await providerB.appendChannel("alice", "@bob task B");
+    await providerA.ackInbox("bob", new Date().toISOString());
+    await providerB.ackInbox("bob", new Date().toISOString());
+
+    // Destroy instance A
+    await providerA.destroy();
+
+    // Instance B inbox state should be unaffected
+    const statePath = join(instanceBDir, "_state", "inbox.json");
+    expect(existsSync(statePath)).toBe(true);
+
+    // Instance B channel should still have its messages
+    const messagesB = await providerB.readChannel();
+    expect(messagesB).toHaveLength(1);
+    expect(messagesB[0].content).toBe("@bob task B");
+  });
+});
+
+// ==================== Resume Semantics Tests ====================
+
+describe("Resume Semantics", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(
+      tmpdir(),
+      `resume-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("new provider sees existing channel messages", async () => {
+    // First session
+    const provider1 = createFileContextProvider(testDir, ["alice", "bob"]);
+    await provider1.appendChannel("alice", "First session message");
+    await provider1.appendChannel("bob", "Response from first session");
+
+    // Second session (reconnecting to same dir)
+    const provider2 = createFileContextProvider(testDir, ["alice", "bob"]);
+    const messages = await provider2.readChannel();
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0].content).toBe("First session message");
+    expect(messages[1].content).toBe("Response from first session");
+  });
+
+  test("new provider sees existing documents", async () => {
+    const provider1 = createFileContextProvider(testDir, ["alice"]);
+    await provider1.writeDocument("# Progress Notes\n- Task 1 done");
+
+    const provider2 = createFileContextProvider(testDir, ["alice"]);
+    expect(await provider2.readDocument()).toBe("# Progress Notes\n- Task 1 done");
+  });
+
+  test("new provider can append to existing channel", async () => {
+    const provider1 = createFileContextProvider(testDir, ["alice", "bob"]);
+    await provider1.appendChannel("alice", "From session 1");
+
+    const provider2 = createFileContextProvider(testDir, ["alice", "bob"]);
+    await provider2.appendChannel("bob", "From session 2");
+
+    const messages = await provider2.readChannel();
+    expect(messages).toHaveLength(2);
+    expect(messages[0].content).toBe("From session 1");
+    expect(messages[1].content).toBe("From session 2");
+  });
+
+  test("inbox state resets after destroy + reconnect", async () => {
+    const provider1 = createFileContextProvider(testDir, ["alice", "bob"]);
+    await provider1.appendChannel("alice", "@bob check this");
+    const inbox1 = await provider1.getInbox("bob");
+    await provider1.ackInbox("bob", inbox1[0].entry.timestamp);
+
+    // Verify bob has no unread messages
+    expect(await provider1.getInbox("bob")).toHaveLength(0);
+
+    // Destroy (clears inbox state)
+    await provider1.destroy();
+
+    // Reconnect
+    const provider2 = createFileContextProvider(testDir, ["alice", "bob"]);
+    // Bob should see the message again since inbox state was cleared
+    const inbox2 = await provider2.getInbox("bob");
+    expect(inbox2).toHaveLength(1);
+    expect(inbox2[0].entry.content).toBe("@bob check this");
+  });
+
+  test("resources survive provider recreation", async () => {
+    const provider1 = createFileContextProvider(testDir, ["alice"]);
+    const res = await provider1.createResource("Persistent blob", "alice");
+
+    const provider2 = createFileContextProvider(testDir, ["alice"]);
+    expect(await provider2.readResource(res.id)).toBe("Persistent blob");
+  });
+});
+
+// ==================== Instance Lock Tests ====================
+
+describe("Instance Lock", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(
+      tmpdir(),
+      `lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("acquireLock creates lock file", () => {
+    const provider = createFileContextProvider(testDir, ["alice"]);
+    provider.acquireLock();
+
+    const lockPath = join(testDir, "_state", "instance.lock");
+    expect(existsSync(lockPath)).toBe(true);
+
+    const lock = JSON.parse(readFileSync(lockPath, "utf-8"));
+    expect(lock.pid).toBe(process.pid);
+    expect(lock.startedAt).toBeDefined();
+
+    provider.releaseLock();
+  });
+
+  test("releaseLock removes lock file", () => {
+    const provider = createFileContextProvider(testDir, ["alice"]);
+    provider.acquireLock();
+    provider.releaseLock();
+
+    expect(existsSync(join(testDir, "_state", "instance.lock"))).toBe(false);
+  });
+
+  test("acquireLock cleans up stale lock from dead process", () => {
+    // Write a lock file with a fake (dead) PID
+    const stateDir = join(testDir, "_state");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, "instance.lock"),
+      JSON.stringify({ pid: 999999999, startedAt: "2020-01-01T00:00:00Z" }),
+    );
+
+    // Should succeed because PID 999999999 doesn't exist
+    const provider = createFileContextProvider(testDir, ["alice"]);
+    expect(() => provider.acquireLock()).not.toThrow();
+
+    // Lock should now be ours
+    const lock = JSON.parse(readFileSync(join(stateDir, "instance.lock"), "utf-8"));
+    expect(lock.pid).toBe(process.pid);
+
+    provider.releaseLock();
+  });
+
+  test("acquireLock throws when locked by live process (self)", () => {
+    const provider1 = createFileContextProvider(testDir, ["alice"]);
+    provider1.acquireLock();
+
+    // Second provider trying to lock the same dir should fail
+    const provider2 = createFileContextProvider(testDir, ["alice"]);
+    expect(() => provider2.acquireLock()).toThrow("Context directory is locked");
+
+    provider1.releaseLock();
+  });
+
+  test("releaseLock only releases own lock", () => {
+    // Write a lock file owned by a different PID
+    const stateDir = join(testDir, "_state");
+    mkdirSync(stateDir, { recursive: true });
+    const otherPid = process.pid + 1; // Different PID (won't exist as a real lock)
+    writeFileSync(
+      join(stateDir, "instance.lock"),
+      JSON.stringify({ pid: otherPid, startedAt: "2020-01-01T00:00:00Z" }),
+    );
+
+    const provider = createFileContextProvider(testDir, ["alice"]);
+    provider.releaseLock();
+
+    // Lock file should still exist (not ours to release)
+    expect(existsSync(join(stateDir, "instance.lock"))).toBe(true);
+  });
+
+  test("acquireLock handles malformed lock file", () => {
+    const stateDir = join(testDir, "_state");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, "instance.lock"), "not json");
+
+    // Should clean up malformed lock and succeed
+    const provider = createFileContextProvider(testDir, ["alice"]);
+    expect(() => provider.acquireLock()).not.toThrow();
+
+    provider.releaseLock();
+  });
+});
+
+// ==================== Concurrent Write Safety Tests ====================
+
+describe("Concurrent Write Safety (single process)", () => {
+  test("parallel appendChannel calls do not lose messages (MemoryProvider)", async () => {
+    const provider = new MemoryContextProvider(["a", "b", "c"]);
+
+    // Fire 20 concurrent appends
+    const promises = Array.from({ length: 20 }, (_, i) =>
+      provider.appendChannel(`agent-${i % 3}`, `Message ${i}`),
+    );
+    await Promise.all(promises);
+
+    const messages = await provider.readChannel();
+    expect(messages).toHaveLength(20);
+  });
+
+  test("parallel appendChannel calls do not lose messages (FileProvider)", async () => {
+    const testDir = join(
+      tmpdir(),
+      `concurrent-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testDir, { recursive: true });
+
+    try {
+      const provider = createFileContextProvider(testDir, ["a", "b", "c"]);
+
+      // Fire 20 concurrent appends
+      const promises = Array.from({ length: 20 }, (_, i) =>
+        provider.appendChannel(`agent-${i % 3}`, `Message ${i}`),
+      );
+      await Promise.all(promises);
+
+      const messages = await provider.readChannel();
+      expect(messages).toHaveLength(20);
+
+      // All messages should be distinct
+      const contents = new Set(messages.map((m) => m.content));
+      expect(contents.size).toBe(20);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("timestamps are unique even for rapid concurrent writes", async () => {
+    const provider = new MemoryContextProvider(["alice"]);
+
+    const promises = Array.from({ length: 50 }, (_, i) =>
+      provider.appendChannel("alice", `Rapid message ${i}`),
+    );
+    const results = await Promise.all(promises);
+
+    const timestamps = results.map((r) => r.timestamp);
+    const uniqueTimestamps = new Set(timestamps);
+
+    // All timestamps should be unique (sequence counter ensures this)
+    expect(uniqueTimestamps.size).toBe(50);
+  });
+
+  test("concurrent getInbox and appendChannel do not corrupt state", async () => {
+    const provider = new MemoryContextProvider(["alice", "bob"]);
+
+    // Interleave writes and reads
+    const writes = Array.from({ length: 10 }, (_, i) =>
+      provider.appendChannel("alice", `@bob message ${i}`),
+    );
+    const reads = Array.from({ length: 10 }, () => provider.getInbox("bob"));
+
+    await Promise.all([...writes, ...reads]);
+
+    // Final state should be consistent
+    const finalInbox = await provider.getInbox("bob");
+    expect(finalInbox.length).toBe(10);
+    expect(finalInbox.every((m) => m.entry.from === "alice")).toBe(true);
+  });
+});
+
+// ==================== DM Visibility Isolation Tests ====================
+
+describe("DM Visibility Isolation", () => {
+  test("DMs between two agents are invisible to third agent", async () => {
+    const provider = new MemoryContextProvider(["alice", "bob", "charlie"]);
+
+    // Alice sends DM to Bob
+    await provider.appendChannel("alice", "Secret for Bob only", { to: "bob" });
+
+    // Public message
+    await provider.appendChannel("alice", "Hello everyone");
+
+    // Charlie should only see the public message
+    const charlieView = await provider.readChannel({ agent: "charlie" });
+    expect(charlieView).toHaveLength(1);
+    expect(charlieView[0].content).toBe("Hello everyone");
+
+    // Bob should see both
+    const bobView = await provider.readChannel({ agent: "bob" });
+    expect(bobView).toHaveLength(2);
+
+    // Alice (sender) should also see the DM
+    const aliceView = await provider.readChannel({ agent: "alice" });
+    expect(aliceView).toHaveLength(2);
+  });
+
+  test("DM creates inbox entry only for recipient", async () => {
+    const provider = new MemoryContextProvider(["alice", "bob", "charlie"]);
+
+    await provider.appendChannel("alice", "Private to bob", { to: "bob" });
+
+    const bobInbox = await provider.getInbox("bob");
+    const charlieInbox = await provider.getInbox("charlie");
+
+    expect(bobInbox).toHaveLength(1);
+    expect(charlieInbox).toHaveLength(0);
+  });
+
+  test("log entries are hidden from all agents", async () => {
+    const provider = new MemoryContextProvider(["alice", "bob"]);
+
+    await provider.appendChannel("system", "Internal log entry", { kind: "log" });
+    await provider.appendChannel("alice", "Public message");
+
+    // Both agents should only see the public message
+    const aliceView = await provider.readChannel({ agent: "alice" });
+    expect(aliceView).toHaveLength(1);
+    expect(aliceView[0].content).toBe("Public message");
+
+    // Unfiltered view should see both
+    const allEntries = await provider.readChannel();
+    expect(allEntries).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Add ContextProvider.destroy() to clean up transient state (inbox cursors)
on shutdown while preserving persistent data (channel log, documents).

Add PID-based instance lock to FileContextProvider to prevent two
processes from writing to the same context directory simultaneously.
Stale locks from crashed processes are auto-cleaned.

Integrate both into the workflow runner: acquireLock() on init,
destroy() on shutdown.

Add 26 tests covering: destroy lifecycle, cross-instance isolation,
resume semantics, instance locking, concurrent write safety, and
DM visibility isolation.

https://claude.ai/code/session_01W1XF8Vkt9bPVZSNWDjvVVi