### PR TITLE
refactor: unify logging through channel, simplify --debug

### DIFF
--- a/packages/agent-worker/src/cli/commands/send.ts
+++ b/packages/agent-worker/src/cli/commands/send.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { sendRequest, isSessionActive } from "../client.ts";
+import { outputJson } from "../output.ts";
 
 export function registerSendCommands(program: Command) {
   // Send command
@@ -133,6 +134,7 @@ export function registerSendCommands(program: Command) {
     .command("stats")
     .description("Show agent statistics")
     .option("--to <target>", "Target agent")
+    .option("--json", "Output as JSON")
     .action(async (options) => {
       const target = options.to;
 
@@ -151,10 +153,15 @@ export function registerSendCommands(program: Command) {
         messageCount: number;
         usage: { input: number; output: number; total: number };
       };
-      console.log(`Messages: ${stats.messageCount}`);
-      console.log(
-        `Tokens: ${stats.usage.total} (in: ${stats.usage.input}, out: ${stats.usage.output})`,
-      );
+
+      if (options.json) {
+        outputJson(stats);
+      } else {
+        console.log(`Messages: ${stats.messageCount}`);
+        console.log(
+          `Tokens: ${stats.usage.total} (in: ${stats.usage.input}, out: ${stats.usage.output})`,
+        );
+      }
     });
 
   // Export command

--- a/packages/agent-worker/src/cli/commands/tool.ts
+++ b/packages/agent-worker/src/cli/commands/tool.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { join } from "node:path";
 import type { ToolInfo } from "@/agent/types.ts";
 import { sendRequest, isSessionActive } from "../client.ts";
+import { outputJson } from "../output.ts";
 
 export function registerToolCommands(program: Command) {
   const toolCmd = program.command("tool").description("Manage tools");
@@ -123,6 +124,7 @@ export function registerToolCommands(program: Command) {
     .command("list")
     .description("List tools")
     .option("--to <target>", "Target agent")
+    .option("--json", "Output as JSON")
     .action(async (options) => {
       const target = options.to;
 
@@ -138,6 +140,12 @@ export function registerToolCommands(program: Command) {
       }
 
       const tools = res.data as ToolInfo[];
+
+      if (options.json) {
+        outputJson(tools);
+        return;
+      }
+
       if (tools.length === 0) {
         console.log("No tools");
       } else {

--- a/packages/agent-worker/src/cli/output.ts
+++ b/packages/agent-worker/src/cli/output.ts
@@ -1,43 +1,11 @@
 /**
  * CLI Output Utilities
  *
- * Two audiences:
- * - AI agents: need machine-parseable output (--json), no colors, consistent structure
- * - Humans: need rich formatted output (colors, progress, visual hierarchy)
- *
  * Rules:
  * - --json mode: stdout = pure JSON data only, everything else to stderr
- * - Colors: only when stdout is a TTY (auto-detected, overridable)
- * - Errors: always to stderr, never mixed with data output
- * - Exit codes: 0 = success, 1 = failure (authoritative for agents)
+ * - Errors: always to stderr via console.error + process.exit(1)
+ * - Exit codes: 0 = success, 1 = failure (authoritative for agent callers)
  */
-
-// ==================== TTY / Color Detection ====================
-
-/** Whether stdout is a TTY (interactive terminal) */
-export const isTTY = !!process.stdout.isTTY;
-
-/** Whether ANSI colors should be used (respects NO_COLOR env) */
-export const useColor = isTTY && !process.env.NO_COLOR;
-
-// ==================== ANSI Helpers ====================
-
-/** ANSI color codes — returns empty strings when colors are disabled */
-export const c = {
-  reset: useColor ? "\x1b[0m" : "",
-  dim: useColor ? "\x1b[2m" : "",
-  bold: useColor ? "\x1b[1m" : "",
-  red: useColor ? "\x1b[31m" : "",
-  green: useColor ? "\x1b[32m" : "",
-  yellow: useColor ? "\x1b[33m" : "",
-  blue: useColor ? "\x1b[34m" : "",
-  magenta: useColor ? "\x1b[35m" : "",
-  cyan: useColor ? "\x1b[36m" : "",
-  gray: useColor ? "\x1b[90m" : "",
-  brightRed: useColor ? "\x1b[91m" : "",
-};
-
-// ==================== Output Helpers ====================
 
 /**
  * Output JSON data to stdout.
@@ -45,30 +13,4 @@ export const c = {
  */
 export function outputJson(data: unknown): void {
   console.log(JSON.stringify(data, null, 2));
-}
-
-/**
- * Output an error and exit.
- * Error goes to stderr, exit code 1.
- */
-export function exitError(message: string): never {
-  console.error(`${c.red}Error:${c.reset} ${message}`);
-  process.exit(1);
-}
-
-/**
- * Handle a command that returns data.
- * - json mode: output data as JSON
- * - text mode: call the formatter function
- */
-export function outputResult(
-  data: unknown,
-  json: boolean,
-  formatText: (data: unknown) => void,
-): void {
-  if (json) {
-    outputJson(data);
-  } else {
-    formatText(data);
-  }
 }

--- a/packages/agent-worker/src/cli/output.ts
+++ b/packages/agent-worker/src/cli/output.ts
@@ -1,0 +1,74 @@
+/**
+ * CLI Output Utilities
+ *
+ * Two audiences:
+ * - AI agents: need machine-parseable output (--json), no colors, consistent structure
+ * - Humans: need rich formatted output (colors, progress, visual hierarchy)
+ *
+ * Rules:
+ * - --json mode: stdout = pure JSON data only, everything else to stderr
+ * - Colors: only when stdout is a TTY (auto-detected, overridable)
+ * - Errors: always to stderr, never mixed with data output
+ * - Exit codes: 0 = success, 1 = failure (authoritative for agents)
+ */
+
+// ==================== TTY / Color Detection ====================
+
+/** Whether stdout is a TTY (interactive terminal) */
+export const isTTY = !!process.stdout.isTTY;
+
+/** Whether ANSI colors should be used (respects NO_COLOR env) */
+export const useColor = isTTY && !process.env.NO_COLOR;
+
+// ==================== ANSI Helpers ====================
+
+/** ANSI color codes — returns empty strings when colors are disabled */
+export const c = {
+  reset: useColor ? "\x1b[0m" : "",
+  dim: useColor ? "\x1b[2m" : "",
+  bold: useColor ? "\x1b[1m" : "",
+  red: useColor ? "\x1b[31m" : "",
+  green: useColor ? "\x1b[32m" : "",
+  yellow: useColor ? "\x1b[33m" : "",
+  blue: useColor ? "\x1b[34m" : "",
+  magenta: useColor ? "\x1b[35m" : "",
+  cyan: useColor ? "\x1b[36m" : "",
+  gray: useColor ? "\x1b[90m" : "",
+  brightRed: useColor ? "\x1b[91m" : "",
+};
+
+// ==================== Output Helpers ====================
+
+/**
+ * Output JSON data to stdout.
+ * Use this instead of raw console.log(JSON.stringify(...)) for consistency.
+ */
+export function outputJson(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+/**
+ * Output an error and exit.
+ * Error goes to stderr, exit code 1.
+ */
+export function exitError(message: string): never {
+  console.error(`${c.red}Error:${c.reset} ${message}`);
+  process.exit(1);
+}
+
+/**
+ * Handle a command that returns data.
+ * - json mode: output data as JSON
+ * - text mode: call the formatter function
+ */
+export function outputResult(
+  data: unknown,
+  json: boolean,
+  formatText: (data: unknown) => void,
+): void {
+  if (json) {
+    outputJson(data);
+  } else {
+    formatText(data);
+  }
+}

--- a/packages/agent-worker/src/workflow/context/types.ts
+++ b/packages/agent-worker/src/workflow/context/types.ts
@@ -15,8 +15,8 @@ export interface Message {
   mentions: string[];
   /** DM recipient — if set, only visible to sender and recipient */
   to?: string;
-  /** Entry kind — undefined = normal message, 'log' = system log (hidden from agents) */
-  kind?: "log";
+  /** Entry kind — undefined = normal message, 'log' = operational log, 'debug' = debug detail */
+  kind?: "log" | "debug";
 }
 
 // ==================== Resource System ====================

--- a/packages/agent-worker/src/workflow/logger.ts
+++ b/packages/agent-worker/src/workflow/logger.ts
@@ -41,16 +41,20 @@ export interface Logger {
   child: (prefix: string) => Logger;
 }
 
-/** ANSI color codes */
+/** Whether to use ANSI colors */
+const shouldColor = !!process.stdout.isTTY && !process.env.NO_COLOR;
+const a = (code: string) => (shouldColor ? code : "");
+
+/** ANSI color codes — empty when not a TTY */
 const colors = {
-  reset: "\x1b[0m",
-  dim: "\x1b[2m",
-  bold: "\x1b[1m",
-  red: "\x1b[31m",
-  yellow: "\x1b[33m",
-  blue: "\x1b[34m",
-  cyan: "\x1b[36m",
-  gray: "\x1b[90m",
+  reset: a("\x1b[0m"),
+  dim: a("\x1b[2m"),
+  bold: a("\x1b[1m"),
+  red: a("\x1b[31m"),
+  yellow: a("\x1b[33m"),
+  blue: a("\x1b[34m"),
+  cyan: a("\x1b[36m"),
+  gray: a("\x1b[90m"),
 };
 
 /** Format timestamp as HH:MM:SS.mmm */

--- a/packages/agent-worker/src/workflow/logger.ts
+++ b/packages/agent-worker/src/workflow/logger.ts
@@ -1,13 +1,11 @@
 /**
  * Workflow Logger
  *
- * Two logger modes:
- * - Console logger (createLogger): writes formatted text to a log function (default: console.log)
- * - Channel logger (createChannelLogger): writes to a ContextProvider channel
- *
- * Channel logger is the primary mode for workflow execution.
- * All logs go to the channel as entries with kind="log" or kind="debug",
+ * Channel logger writes to the ContextProvider channel.
+ * All logs become channel entries with kind="log" or kind="debug",
  * and the display layer filters what to show based on --debug flag.
+ *
+ * Silent logger produces no output (used when no provider is available).
  */
 
 import type { ContextProvider } from "./context/provider.ts";
@@ -15,101 +13,20 @@ import type { ContextProvider } from "./context/provider.ts";
 /** Log levels */
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
-/** Logger configuration */
-export interface LoggerConfig {
-  /** Enable debug output */
-  debug?: boolean;
-  /** Custom log function (default: console.log) */
-  log?: (message: string) => void;
-  /** Prefix for all messages */
-  prefix?: string;
-}
-
 /** Logger instance */
 export interface Logger {
-  /** Debug level - only shown when debug=true */
+  /** Debug level — only shown with --debug */
   debug: (message: string, ...args: unknown[]) => void;
-  /** Info level - always shown */
+  /** Info level — always shown */
   info: (message: string, ...args: unknown[]) => void;
-  /** Warning level - always shown */
+  /** Warning level — always shown */
   warn: (message: string, ...args: unknown[]) => void;
-  /** Error level - always shown */
+  /** Error level — always shown */
   error: (message: string, ...args: unknown[]) => void;
   /** Check if debug mode is enabled */
   isDebug: () => boolean;
   /** Create a child logger with prefix */
   child: (prefix: string) => Logger;
-}
-
-/** Whether to use ANSI colors */
-const shouldColor = !!process.stdout.isTTY && !process.env.NO_COLOR;
-const a = (code: string) => (shouldColor ? code : "");
-
-/** ANSI color codes — empty when not a TTY */
-const colors = {
-  reset: a("\x1b[0m"),
-  dim: a("\x1b[2m"),
-  bold: a("\x1b[1m"),
-  red: a("\x1b[31m"),
-  yellow: a("\x1b[33m"),
-  blue: a("\x1b[34m"),
-  cyan: a("\x1b[36m"),
-  gray: a("\x1b[90m"),
-};
-
-/** Format timestamp as HH:MM:SS.mmm */
-function formatTimestamp(): string {
-  const now = new Date();
-  return now.toTimeString().slice(0, 8) + "." + now.getMilliseconds().toString().padStart(3, "0");
-}
-
-/**
- * Create a console logger instance (writes formatted text to a log function)
- */
-export function createLogger(config: LoggerConfig = {}): Logger {
-  const { debug: debugEnabled = false, log = console.log, prefix = "" } = config;
-
-  const formatMessage = (level: LogLevel, message: string, args: unknown[]): string => {
-    const timestamp = formatTimestamp();
-    const levelColors: Record<LogLevel, string> = {
-      debug: colors.gray,
-      info: colors.cyan,
-      warn: colors.yellow,
-      error: colors.red,
-    };
-    const levelStr = level.toUpperCase().padEnd(5);
-    const prefixStr = prefix ? `[${prefix}] ` : "";
-    const argsStr = args.length > 0 ? " " + args.map(formatArg).join(" ") : "";
-
-    return `${colors.dim}${timestamp}${colors.reset} ${levelColors[level]}${levelStr}${colors.reset} ${prefixStr}${message}${argsStr}`;
-  };
-
-  return {
-    debug: (message: string, ...args: unknown[]) => {
-      if (debugEnabled) {
-        log(formatMessage("debug", message, args));
-      }
-    },
-
-    info: (message: string, ...args: unknown[]) => {
-      log(formatMessage("info", message, args));
-    },
-
-    warn: (message: string, ...args: unknown[]) => {
-      log(formatMessage("warn", message, args));
-    },
-
-    error: (message: string, ...args: unknown[]) => {
-      log(formatMessage("error", message, args));
-    },
-
-    isDebug: () => debugEnabled,
-
-    child: (childPrefix: string) => {
-      const newPrefix = prefix ? `${prefix}:${childPrefix}` : childPrefix;
-      return createLogger({ debug: debugEnabled, log, prefix: newPrefix });
-    },
-  };
 }
 
 /**
@@ -144,14 +61,12 @@ export interface ChannelLoggerConfig {
  * - debug → channel entry with kind="debug" (only shown with --debug)
  *
  * The display layer handles formatting and filtering.
- * This keeps all output in one unified stream.
  */
 export function createChannelLogger(config: ChannelLoggerConfig): Logger {
   const { provider, from = "system" } = config;
 
   const formatContent = (level: LogLevel, message: string, args: unknown[]): string => {
     const argsStr = args.length > 0 ? " " + args.map(formatArg).join(" ") : "";
-    // Prefix with level for warn/error so they stand out in the channel
     if (level === "warn") return `[WARN] ${message}${argsStr}`;
     if (level === "error") return `[ERROR] ${message}${argsStr}`;
     return `${message}${argsStr}`;

--- a/packages/agent-worker/test/cli-mock-backend.sh
+++ b/packages/agent-worker/test/cli-mock-backend.sh
@@ -97,34 +97,13 @@ else
   fail "No inbox messages in agent prompts"
 fi
 
-# ==================== Test 2: Verbose mode output ====================
+# ==================== Test 2: Default mode shows channel output ====================
 
 echo ""
-echo "Test 2: Verbose mode output"
-echo "───────────────────────────"
+echo "Test 2: Default mode shows channel output"
+echo "──────────────────────────────────────────"
 
 OUTPUT="$OUTPUT_DIR/test2.txt"
-
-if timeout 60 npx tsx src/cli/index.ts run "$FIXTURE" --verbose > "$OUTPUT" 2>&1; then
-  pass "Exit code 0 (verbose)"
-else
-  fail "Exit code non-zero (verbose)"
-fi
-
-# Channel messages should be visible in non-debug mode
-if grep -q "alice\|bob" "$OUTPUT" 2>/dev/null; then
-  pass "Agent activity visible in verbose output"
-else
-  fail "No agent activity in verbose output"
-fi
-
-# ==================== Test 3: Default mode (no flags) ====================
-
-echo ""
-echo "Test 3: Default mode (no flags)"
-echo "────────────────────────────────"
-
-OUTPUT="$OUTPUT_DIR/test3.txt"
 
 if timeout 60 npx tsx src/cli/index.ts run "$FIXTURE" > "$OUTPUT" 2>&1; then
   pass "Exit code 0 (default mode)"
@@ -132,11 +111,27 @@ else
   fail "Exit code non-zero (default mode)"
 fi
 
-# Should show workflow name
-if grep -q "mock-test\|Running workflow" "$OUTPUT" 2>/dev/null; then
-  pass "Workflow header displayed"
+# Channel messages (agent activity + operational logs) should be visible by default
+if grep -q "alice\|bob" "$OUTPUT" 2>/dev/null; then
+  pass "Agent activity visible in default output"
 else
-  fail "No workflow header in output"
+  fail "No agent activity in default output"
+fi
+
+# ==================== Test 3: Operational logs visible by default ====================
+
+echo ""
+echo "Test 3: Operational logs visible by default"
+echo "────────────────────────────────────────────"
+
+# Reuse test2 output (same default mode)
+OUTPUT="$OUTPUT_DIR/test2.txt"
+
+# Should show workflow name via operational logs (kind="log")
+if grep -q "mock-test\|Running workflow" "$OUTPUT" 2>/dev/null; then
+  pass "Workflow info displayed via channel logs"
+else
+  fail "No workflow info in output"
 fi
 
 # ==================== Summary ====================


### PR DESCRIPTION
All workflow output now flows through the channel as typed entries:
- kind=undefined: agent messages (always visible)
- kind="log": operational events (always visible, dimmed)
- kind="debug": internal details (only with --debug)

Key changes:
- Add createChannelLogger: writes to channel instead of console
- Extract createWorkflowProvider from initWorkflow for early init
- Channel watcher filters entries based on --debug flag
- Remove --verbose flag (operational logs always visible now)
- Add --debug to context channel read/peek commands
- Extend Message.kind to "log" | "debug"

https://claude.ai/code/session_01Cpx12VxDS8pUU3gNwyGTsn