### PR TITLE
feat(agent-worker): add scheduled wakeup for agent sessions

### DIFF
--- a/packages/agent-worker/src/daemon/cron.ts
+++ b/packages/agent-worker/src/daemon/cron.ts
@@ -1,0 +1,123 @@
+/**
+ * Minimal cron expression parser.
+ * Supports standard 5-field cron: minute hour day-of-month month day-of-week
+ *
+ * Field syntax:
+ *   *       every value
+ *   N       exact value
+ *   N-M     range (inclusive)
+ *   N,M,O   list
+ *   * /step  every step (e.g. * /15 = 0,15,30,45)  [no space — formatting only]
+ *   N-M/step range with step
+ */
+
+function range(min: number, max: number): number[] {
+  const r: number[] = [];
+  for (let i = min; i <= max; i++) r.push(i);
+  return r;
+}
+
+function parseCronField(field: string, min: number, max: number): Set<number> {
+  const values = new Set<number>();
+
+  for (const part of field.split(",")) {
+    if (part === "*") {
+      for (const v of range(min, max)) values.add(v);
+    } else if (part.includes("/")) {
+      const [rangeStr, stepStr] = part.split("/");
+      const step = parseInt(stepStr!, 10);
+      if (isNaN(step) || step <= 0) throw new Error(`Invalid step: ${part}`);
+
+      let lo = min;
+      let hi = max;
+      if (rangeStr !== "*") {
+        if (rangeStr!.includes("-")) {
+          [lo, hi] = rangeStr!.split("-").map(Number) as [number, number];
+        } else {
+          lo = parseInt(rangeStr!, 10);
+          hi = max;
+        }
+      }
+      for (let v = lo; v <= hi; v += step) values.add(v);
+    } else if (part.includes("-")) {
+      const [lo, hi] = part.split("-").map(Number) as [number, number];
+      for (const v of range(lo, hi)) values.add(v);
+    } else {
+      values.add(parseInt(part, 10));
+    }
+  }
+
+  return values;
+}
+
+export interface CronFields {
+  minutes: Set<number>;
+  hours: Set<number>;
+  daysOfMonth: Set<number>;
+  months: Set<number>;
+  daysOfWeek: Set<number>;
+}
+
+/**
+ * Parse a 5-field cron expression into sets of matching values.
+ */
+export function parseCron(expr: string): CronFields {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error(`Invalid cron expression (expected 5 fields): ${expr}`);
+  }
+
+  return {
+    minutes: parseCronField(parts[0]!, 0, 59),
+    hours: parseCronField(parts[1]!, 0, 23),
+    daysOfMonth: parseCronField(parts[2]!, 1, 31),
+    months: parseCronField(parts[3]!, 1, 12),
+    daysOfWeek: parseCronField(parts[4]!, 0, 6),
+  };
+}
+
+/**
+ * Check if a Date matches a parsed cron expression.
+ */
+function matchesCron(date: Date, fields: CronFields): boolean {
+  return (
+    fields.minutes.has(date.getMinutes()) &&
+    fields.hours.has(date.getHours()) &&
+    fields.daysOfMonth.has(date.getDate()) &&
+    fields.months.has(date.getMonth() + 1) &&
+    fields.daysOfWeek.has(date.getDay())
+  );
+}
+
+/**
+ * Calculate the next occurrence of a cron expression after `from`.
+ * Searches forward minute-by-minute, up to 1 year.
+ * Returns the Date of the next match.
+ */
+export function nextCronTime(expr: string, from: Date = new Date()): Date {
+  const fields = parseCron(expr);
+
+  // Start from next minute boundary
+  const next = new Date(from);
+  next.setSeconds(0, 0);
+  next.setMinutes(next.getMinutes() + 1);
+
+  // Search forward (max ~1 year worth of minutes)
+  const maxMinutes = 366 * 24 * 60;
+  for (let i = 0; i < maxMinutes; i++) {
+    if (matchesCron(next, fields)) {
+      return next;
+    }
+    next.setMinutes(next.getMinutes() + 1);
+  }
+
+  throw new Error(`No matching cron time found within 1 year: ${expr}`);
+}
+
+/**
+ * Calculate ms until the next cron occurrence.
+ */
+export function msUntilNextCron(expr: string, from: Date = new Date()): number {
+  const next = nextCronTime(expr, from);
+  return next.getTime() - from.getTime();
+}

