### PR TITLE
feat(agent-worker): add feedback tool for agent observations

### DIFF
--- a/packages/agent-worker/src/agent/tools/feedback.ts
+++ b/packages/agent-worker/src/agent/tools/feedback.ts
@@ -104,10 +104,16 @@ export function createFeedbackTool(
       required: ["target", "type", "description"],
     }),
     execute: async (args: Record<string, unknown>) => {
+      const validTypes = ["missing", "friction", "suggestion"] as const;
+      const rawType = args.type as string;
+      const type = validTypes.includes(rawType as (typeof validTypes)[number])
+        ? (rawType as FeedbackEntry["type"])
+        : "suggestion";
+
       const entry: FeedbackEntry = {
         timestamp: new Date().toISOString(),
         target: args.target as string,
-        type: args.type as FeedbackEntry["type"],
+        type,
         description: args.description as string,
         ...(args.context ? { context: args.context as string } : {}),
       };

--- a/packages/agent-worker/src/agent/tools/feedback.ts
+++ b/packages/agent-worker/src/agent/tools/feedback.ts
@@ -1,0 +1,137 @@
+/**
+ * Feedback tool — lets agents report observations about tools and workflows
+ *
+ * When enabled, agents can call this tool to leave structured feedback:
+ * friction points, bugs, suggestions, or praise. Feedback is collected
+ * in memory and optionally forwarded via a callback.
+ *
+ * @example
+ * ```typescript
+ * const { tool, getFeedback } = createFeedbackTool();
+ *
+ * const session = new AgentSession({
+ *   model: 'anthropic/claude-sonnet-4-5',
+ *   system: FEEDBACK_PROMPT + '\nYou are a coding assistant.',
+ *   tools: { feedback: tool, bash: bashTool },
+ * });
+ *
+ * await session.send('...');
+ * console.log(getFeedback()); // review what the agent reported
+ * ```
+ */
+
+import { tool, jsonSchema } from "ai";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface FeedbackEntry {
+  /** ISO timestamp */
+  timestamp: string;
+  /** What is being commented on — tool name, skill name, "workflow", etc. */
+  target: string;
+  /** Category */
+  type: "bug" | "suggestion" | "friction" | "praise";
+  /** What the agent observed or suggests */
+  description: string;
+  /** Optional: what the agent was doing when it noticed */
+  context?: string;
+}
+
+export interface FeedbackToolOptions {
+  /** Called each time the agent submits feedback */
+  onFeedback?: (entry: FeedbackEntry) => void;
+  /** Maximum entries to keep (default: 50) */
+  maxEntries?: number;
+}
+
+export interface FeedbackToolResult {
+  /** AI SDK tool() object — pass to AgentSession as a tool */
+  tool: unknown;
+  /** Retrieve all collected feedback entries */
+  getFeedback(): FeedbackEntry[];
+  /** Clear collected feedback */
+  clearFeedback(): void;
+}
+
+// ── System prompt snippet ──────────────────────────────────────────
+
+/**
+ * Append this to the system prompt when the feedback tool is enabled.
+ * Tells the agent the tool exists and when to use it.
+ */
+export const FEEDBACK_PROMPT = `
+## Feedback
+
+You have a \`feedback\` tool. Use it when you notice something about the tools or workflow worth reporting — a friction point, a bug, a missing capability, or something that works well.
+
+Guidelines:
+- Only call it when you genuinely have something to say. No obligation to give feedback.
+- Be specific: name the tool/workflow, describe what happened, suggest what could be better.
+- One entry per observation. Multiple calls are fine.
+`.trim();
+
+// ── Factory ────────────────────────────────────────────────────────
+
+export function createFeedbackTool(
+  options: FeedbackToolOptions = {},
+): FeedbackToolResult {
+  const { onFeedback, maxEntries = 50 } = options;
+  const entries: FeedbackEntry[] = [];
+
+  const feedbackTool = tool({
+    description:
+      "Submit feedback about a tool, skill, or workflow. Use when you notice friction, bugs, missing capabilities, or something that works particularly well.",
+    parameters: jsonSchema({
+      type: "object",
+      properties: {
+        target: {
+          type: "string",
+          description:
+            "What you are giving feedback on — a tool name (e.g. bash, readFile), a skill name, or a general area (e.g. workflow, prompt).",
+        },
+        type: {
+          type: "string",
+          enum: ["bug", "suggestion", "friction", "praise"],
+          description:
+            "bug: something broken. suggestion: an improvement idea. friction: something awkward or slow. praise: something that works well.",
+        },
+        description: {
+          type: "string",
+          description: "What you observed or suggest. Be specific.",
+        },
+        context: {
+          type: "string",
+          description: "Optional: what you were doing when you noticed this.",
+        },
+      },
+      required: ["target", "type", "description"],
+    }),
+    execute: async (args: Record<string, unknown>) => {
+      const entry: FeedbackEntry = {
+        timestamp: new Date().toISOString(),
+        target: args.target as string,
+        type: args.type as FeedbackEntry["type"],
+        description: args.description as string,
+        ...(args.context ? { context: args.context as string } : {}),
+      };
+
+      // Enforce cap
+      if (entries.length >= maxEntries) {
+        entries.shift();
+      }
+      entries.push(entry);
+
+      onFeedback?.(entry);
+
+      return { recorded: true };
+    },
+  });
+
+  return {
+    tool: feedbackTool,
+    getFeedback: () => [...entries],
+    clearFeedback: () => {
+      entries.length = 0;
+    },
+  };
+}

--- a/packages/agent-worker/src/agent/tools/index.ts
+++ b/packages/agent-worker/src/agent/tools/index.ts
@@ -7,6 +7,7 @@
  * Available tools:
  * - Skills: Access and read agent skills
  * - Bash: Execute bash commands in sandboxed environment (includes readFile, writeFile)
+ * - Feedback: Let agents report observations about tools and workflows
  *
  * Future tools:
  * - Git: Git operations
@@ -24,3 +25,7 @@ export {
   createBashTool,
 } from "./bash.ts";
 export type { BashToolsOptions, BashToolkit, CreateBashToolOptions } from "./bash.ts";
+
+// Feedback tool
+export { createFeedbackTool, FEEDBACK_PROMPT } from "./feedback.ts";
+export type { FeedbackEntry, FeedbackToolOptions, FeedbackToolResult } from "./feedback.ts";

--- a/packages/agent-worker/src/cli/commands/agent.ts
+++ b/packages/agent-worker/src/cli/commands/agent.ts
@@ -29,6 +29,7 @@ async function createAgentAction(
     foreground?: boolean;
     instance?: string;
     json?: boolean;
+    feedback?: boolean;
   },
 ) {
   let system = options.system ?? "You are a helpful assistant.";
@@ -64,6 +65,7 @@ async function createAgentAction(
       skills: options.skill,
       skillDirs: options.skillDir,
       importSkills: options.importSkill,
+      feedback: options.feedback,
     });
   } else {
     const scriptPath = process.argv[1] ?? "";
@@ -72,6 +74,9 @@ async function createAgentAction(
       args.splice(2, 0, agentName);
     }
     args.push("--idle-timeout", String(idleTimeout));
+    if (options.feedback) {
+      args.push("--feedback");
+    }
     if (options.skill) {
       for (const skillPath of options.skill) {
         args.push("--skill", skillPath);
@@ -170,6 +175,7 @@ function addNewCommandOptions(cmd: Command): Command {
     .option("--skill <path...>", "Add individual skill directories")
     .option("--skill-dir <path...>", "Scan directories for skills")
     .option("--import-skill <spec...>", "Import skills from Git (owner/repo:{skill1,skill2})")
+    .option("--feedback", "Enable feedback tool (agent can report tool/workflow observations)")
     .option("--instance <name>", "Instance name")
     .option("--foreground", "Run in foreground")
     .option("--json", "Output as JSON");

--- a/packages/agent-worker/src/cli/commands/tool.ts
+++ b/packages/agent-worker/src/cli/commands/tool.ts
@@ -190,13 +190,11 @@ export function registerToolCommands(program: Command) {
       } else {
         for (const entry of entries) {
           const icon =
-            entry.type === "bug"
-              ? "[bug]"
+            entry.type === "missing"
+              ? "[missing]"
               : entry.type === "friction"
                 ? "[friction]"
-                : entry.type === "praise"
-                  ? "[praise]"
-                  : "[suggestion]";
+                : "[suggestion]";
           console.log(`  ${icon} ${entry.target}: ${entry.description}`);
           if (entry.context) {
             console.log(`         context: ${entry.context}`);

--- a/packages/agent-worker/src/cli/commands/workflow.ts
+++ b/packages/agent-worker/src/cli/commands/workflow.ts
@@ -10,6 +10,7 @@ export function registerWorkflowCommands(program: Command) {
     .description("Execute workflow and exit when complete")
     .option("--instance <name>", "Instance name", "default")
     .option("-d, --debug", "Show debug details (internal logs, MCP traces, idle checks)")
+    .option("--feedback", "Enable feedback tool (agents can report tool/workflow observations)")
     .option("--json", "Output results as JSON")
     .action(async (file, options) => {
       const { parseWorkflowFile, runWorkflowWithControllers } =
@@ -24,6 +25,7 @@ export function registerWorkflowCommands(program: Command) {
           debug: options.debug,
           log: console.log,
           mode: "run",
+          feedback: options.feedback,
         });
 
         if (!result.success) {
@@ -41,6 +43,7 @@ export function registerWorkflowCommands(program: Command) {
                   success: true,
                   duration: result.duration,
                   document: finalDoc,
+                  feedback: result.feedback,
                 },
                 null,
                 2,
@@ -49,6 +52,14 @@ export function registerWorkflowCommands(program: Command) {
           } else if (finalDoc) {
             console.log("\n--- Document ---");
             console.log(finalDoc);
+          }
+        }
+
+        // Print feedback summary
+        if (result.feedback && result.feedback.length > 0) {
+          console.log(`\n--- Feedback (${result.feedback.length}) ---`);
+          for (const entry of result.feedback) {
+            console.log(`  [${entry.type}] ${entry.target}: ${entry.description}`);
           }
         }
       } catch (error) {
@@ -63,6 +74,7 @@ export function registerWorkflowCommands(program: Command) {
     .description("Start workflow and keep agents running")
     .option("--instance <name>", "Instance name", "default")
     .option("-d, --debug", "Show debug details (internal logs, MCP traces, idle checks)")
+    .option("--feedback", "Enable feedback tool (agents can report tool/workflow observations)")
     .option("--background", "Run in background (daemonize)")
     .action(async (file, options) => {
       const { parseWorkflowFile, runWorkflowWithControllers } =
@@ -107,6 +119,7 @@ export function registerWorkflowCommands(program: Command) {
           debug: options.debug,
           log: console.log,
           mode: "start",
+          feedback: options.feedback,
         });
 
         if (!result.success) {

--- a/packages/agent-worker/src/cli/commands/workflow.ts
+++ b/packages/agent-worker/src/cli/commands/workflow.ts
@@ -84,6 +84,9 @@ export function registerWorkflowCommands(program: Command) {
       if (options.background) {
         const scriptPath = process.argv[1] ?? "";
         const args = [scriptPath, "start", file, "--instance", options.instance];
+        if (options.feedback) {
+          args.push("--feedback");
+        }
 
         const child = spawn(process.execPath, args, {
           detached: true,

--- a/packages/agent-worker/src/index.ts
+++ b/packages/agent-worker/src/index.ts
@@ -16,6 +16,7 @@ export {
   createBashToolsFromDirectory,
   createBashToolsFromFiles,
 } from "./agent/tools/bash.ts";
+export { createFeedbackTool, FEEDBACK_PROMPT } from "./agent/tools/feedback.ts";
 export {
   createBackend,
   checkBackends,
@@ -41,6 +42,7 @@ export {
 } from "./agent/skills/index.ts";
 export type { SupportedProvider } from "./agent/models.ts";
 export type { BashToolkit, BashToolsOptions, CreateBashToolOptions } from "./agent/tools/bash.ts";
+export type { FeedbackEntry, FeedbackToolOptions, FeedbackToolResult } from "./agent/tools/feedback.ts";
 export type {
   Backend,
   BackendType,

--- a/packages/agent-worker/src/workflow/context/mcp-server.ts
+++ b/packages/agent-worker/src/workflow/context/mcp-server.ts
@@ -690,23 +690,23 @@ export function createContextMCPServer(options: ContextMCPServerOptions) {
   if (feedbackEnabled) {
     server.tool(
       "feedback_submit",
-      "Submit feedback about a tool, workflow, or process. Use when you notice friction, bugs, missing capabilities, or something that works well.",
+      "Report a workflow improvement need. Use when you hit something inconvenient — a missing tool, an awkward step, or a capability you wished you had.",
       {
         target: z
           .string()
           .describe(
-            "What you are giving feedback on — a tool name, a workflow step, or a general area.",
+            "The area this is about — a tool name, a workflow step, or a general area (e.g. file search, code review).",
           ),
         type: z
-          .enum(["bug", "suggestion", "friction", "praise"])
+          .enum(["missing", "friction", "suggestion"])
           .describe(
-            "bug: something broken. suggestion: an improvement idea. friction: something awkward or slow. praise: something that works well.",
+            "missing: a tool or capability you needed but didn't have. friction: something that works but is awkward or slow. suggestion: a concrete improvement idea.",
           ),
-        description: z.string().describe("What you observed or suggest. Be specific."),
+        description: z.string().describe("What you needed or what could be improved. Be specific."),
         context: z
           .string()
           .optional()
-          .describe("Optional: what you were doing when you noticed this."),
+          .describe("Optional: what you were trying to do when you hit this."),
       },
       async ({ target, type, description, context: ctx }, extra) => {
         const from = getAgentId(extra) || "anonymous";

--- a/packages/agent-worker/src/workflow/controller/controller.ts
+++ b/packages/agent-worker/src/workflow/controller/controller.ts
@@ -47,6 +47,7 @@ export function createAgentController(config: AgentControllerConfig): AgentContr
     backend,
     onRunComplete,
     log = () => {},
+    feedback,
   } = config;
 
   const pollInterval = config.pollInterval ?? CONTROLLER_DEFAULTS.pollInterval;
@@ -130,6 +131,7 @@ export function createAgentController(config: AgentControllerConfig): AgentContr
           workspaceDir,
           projectDir,
           retryAttempt: attempt,
+          feedback,
         };
 
         // Orchestrate: build prompt → configure workspace → send

--- a/packages/agent-worker/src/workflow/controller/prompt.ts
+++ b/packages/agent-worker/src/workflow/controller/prompt.ts
@@ -118,6 +118,17 @@ export function buildAgentPrompt(ctx: AgentRunContext): string {
     "- **resource_create**: Store large content, get a reference (resource:id) for use anywhere.",
   );
   sections.push("- **resource_read**: Read resource content by ID.");
+
+  // Feedback tool (opt-in)
+  if (ctx.feedback) {
+    sections.push("");
+    sections.push("### Feedback Tool");
+    sections.push(
+      "- **feedback_submit**: Report observations about tools or workflows — friction, bugs, suggestions, or praise.",
+    );
+    sections.push("  Only use when you genuinely have something to say. Be specific.");
+  }
+
   sections.push("");
   sections.push("### Workflow");
   sections.push("1. Read your inbox messages above");

--- a/packages/agent-worker/src/workflow/controller/prompt.ts
+++ b/packages/agent-worker/src/workflow/controller/prompt.ts
@@ -124,9 +124,9 @@ export function buildAgentPrompt(ctx: AgentRunContext): string {
     sections.push("");
     sections.push("### Feedback Tool");
     sections.push(
-      "- **feedback_submit**: Report observations about tools or workflows — friction, bugs, suggestions, or praise.",
+      "- **feedback_submit**: Report workflow improvement needs — a missing tool, an awkward step, or a capability gap.",
     );
-    sections.push("  Only use when you genuinely have something to say. Be specific.");
+    sections.push("  Only use when you genuinely hit a pain point during your work.");
   }
 
   sections.push("");

--- a/packages/agent-worker/src/workflow/controller/types.ts
+++ b/packages/agent-worker/src/workflow/controller/types.ts
@@ -65,6 +65,8 @@ export interface AgentControllerConfig {
   onRunComplete?: (result: AgentRunResult) => void;
   /** Log function */
   log?: (message: string) => void;
+  /** Enable feedback tool in agent prompts */
+  feedback?: boolean;
 }
 
 // ==================== Agent Run ====================
@@ -89,6 +91,8 @@ export interface AgentRunContext {
   projectDir: string;
   /** Retry attempt number (1 = first try, 2+ = retry) */
   retryAttempt: number;
+  /** Whether feedback tool is enabled */
+  feedback?: boolean;
 }
 
 /** Result of an agent run */

--- a/packages/agent-worker/src/workflow/runner.ts
+++ b/packages/agent-worker/src/workflow/runner.ts
@@ -446,8 +446,10 @@ export interface ControllerRunResult {
   controllers?: Map<string, AgentController>;
   /** Shutdown function */
   shutdown?: () => Promise<void>;
-  /** Feedback entries collected during workflow (when --feedback enabled) */
+  /** Feedback entries collected during workflow (when --feedback enabled, run mode) */
   feedback?: import("../agent/tools/feedback.ts").FeedbackEntry[];
+  /** Live feedback accessor (when --feedback enabled, start mode) */
+  getFeedback?: () => import("../agent/tools/feedback.ts").FeedbackEntry[];
 }
 
 /**
@@ -649,7 +651,7 @@ export async function runWorkflowWithControllers(
         await shutdownControllers(controllers, logger);
         await runtime.shutdown();
       },
-      feedback: runtime.getFeedback?.(),
+      getFeedback: runtime.getFeedback,
     };
   } catch (error) {
     // Error during init — no channel logger available, fall back to console

--- a/packages/agent-worker/test/feedback.test.ts
+++ b/packages/agent-worker/test/feedback.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Feedback Tool Tests
+ */
+
+import { describe, test, expect } from 'bun:test'
+import {
+  createFeedbackTool,
+  FEEDBACK_PROMPT,
+  type FeedbackEntry,
+} from '../src/agent/tools/feedback.js'
+
+/** Helper: call the tool's execute function directly */
+async function submitFeedback(
+  toolResult: ReturnType<typeof createFeedbackTool>,
+  args: Record<string, unknown>,
+) {
+  const t = toolResult.tool as { execute: (args: Record<string, unknown>) => Promise<unknown> }
+  return t.execute(args)
+}
+
+describe('createFeedbackTool', () => {
+  test('returns tool, getFeedback, and clearFeedback', () => {
+    const result = createFeedbackTool()
+
+    expect(result.tool).toBeDefined()
+    expect(typeof result.getFeedback).toBe('function')
+    expect(typeof result.clearFeedback).toBe('function')
+  })
+
+  test('starts with empty feedback', () => {
+    const { getFeedback } = createFeedbackTool()
+    expect(getFeedback()).toEqual([])
+  })
+
+  describe('execute', () => {
+    test('records a feedback entry with required fields', async () => {
+      const result = createFeedbackTool()
+
+      const response = await submitFeedback(result, {
+        target: 'file-search',
+        type: 'missing',
+        description: 'Need a recursive grep tool',
+      })
+
+      expect(response).toEqual({ recorded: true })
+
+      const entries = result.getFeedback()
+      expect(entries).toHaveLength(1)
+      expect(entries[0].target).toBe('file-search')
+      expect(entries[0].type).toBe('missing')
+      expect(entries[0].description).toBe('Need a recursive grep tool')
+      expect(entries[0].timestamp).toBeTruthy()
+      expect(entries[0].context).toBeUndefined()
+    })
+
+    test('records optional context field', async () => {
+      const result = createFeedbackTool()
+
+      await submitFeedback(result, {
+        target: 'bash',
+        type: 'friction',
+        description: 'Timeout too short for builds',
+        context: 'Running npm run build in a large monorepo',
+      })
+
+      const entries = result.getFeedback()
+      expect(entries[0].context).toBe('Running npm run build in a large monorepo')
+    })
+
+    test('accepts all three valid types', async () => {
+      const result = createFeedbackTool()
+
+      for (const type of ['missing', 'friction', 'suggestion'] as const) {
+        await submitFeedback(result, {
+          target: 'test',
+          type,
+          description: `Testing ${type}`,
+        })
+      }
+
+      const entries = result.getFeedback()
+      expect(entries).toHaveLength(3)
+      expect(entries.map((e) => e.type)).toEqual(['missing', 'friction', 'suggestion'])
+    })
+
+    test('falls back to suggestion for invalid type', async () => {
+      const result = createFeedbackTool()
+
+      await submitFeedback(result, {
+        target: 'test',
+        type: 'bug',
+        description: 'Invalid type should fallback',
+      })
+
+      const entries = result.getFeedback()
+      expect(entries[0].type).toBe('suggestion')
+    })
+
+    test('accumulates multiple entries in order', async () => {
+      const result = createFeedbackTool()
+
+      await submitFeedback(result, {
+        target: 'a',
+        type: 'missing',
+        description: 'first',
+      })
+      await submitFeedback(result, {
+        target: 'b',
+        type: 'friction',
+        description: 'second',
+      })
+
+      const entries = result.getFeedback()
+      expect(entries).toHaveLength(2)
+      expect(entries[0].target).toBe('a')
+      expect(entries[1].target).toBe('b')
+    })
+  })
+
+  describe('maxEntries', () => {
+    test('enforces default cap of 50', async () => {
+      const result = createFeedbackTool()
+
+      for (let i = 0; i < 55; i++) {
+        await submitFeedback(result, {
+          target: `tool-${i}`,
+          type: 'suggestion',
+          description: `Entry ${i}`,
+        })
+      }
+
+      const entries = result.getFeedback()
+      expect(entries).toHaveLength(50)
+      // Oldest entries should have been evicted
+      expect(entries[0].target).toBe('tool-5')
+      expect(entries[49].target).toBe('tool-54')
+    })
+
+    test('respects custom maxEntries', async () => {
+      const result = createFeedbackTool({ maxEntries: 3 })
+
+      for (let i = 0; i < 5; i++) {
+        await submitFeedback(result, {
+          target: `t-${i}`,
+          type: 'missing',
+          description: `Entry ${i}`,
+        })
+      }
+
+      const entries = result.getFeedback()
+      expect(entries).toHaveLength(3)
+      expect(entries[0].target).toBe('t-2')
+      expect(entries[2].target).toBe('t-4')
+    })
+  })
+
+  describe('onFeedback callback', () => {
+    test('calls onFeedback for each submission', async () => {
+      const received: FeedbackEntry[] = []
+      const result = createFeedbackTool({
+        onFeedback: (entry) => received.push(entry),
+      })
+
+      await submitFeedback(result, {
+        target: 'readFile',
+        type: 'friction',
+        description: 'Too slow on large files',
+      })
+
+      expect(received).toHaveLength(1)
+      expect(received[0].target).toBe('readFile')
+    })
+  })
+
+  describe('getFeedback', () => {
+    test('returns a copy (not a reference to internal array)', async () => {
+      const result = createFeedbackTool()
+
+      await submitFeedback(result, {
+        target: 'test',
+        type: 'suggestion',
+        description: 'Test isolation',
+      })
+
+      const snapshot = result.getFeedback()
+      // Mutating the snapshot should not affect internal state
+      snapshot.pop()
+      expect(result.getFeedback()).toHaveLength(1)
+    })
+  })
+
+  describe('clearFeedback', () => {
+    test('removes all entries', async () => {
+      const result = createFeedbackTool()
+
+      await submitFeedback(result, {
+        target: 'test',
+        type: 'missing',
+        description: 'Will be cleared',
+      })
+
+      expect(result.getFeedback()).toHaveLength(1)
+      result.clearFeedback()
+      expect(result.getFeedback()).toHaveLength(0)
+    })
+
+    test('allows new entries after clearing', async () => {
+      const result = createFeedbackTool()
+
+      await submitFeedback(result, {
+        target: 'old',
+        type: 'missing',
+        description: 'Old entry',
+      })
+      result.clearFeedback()
+
+      await submitFeedback(result, {
+        target: 'new',
+        type: 'suggestion',
+        description: 'New entry',
+      })
+
+      const entries = result.getFeedback()
+      expect(entries).toHaveLength(1)
+      expect(entries[0].target).toBe('new')
+    })
+  })
+
+  describe('isolation', () => {
+    test('separate instances do not share state', async () => {
+      const a = createFeedbackTool()
+      const b = createFeedbackTool()
+
+      await submitFeedback(a, {
+        target: 'only-a',
+        type: 'missing',
+        description: 'Only in A',
+      })
+
+      expect(a.getFeedback()).toHaveLength(1)
+      expect(b.getFeedback()).toHaveLength(0)
+    })
+  })
+})
+
+describe('FEEDBACK_PROMPT', () => {
+  test('mentions the feedback tool', () => {
+    expect(FEEDBACK_PROMPT).toContain('`feedback`')
+  })
+
+  test('describes workflow improvement purpose', () => {
+    expect(FEEDBACK_PROMPT).toContain('improve the workflow')
+  })
+})


### PR DESCRIPTION
Agents can now report observations about tools and workflows through a
structured feedback channel. Two integration paths:

- Single agent (daemon): AI SDK tool via createFeedbackTool(), enabled
  with `agent-worker new --feedback`. Query with `tool feedback`.
- Multi-agent (workflow): MCP tool via feedback_submit, enabled with
  `agent-worker run --feedback`. Results printed at workflow end.

When enabled, a prompt snippet is injected telling the agent the tool
exists and when to use it (opt-in, not mandatory).

https://claude.ai/code/session_01RDqx6ZrnhbirbJAGMkYvn5