--- a/packages/agent-worker/src/daemon/daemon.ts
+++ b/packages/agent-worker/src/daemon/daemon.ts
@@ -456,6 +456,14 @@ export async function startDaemon(config: {
         const resolved = resolveSchedule(config.schedule);
         if (resolved.type === "interval") {
           console.log(`Wakeup: every ${resolved.ms! / 1000}s when idle`);
+          // Warn if idle timeout would fire before wakeup interval
+          const idleMs = config.idleTimeout ?? DEFAULT_IDLE_TIMEOUT;
+          if (idleMs > 0 && resolved.ms! > idleMs) {
+            console.warn(
+              `Warning: idle timeout (${idleMs / 1000}s) is shorter than wakeup interval (${resolved.ms! / 1000}s). ` +
+                `Session will shut down before wakeup fires. Use --idle-timeout 0 to disable.`,
+            );
+          }
         } else {
           console.log(`Wakeup: cron ${resolved.expr}`);
         }

--- a/packages/agent-worker/src/daemon/index.ts
+++ b/packages/agent-worker/src/daemon/index.ts
@@ -7,7 +7,11 @@ export {
   registerSession,
   unregisterSession,
   getSessionInfo,
+  parseDuration,
+  resolveSchedule,
   type SessionInfo,
+  type ScheduleConfig,
+  type ResolvedSchedule,
 } from "./registry.ts";
 
 // Re-export daemon entry point
@@ -15,3 +19,6 @@ export { startDaemon } from "./daemon.ts";
 
 // Re-export handler types
 export type { ServerState, Request, Response } from "./handler.ts";
+
+// Re-export cron utilities
+export { parseCron, nextCronTime, msUntilNextCron } from "./cron.ts";

--- a/packages/agent-worker/src/daemon/registry.ts
+++ b/packages/agent-worker/src/daemon/registry.ts
@@ -30,7 +30,7 @@ const DEFAULT_FILE = join(CONFIG_DIR, "default");
  * The `wakeup` field accepts three mutually exclusive formats:
  * - **number (ms)**: idle-based interval, resets on activity. e.g. `60000`
  * - **duration string**: idle-based interval, resets on activity. e.g. `"30s"`, `"5m"`, `"2h"`
- * - **cron expression**: fixed schedule, NOT reset by activity. e.g. `"0 *​/2 * * *"`
+ * - **cron expression**: fixed schedule, NOT reset by activity. e.g. `"0 9 * * 1-5"`
  */
 export interface ScheduleConfig {
   /** Wakeup schedule: number (ms), duration string ("30s"/"5m"/"2h"), or cron expression. */

--- a/packages/agent-worker/test/unit/cron.test.ts
+++ b/packages/agent-worker/test/unit/cron.test.ts
@@ -57,6 +57,13 @@ describe("parseCron", () => {
     expect(() => parseCron("* * *")).toThrow("expected 5 fields");
     expect(() => parseCron("* * * * * *")).toThrow("expected 5 fields");
   });
+
+  test("throws on non-numeric values", () => {
+    expect(() => parseCron("abc * * * *")).toThrow("Invalid number");
+    expect(() => parseCron("* * * * foo")).toThrow("Invalid number");
+    expect(() => parseCron("a-b * * * *")).toThrow("Invalid number");
+    expect(() => parseCron("*/x * * * *")).toThrow("Invalid number");
+  });
 });
 
 describe("nextCronTime", () => {

--- a/packages/agent-worker/test/unit/cron.test.ts
+++ b/packages/agent-worker/test/unit/cron.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Cron Parser Unit Tests
+ *
+ * Tests the minimal cron expression parser in daemon/cron.ts.
+ * Covers field parsing, next-time calculation, and edge cases.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { parseCron, nextCronTime, msUntilNextCron } from "../../src/daemon/cron.ts";
+import { parseDuration, resolveSchedule } from "../../src/daemon/registry.ts";
+
+describe("parseCron", () => {
+  test("parses wildcard fields", () => {
+    const fields = parseCron("* * * * *");
+    expect(fields.minutes.size).toBe(60); // 0-59
+    expect(fields.hours.size).toBe(24); // 0-23
+    expect(fields.daysOfMonth.size).toBe(31); // 1-31
+    expect(fields.months.size).toBe(12); // 1-12
+    expect(fields.daysOfWeek.size).toBe(7); // 0-6
+  });
+
+  test("parses exact values", () => {
+    const fields = parseCron("30 14 1 6 3");
+    expect([...fields.minutes]).toEqual([30]);
+    expect([...fields.hours]).toEqual([14]);
+    expect([...fields.daysOfMonth]).toEqual([1]);
+    expect([...fields.months]).toEqual([6]);
+    expect([...fields.daysOfWeek]).toEqual([3]);
+  });
+
+  test("parses step values", () => {
+    const fields = parseCron("*/15 */6 * * *");
+    expect([...fields.minutes].sort((a, b) => a - b)).toEqual([0, 15, 30, 45]);
+    expect([...fields.hours].sort((a, b) => a - b)).toEqual([0, 6, 12, 18]);
+  });
+
+  test("parses ranges", () => {
+    const fields = parseCron("0-5 9-17 * * *");
+    expect([...fields.minutes].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect([...fields.hours].sort((a, b) => a - b)).toEqual([
+      9, 10, 11, 12, 13, 14, 15, 16, 17,
+    ]);
+  });
+
+  test("parses lists", () => {
+    const fields = parseCron("0,30 9,12,18 * * *");
+    expect([...fields.minutes].sort((a, b) => a - b)).toEqual([0, 30]);
+    expect([...fields.hours].sort((a, b) => a - b)).toEqual([9, 12, 18]);
+  });
+
+  test("parses range with step", () => {
+    const fields = parseCron("0-30/10 * * * *");
+    expect([...fields.minutes].sort((a, b) => a - b)).toEqual([0, 10, 20, 30]);
+  });
+
+  test("throws on invalid field count", () => {
+    expect(() => parseCron("* * *")).toThrow("expected 5 fields");
+    expect(() => parseCron("* * * * * *")).toThrow("expected 5 fields");
+  });
+});
+
+describe("nextCronTime", () => {
+  test("finds next minute for every-minute cron", () => {
+    const from = new Date("2026-02-07T10:30:00Z");
+    const next = nextCronTime("* * * * *", from);
+    expect(next.getTime()).toBe(new Date("2026-02-07T10:31:00Z").getTime());
+  });
+
+  test("finds next matching minute", () => {
+    const from = new Date("2026-02-07T10:20:00Z");
+    const next = nextCronTime("30 * * * *", from);
+    expect(next.getMinutes()).toBe(30);
+    expect(next.getHours()).toBe(10);
+  });
+
+  test("rolls to next hour if past target minute", () => {
+    const from = new Date("2026-02-07T10:35:00Z");
+    const next = nextCronTime("30 * * * *", from);
+    expect(next.getMinutes()).toBe(30);
+    expect(next.getHours()).toBe(11);
+  });
+
+  test("handles every-2-hours cron", () => {
+    const from = new Date("2026-02-07T09:00:00Z");
+    const next = nextCronTime("0 */2 * * *", from);
+    expect(next.getMinutes()).toBe(0);
+    expect(next.getHours()).toBe(10);
+  });
+
+  test("handles specific day of week", () => {
+    // 2026-02-07 is a Saturday (day 6)
+    const from = new Date("2026-02-07T10:00:00Z");
+    // Find next Monday (day 1)
+    const next = nextCronTime("0 9 * * 1", from);
+    expect(next.getDay()).toBe(1); // Monday
+    expect(next.getHours()).toBe(9);
+    expect(next.getMinutes()).toBe(0);
+  });
+
+  test("returns time in the future", () => {
+    const from = new Date();
+    const next = nextCronTime("* * * * *", from);
+    expect(next.getTime()).toBeGreaterThan(from.getTime());
+  });
+});
+
+describe("msUntilNextCron", () => {
+  test("returns positive milliseconds", () => {
+    const ms = msUntilNextCron("* * * * *");
+    expect(ms).toBeGreaterThan(0);
+    // Every-minute cron should be <= 60 seconds away
+    expect(ms).toBeLessThanOrEqual(60 * 1000);
+  });
+
+  test("returns correct delay for specific time", () => {
+    const from = new Date("2026-02-07T10:00:00Z");
+    const ms = msUntilNextCron("30 10 * * *", from);
+    // Should be 30 minutes = 1800000ms
+    expect(ms).toBe(30 * 60 * 1000);
+  });
+});
+
+describe("parseDuration", () => {
+  test("parses milliseconds", () => {
+    expect(parseDuration("500ms")).toBe(500);
+  });
+
+  test("parses seconds", () => {
+    expect(parseDuration("30s")).toBe(30_000);
+  });
+
+  test("parses minutes", () => {
+    expect(parseDuration("5m")).toBe(300_000);
+  });
+
+  test("parses hours", () => {
+    expect(parseDuration("2h")).toBe(7_200_000);
+  });
+
+  test("parses days", () => {
+    expect(parseDuration("1d")).toBe(86_400_000);
+  });
+
+  test("parses decimal values", () => {
+    expect(parseDuration("1.5h")).toBe(5_400_000);
+  });
+
+  test("returns null for non-duration strings", () => {
+    expect(parseDuration("0 */2 * * *")).toBeNull();
+    expect(parseDuration("hello")).toBeNull();
+    expect(parseDuration("")).toBeNull();
+  });
+});
+
+describe("resolveSchedule", () => {
+  test("resolves number as interval", () => {
+    const result = resolveSchedule({ wakeup: 60000 });
+    expect(result.type).toBe("interval");
+    expect(result.ms).toBe(60000);
+  });
+
+  test("resolves duration string as interval", () => {
+    const result = resolveSchedule({ wakeup: "5m" });
+    expect(result.type).toBe("interval");
+    expect(result.ms).toBe(300_000);
+  });
+
+  test("resolves cron expression as cron", () => {
+    const result = resolveSchedule({ wakeup: "0 */2 * * *" });
+    expect(result.type).toBe("cron");
+    expect(result.expr).toBe("0 */2 * * *");
+  });
+
+  test("preserves prompt", () => {
+    const result = resolveSchedule({ wakeup: "30s", prompt: "Check tasks" });
+    expect(result.prompt).toBe("Check tasks");
+  });
+
+  test("throws for non-positive number", () => {
+    expect(() => resolveSchedule({ wakeup: 0 })).toThrow("positive");
+    expect(() => resolveSchedule({ wakeup: -1 })).toThrow("positive");
+  });
+});

--- a/packages/agent-worker/test/unit/handler.test.ts
+++ b/packages/agent-worker/test/unit/handler.test.ts
@@ -705,6 +705,36 @@ describe('handleRequest', () => {
       expect(data.prompt).toBe('wake up')
     })
 
+    test('schedule_set rejects invalid cron expression', async () => {
+      const result = await handleRequest(
+        getState(state),
+        {
+          action: 'schedule_set',
+          payload: { wakeup: 'not a cron' },
+        },
+        noopResetTimer,
+        noopShutdown,
+        noopResetTimer,
+      )
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('expected 5 fields')
+    })
+
+    test('schedule_set rejects negative number', async () => {
+      const result = await handleRequest(
+        getState(state),
+        {
+          action: 'schedule_set',
+          payload: { wakeup: -100 },
+        },
+        noopResetTimer,
+        noopShutdown,
+        noopResetTimer,
+      )
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('positive')
+    })
+
     test('schedule_clear removes schedule', async () => {
       state.info.schedule = { wakeup: 60000 }
       const resetAllCalled: boolean[] = []

--- a/skills/agent-worker/SKILL.md
+++ b/skills/agent-worker/SKILL.md
@@ -21,10 +21,10 @@ You're here to create sessions, orchestrate agents, manage tools—all from the 
 
 ```bash
 # Create a session (SDK backend, default)
-agent-worker session new -m anthropic/claude-sonnet-4-5
+agent-worker new -m anthropic/claude-sonnet-4-5
 
 # Create with Claude CLI backend
-agent-worker session new -b claude
+agent-worker new -b claude
 
 # Send a message (async by default)
 agent-worker send "What is 2+2?"
@@ -36,7 +36,7 @@ agent-worker peek
 agent-worker send "What is 3+3?" --wait
 
 # End session
-agent-worker session end
+agent-worker agent end
 ```
 
 That's it. Session persists across commands. State maintained until you end it.
@@ -59,12 +59,12 @@ That's it. Session persists across commands. State maintained until you end it.
 agent-worker backends
 
 # SDK backend with specific model
-agent-worker session new -m openai/gpt-5.2
+agent-worker new -m openai/gpt-5.2
 
 # CLI backends
-agent-worker session new -b claude
-agent-worker session new -b codex
-agent-worker session new -b cursor
+agent-worker new -b claude
+agent-worker new -b codex
+agent-worker new -b cursor
 ```
 
 **Important Notes**:
@@ -80,49 +80,49 @@ agent-worker session new -b cursor
 
 ```bash
 # Basic session
-agent-worker session new
+agent-worker new
 
 # With custom system prompt
-agent-worker session new -s "You are a code reviewer."
+agent-worker new -s "You are a code reviewer."
 
 # From file
-agent-worker session new -f ./prompts/reviewer.txt
+agent-worker new -f ./prompts/reviewer.txt
 
 # Named session (easier reference)
-agent-worker session new -n my-session
+agent-worker new -n my-session
 
 # Custom idle timeout (ms, 0 = no timeout)
-agent-worker session new --idle-timeout 3600000
+agent-worker new --idle-timeout 3600000
 
 # With scheduled wakeup (see Scheduled Wakeup section)
-agent-worker session new --wakeup 5m
-agent-worker session new --wakeup "0 */2 * * *"
+agent-worker new --wakeup 5m
+agent-worker new --wakeup "0 */2 * * *"
 ```
 
 ### Multiple Sessions
 
 ```bash
 # List all
-agent-worker session list
+agent-worker ls
 
 # Switch default
-agent-worker session use my-session
+agent-worker agent use my-session
 
 # Target specific session
 agent-worker send "Hello" --to my-session
 
 # End specific
-agent-worker session end my-session
+agent-worker agent end my-session
 
 # End all
-agent-worker session end --all
+agent-worker agent end --all
 ```
 
 ### Session Info
 
 ```bash
 # Status
-agent-worker session status
+agent-worker agent status
 
 # Statistics (tokens, messages)
 agent-worker stats
@@ -224,15 +224,15 @@ SDK backend supports multiple formats:
 
 ```bash
 # Gateway format (recommended)
-agent-worker session new -m openai/gpt-5.2
-agent-worker session new -m anthropic/claude-sonnet-4-5
+agent-worker new -m openai/gpt-5.2
+agent-worker new -m anthropic/claude-sonnet-4-5
 
 # Provider-only (uses provider's frontier model)
-agent-worker session new -m openai
-agent-worker session new -m anthropic
+agent-worker new -m openai
+agent-worker new -m anthropic
 
 # Direct provider format
-agent-worker session new -m deepseek:deepseek-chat
+agent-worker new -m deepseek:deepseek-chat
 ```
 
 Check available providers:
@@ -248,7 +248,7 @@ agent-worker providers
 
 ```bash
 # Create session with your system prompt
-agent-worker session new -f ./my-prompt.txt -n test
+agent-worker new -f ./my-prompt.txt -n test
 
 # Run test cases (async)
 agent-worker send "Test case 1: ..." --to test
@@ -261,14 +261,14 @@ agent-worker peek --to test
 agent-worker send "Test case 3: ..." --to test --wait
 
 # Clean up
-agent-worker session end test
+agent-worker agent end test
 ```
 
 ### Tool Development
 
 ```bash
 # Start session
-agent-worker session new -n dev
+agent-worker new -n dev
 
 # Add tool with mock
 agent-worker tool add my_api -d "Call my API" -p "endpoint:string"
@@ -286,8 +286,8 @@ agent-worker send "Call my API at /users"
 
 ```bash
 # Same prompt, different backends
-agent-worker session new -m anthropic/claude-sonnet-4-5 -n anthropic
-agent-worker session new -b claude -n claude-cli
+agent-worker new -m anthropic/claude-sonnet-4-5 -n anthropic
+agent-worker new -b claude -n claude-cli
 
 agent-worker send "Explain recursion" --to anthropic
 agent-worker send "Explain recursion" --to claude-cli
@@ -340,13 +340,13 @@ Agents can be configured to wake up periodically. Two modes:
 
 ```bash
 # Wake every 5 minutes of inactivity
-agent-worker session new --wakeup 5m
+agent-worker new --wakeup 5m
 
 # Wake every 2 hours (fixed, cron)
-agent-worker session new --wakeup "0 */2 * * *"
+agent-worker new --wakeup "0 */2 * * *"
 
 # With custom wakeup prompt
-agent-worker session new --wakeup 30s --wakeup-prompt "Check for new tasks"
+agent-worker new --wakeup 30s --wakeup-prompt "Check for new tasks"
 ```
 
 ### Runtime management
@@ -380,11 +380,11 @@ The `--wakeup` value is automatically detected:
 
 | Issue | Solution |
 |-------|----------|
-| "No active session" | Run `agent-worker session new` first |
-| "Session not found" | Check `agent-worker session list` |
+| "No active session" | Run `agent-worker new` first |
+| "Session not found" | Check `agent-worker ls` |
 | "Tool management not supported" | Use SDK backend (`-b sdk` or omit `-b`) |
 | "Provider not loaded" | Check API key with `agent-worker providers` |
-| Session not responding | Check if process alive: `agent-worker session status` |
+| Agent not responding | Check if process alive: `agent-worker agent status` |
 | Message stuck in "(processing...)" | Wait up to 60s (timeout), or check with `--debug` |
 | Send appears to hang | Use `agent-worker send "message" --debug` to see details |
 | Claude backend not working | Use SDK backend instead (Claude CLI has environment limitations) |
@@ -394,11 +394,13 @@ The `--wakeup` value is automatically detected:
 ## Command Reference
 
 ```
-agent-worker session new     Create session
-agent-worker session list    List sessions
-agent-worker session status  Check session
-agent-worker session use     Set default
-agent-worker session end     End session
+agent-worker new             Create agent (shorthand)
+agent-worker ls              List agents (shorthand)
+agent-worker agent new       Create agent
+agent-worker agent list      List agents
+agent-worker agent status    Check agent
+agent-worker agent use       Set default
+agent-worker agent end       End agent
 
 agent-worker send            Send message (async by default)
   --wait                     Wait for response (synchronous mode)


### PR DESCRIPTION
Agents can now be configured to wake up periodically when idle.
Two modes via a unified --wakeup flag:

- Interval (30s, 5m, 60000): idle-based, resets on external activity
- Cron (0 */2 * * *): fixed wall-clock schedule, not reset by activity

Includes runtime management via agent schedule set/get/clear commands,
a minimal zero-dependency cron parser, and duration string parsing.

https://claude.ai/code/session_01R6C5ey4nTL4Kh9xGoJ7BV7