### PR TITLE
fix(ci): tighten GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/agent-workflow.yml
+++ b/.github/workflows/agent-workflow.yml
@@ -96,6 +96,34 @@ jobs:
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
             -f content='eyes'
 
+      # Create placeholder comment for agent-review (shows "reviewing..." while agent works)
+      - name: Create review placeholder
+        if: steps.parse.outputs.command == 'agent-review' && steps.resolve.outputs.file != ''
+        id: placeholder
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+          REPO="${{ github.repository }}"
+
+          # Find existing review comment
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.body | startswith("<!-- agent-review -->")) | .id' 2>/dev/null | head -1 || true)
+
+          if [ -n "$COMMENT_ID" ]; then
+            # Update existing comment with "reviewing" status
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+              -X PATCH -f body='<!-- agent-review -->
+          > ⏳ **Re-reviewing** (new changes detected)...'
+            echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+          else
+            # Create new placeholder
+            COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -f body='<!-- agent-review -->
+          > ⏳ **Reviewing...**' --jq '.id')
+            echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -130,6 +158,110 @@ jobs:
           AFTER_SHA: ${{ steps.pr.outputs.after_sha }}
         run: |
           bun packages/agent-worker/src/cli/index.ts run ${{ steps.resolve.outputs.file }}
+
+      # Post-processing: publish agent-review results from JSON
+      - name: Publish review
+        if: always() && steps.parse.outputs.command == 'agent-review' && steps.resolve.outputs.file != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
+          REPO="${{ github.repository }}"
+          COMMENT_ID="${{ steps.placeholder.outputs.comment_id }}"
+          REVIEW_TYPE="${{ steps.parse.outputs.trigger_type }}"
+          TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M UTC")
+
+          # Check if review result exists and is valid JSON
+          if [ ! -f /tmp/review-result.json ]; then
+            echo "::warning::No review result file found — agent may have failed"
+            # Update placeholder with error
+            if [ -n "$COMMENT_ID" ]; then
+              gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+                -X PATCH -f body="<!-- agent-review -->
+          > ⚠️ **Review failed** — agent did not produce results. Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            fi
+            exit 0
+          fi
+
+          if ! jq empty /tmp/review-result.json 2>/dev/null; then
+            echo "::warning::Invalid JSON in review result"
+            if [ -n "$COMMENT_ID" ]; then
+              gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+                -X PATCH -f body="<!-- agent-review -->
+          > ⚠️ **Review failed** — invalid output. Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            fi
+            exit 0
+          fi
+
+          # Get file stats
+          FILE_STATS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json additions,deletions,changedFiles \
+            --jq '"+\(.additions)/-\(.deletions) in \(.changedFiles) files"' 2>/dev/null || echo "unknown")
+
+          # Extract review data
+          SUMMARY=$(jq -r '.summary // "No summary provided"' /tmp/review-result.json)
+          ISSUE_COUNT=$(jq '[.issues // [] | .[]] | length' /tmp/review-result.json)
+          ERROR_COUNT=$(jq '[.issues // [] | .[] | select(.severity == "error")] | length' /tmp/review-result.json)
+          WARNING_COUNT=$(jq '[.issues // [] | .[] | select(.severity == "warning")] | length' /tmp/review-result.json)
+          SUGGESTION_COUNT=$(jq '[.issues // [] | .[] | select(.severity == "suggestion")] | length' /tmp/review-result.json)
+
+          # Build review comment
+          {
+            echo '<!-- agent-review -->'
+            echo '### 🤖 Automated Code Review'
+            echo ''
+            echo "**${SUMMARY}**"
+            echo ''
+
+            if [ "$ISSUE_COUNT" -gt 0 ]; then
+              echo "#### Issues (${ERROR_COUNT} errors, ${WARNING_COUNT} warnings, ${SUGGESTION_COUNT} suggestions)"
+              echo ''
+
+              # Group by severity
+              for sev in error warning suggestion; do
+                COUNT=$(jq "[.issues // [] | .[] | select(.severity == \"$sev\")] | length" /tmp/review-result.json)
+                if [ "$COUNT" -gt 0 ]; then
+                  case "$sev" in
+                    error) ICON="🔴" ;;
+                    warning) ICON="🟡" ;;
+                    suggestion) ICON="🔵" ;;
+                  esac
+                  jq -r ".issues // [] | .[] | select(.severity == \"$sev\") | \"- ${ICON} **\(.file):\(.line // \"?\")** — \(.message)\"" /tmp/review-result.json
+                fi
+              done
+              echo ''
+            else
+              echo '✅ **No issues found.**'
+              echo ''
+            fi
+
+            HIGHLIGHT_COUNT=$(jq '[.highlights // [] | .[]] | length' /tmp/review-result.json)
+            if [ "$HIGHLIGHT_COUNT" -gt 0 ]; then
+              echo '#### Highlights'
+              jq -r '.highlights // [] | .[] | "- ✨ \(.)"' /tmp/review-result.json
+              echo ''
+            fi
+
+            echo '---'
+            echo '<details>'
+            echo '<summary>📋 Review Details</summary>'
+            echo ''
+            echo "- **Type**: ${REVIEW_TYPE:-initial}"
+            echo "- **Timestamp**: ${TIMESTAMP}"
+            echo "- **Stats**: ${FILE_STATS}"
+            echo ''
+            echo '</details>'
+          } > /tmp/review-comment.md
+
+          # Post or update comment
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
+              -X PATCH -F body=@/tmp/review-comment.md
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-comment.md
+          fi
+
+          echo "✅ Review published (${ISSUE_COUNT} issues)"
 
       - name: Report unknown command
         if: steps.parse.outputs.command != '' && steps.resolve.outputs.file == ''

--- a/.github/workflows/changeset-agent.yml
+++ b/.github/workflows/changeset-agent.yml
@@ -1,39 +1,40 @@
 name: Changeset Agent
 
-# Automatically generates changesets for merged PRs and manages the release PR.
-# Note: During 0.x development, breaking changes use 'minor' version bumps (not 'major')
-# to keep versions in 0.x range (e.g., 0.4.0 -> 0.5.0, not 1.0.0)
-#
 # Flow:
-# 1. Agent analyzes merged PR → writes /tmp/changeset-result.json
-# 2. Action reads JSON, creates changeset file
-# 3. Checks for existing release/next PR
-#    - If none: create fresh branch, run version, create PR
-#    - If exists: rebuild from main with all accumulated changesets, force push
+# 1. Agent analyzes merged PR → /tmp/changeset-result.json
+# 2. If needed: create .changeset/auto-pr-{N}.md, commit to main
+# 3. Create release/next from main, run `bun run version`
+# 4. Force push release/next, create/update release PR
+#
+# Changeset files on main are the single source of truth.
+# `changeset version` on the release branch consumes them;
+# merging the release PR brings the deletions back to main.
+# No extra tracking files needed.
 
 on:
   pull_request:
     types: [closed]
-    branches:
-      - main
+    branches: [main]
+
+# Serialize runs — prevents races on main and release/next
+concurrency:
+  group: changeset-release
+  cancel-in-progress: false
 
 jobs:
   generate-changeset:
-    # Only run if PR was merged (not just closed) and is NOT a release PR
     if: github.event.pull_request.merged == true && !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout main branch
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -54,10 +55,10 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --global user.name "Changeset Bot"
-          git config --global user.email "changeset-bot@users.noreply.github.com"
+          git config user.name "Changeset Bot"
+          git config user.email "changeset-bot@users.noreply.github.com"
 
-      - name: Run changeset analysis
+      - name: Analyze PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,180 +67,79 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -e
-          bun packages/agent-worker/src/cli/index.ts run .workflows/agent-changeset.yaml || {
-            echo "::warning::Changeset analysis failed"
-            exit 1
-          }
+          bun packages/agent-worker/src/cli/index.ts run .workflows/agent-changeset.yaml
 
-      - name: Read analysis result
-        id: analysis
+      - name: Check result
+        id: result
         run: |
-          if [ ! -f /tmp/changeset-result.json ]; then
-            echo "::warning::No changeset result file found"
+          if [ ! -f /tmp/changeset-result.json ] || ! jq empty /tmp/changeset-result.json 2>/dev/null; then
             echo "needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "needed=$(jq -r '.needed // false' /tmp/changeset-result.json)" >> "$GITHUB_OUTPUT"
 
-          if ! jq empty /tmp/changeset-result.json 2>/dev/null; then
-            echo "::error::Invalid JSON in changeset result"
-            exit 1
-          fi
-
-          NEEDED=$(jq -r '.needed // false' /tmp/changeset-result.json)
-          echo "needed=$NEEDED" >> "$GITHUB_OUTPUT"
-
-          if [ "$NEEDED" = "true" ]; then
-            echo "description=$(jq -r '.description // ""' /tmp/changeset-result.json)" >> "$GITHUB_OUTPUT"
-            # Store packages JSON for later use
-            jq -c '.packages // {}' /tmp/changeset-result.json > /tmp/changeset-packages.json
-          else
-            REASON=$(jq -r '.reason // "unknown"' /tmp/changeset-result.json)
-            echo "Changeset not needed: $REASON"
-          fi
-
-      - name: Check for existing release PR
-        if: steps.analysis.outputs.needed == 'true'
-        id: existing
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Check if there's an open PR from release/next
-          EXISTING_PR=$(gh pr list --head release/next --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)
-          echo "pr_number=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
-
-          if [ -n "$EXISTING_PR" ]; then
-            echo "Found existing release PR: #${EXISTING_PR}"
-
-            # Fetch _pending.json from the existing release branch
-            git fetch origin release/next 2>/dev/null || true
-            git show origin/release/next:_pending.json > /tmp/existing-pending.json 2>/dev/null || echo '[]' > /tmp/existing-pending.json
-            echo "Loaded existing pending changesets"
-          else
-            echo "No existing release PR found"
-            echo '[]' > /tmp/existing-pending.json
-          fi
-
-      - name: Build pending changesets
-        if: steps.analysis.outputs.needed == 'true'
+      - name: Commit changeset to main
+        if: steps.result.outputs.needed == 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Add current PR's changeset to pending list
-          # Use jq to merge: append new entry, deduplicate by PR number
-          NEW_ENTRY=$(jq -n \
-            --arg pr "$PR_NUMBER" \
-            --arg title "$PR_TITLE" \
-            --arg desc "$(jq -r '.description // ""' /tmp/changeset-result.json)" \
-            --argjson packages "$(cat /tmp/changeset-packages.json)" \
-            '{pr: ($pr | tonumber), title: $title, description: $desc, packages: $packages}')
+          CHANGESET_ID="auto-pr-${PR_NUMBER}"
+          DESC=$(jq -r '.description // "update"' /tmp/changeset-result.json)
+          {
+            echo "---"
+            jq -r '.packages | to_entries[] | "\"\(.key)\": \(.value)"' /tmp/changeset-result.json
+            echo "---"
+            echo ""
+            echo "$DESC"
+          } > ".changeset/${CHANGESET_ID}.md"
 
-          # Merge: remove any existing entry for this PR, then append
-          jq --argjson new "$NEW_ENTRY" \
-            '[.[] | select(.pr != $new.pr)] + [$new]' \
-            /tmp/existing-pending.json > /tmp/pending.json
+          git add ".changeset/${CHANGESET_ID}.md"
+          git commit -m "chore: add changeset for PR #${PR_NUMBER}"
+          git push origin main
 
-          echo "Pending changesets:"
-          jq '.' /tmp/pending.json
-
-      - name: Create release branch and version
-        if: steps.analysis.outputs.needed == 'true'
+      - name: Version and create release PR
+        if: steps.result.outputs.needed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -e
+          # Collect pending changeset info before version consumes them
+          PENDING=$(ls .changeset/auto-pr-*.md 2>/dev/null || true)
+          if [ -z "$PENDING" ]; then
+            echo "No pending changesets"
+            exit 0
+          fi
 
-          # Always start fresh from main
-          git checkout main
-          git pull origin main
+          PR_BODY="## Pending Changes"
+          for f in $PENDING; do
+            PR_NUM=$(basename "$f" .md | sed 's/auto-pr-//')
+            DESC=$(tail -1 "$f")
+            PR_BODY="${PR_BODY}"$'\n'"- #${PR_NUM}: ${DESC}"
+          done
+          PR_BODY="${PR_BODY}"$'\n\n---\nMerge to publish packages to npm.'
+
+          # Fresh release branch from current main
           git branch -D release/next 2>/dev/null || true
           git checkout -b release/next
 
-          # Create changeset files for ALL pending PRs
-          jq -c '.[]' /tmp/pending.json | while read -r entry; do
-            PR_NUM=$(echo "$entry" | jq -r '.pr')
-            DESC=$(echo "$entry" | jq -r '.description')
-            PACKAGES=$(echo "$entry" | jq -r '.packages')
-
-            CHANGESET_ID="auto-pr-${PR_NUM}"
-
-            # Build changeset frontmatter
-            {
-              echo "---"
-              echo "$PACKAGES" | jq -r 'to_entries[] | "\"\(.key)\": \(.value)"'
-              echo "---"
-              echo ""
-              echo "$DESC"
-            } > ".changeset/${CHANGESET_ID}.md"
-
-            echo "Created .changeset/${CHANGESET_ID}.md"
-          done
-
-          # Save _pending.json to track accumulated changesets
-          cp /tmp/pending.json _pending.json
-
-          # Commit changesets + pending tracker
-          git add .changeset/ _pending.json
-          git commit -m "chore: add changesets for pending PRs"
-
-          # Run version to consume changesets and bump packages
           bun run version
 
-          # Commit version updates (changeset files are consumed/deleted by version)
           git add -A
-          git commit -m "chore: version packages" || echo "No version changes to commit"
+          git commit -m "chore: version packages" || { echo "No version changes"; exit 0; }
+          git push -f -u origin release/next
 
-          # Force push (we always rebuild from main)
-          git push --force-with-lease -u origin release/next
-
-      - name: Create or update release PR
-        if: steps.analysis.outputs.needed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXISTING_PR: ${{ steps.existing.outputs.pr_number }}
-        run: |
-          # Build PR body with all source PRs listed
-          SOURCE_PRS=$(jq -r '.[] | "- #\(.pr): \(.title)"' /tmp/pending.json)
-          PR_COUNT=$(jq '. | length' /tmp/pending.json)
-          PACKAGES_AFFECTED=$(jq -r '[.[].packages | keys[]] | unique | join(", ")' /tmp/pending.json)
-
-          PR_BODY=$(cat <<EOF
-          ## Release
-
-          **Packages**: ${PACKAGES_AFFECTED}
-          **Source PRs** (${PR_COUNT}):
-          ${SOURCE_PRS}
-
-          Merge this PR to publish updated packages to npm.
-
-          ---
-          *Auto-generated by changeset-agent*
-          EOF
-          )
-
-          if [ -n "$EXISTING_PR" ]; then
-            # Update existing PR body (branch was force-pushed, so diff is already updated)
-            gh pr edit "$EXISTING_PR" \
-              --title "chore: release packages" \
-              --body "$PR_BODY"
-            echo "✅ Updated release PR #${EXISTING_PR}"
+          # Create or update PR
+          EXISTING=$(gh pr list --head release/next --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --body "$PR_BODY"
+            echo "Updated release PR #${EXISTING}"
           else
-            # Create new PR
-            gh pr create \
-              --title "chore: release packages" \
-              --body "$PR_BODY" \
-              --base main \
-              --head release/next
-            echo "✅ Created new release PR"
+            gh pr create --title "chore: release packages" --body "$PR_BODY" --base main --head release/next
+            echo "Created release PR"
           fi
 
       - name: Summary
         run: |
-          echo "### Changeset Analysis Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Analyzed PR #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Title: ${{ github.event.pull_request.title }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Author: @${{ github.event.pull_request.user.login }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Changeset needed: ${{ steps.analysis.outputs.needed }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Changeset Analysis" >> $GITHUB_STEP_SUMMARY
+          echo "- PR: #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Changeset needed: ${{ steps.result.outputs.needed }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/changeset-agent.yml
+++ b/.github/workflows/changeset-agent.yml
@@ -1,8 +1,15 @@
 name: Changeset Agent
 
-# Automatically generates changesets for merged PRs
+# Automatically generates changesets for merged PRs and manages the release PR.
 # Note: During 0.x development, breaking changes use 'minor' version bumps (not 'major')
 # to keep versions in 0.x range (e.g., 0.4.0 -> 0.5.0, not 1.0.0)
+#
+# Flow:
+# 1. Agent analyzes merged PR → writes /tmp/changeset-result.json
+# 2. Action reads JSON, creates changeset file
+# 3. Checks for existing release/next PR
+#    - If none: create fresh branch, run version, create PR
+#    - If exists: rebuild from main with all accumulated changesets, force push
 
 on:
   pull_request:
@@ -23,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0  # Need full history to analyze commits
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -50,10 +57,8 @@ jobs:
           git config --global user.name "Changeset Bot"
           git config --global user.email "changeset-bot@users.noreply.github.com"
 
-      - name: Run changeset generation workflow
+      - name: Run changeset analysis
         env:
-          # GH_TOKEN: Used by gh CLI commands in workflow
-          # GITHUB_TOKEN: Required by @changesets/changelog-github plugin for PR info
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
@@ -61,11 +66,174 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -e  # Exit on error
+          set -e
           bun packages/agent-worker/src/cli/index.ts run .workflows/agent-changeset.yaml || {
-            echo "❌ Changeset generation failed"
+            echo "::warning::Changeset analysis failed"
             exit 1
           }
+
+      - name: Read analysis result
+        id: analysis
+        run: |
+          if [ ! -f /tmp/changeset-result.json ]; then
+            echo "::warning::No changeset result file found"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! jq empty /tmp/changeset-result.json 2>/dev/null; then
+            echo "::error::Invalid JSON in changeset result"
+            exit 1
+          fi
+
+          NEEDED=$(jq -r '.needed // false' /tmp/changeset-result.json)
+          echo "needed=$NEEDED" >> "$GITHUB_OUTPUT"
+
+          if [ "$NEEDED" = "true" ]; then
+            echo "description=$(jq -r '.description // ""' /tmp/changeset-result.json)" >> "$GITHUB_OUTPUT"
+            # Store packages JSON for later use
+            jq -c '.packages // {}' /tmp/changeset-result.json > /tmp/changeset-packages.json
+          else
+            REASON=$(jq -r '.reason // "unknown"' /tmp/changeset-result.json)
+            echo "Changeset not needed: $REASON"
+          fi
+
+      - name: Check for existing release PR
+        if: steps.analysis.outputs.needed == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if there's an open PR from release/next
+          EXISTING_PR=$(gh pr list --head release/next --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          echo "pr_number=${EXISTING_PR}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Found existing release PR: #${EXISTING_PR}"
+
+            # Fetch _pending.json from the existing release branch
+            git fetch origin release/next 2>/dev/null || true
+            git show origin/release/next:_pending.json > /tmp/existing-pending.json 2>/dev/null || echo '[]' > /tmp/existing-pending.json
+            echo "Loaded existing pending changesets"
+          else
+            echo "No existing release PR found"
+            echo '[]' > /tmp/existing-pending.json
+          fi
+
+      - name: Build pending changesets
+        if: steps.analysis.outputs.needed == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Add current PR's changeset to pending list
+          # Use jq to merge: append new entry, deduplicate by PR number
+          NEW_ENTRY=$(jq -n \
+            --arg pr "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg desc "$(jq -r '.description // ""' /tmp/changeset-result.json)" \
+            --argjson packages "$(cat /tmp/changeset-packages.json)" \
+            '{pr: ($pr | tonumber), title: $title, description: $desc, packages: $packages}')
+
+          # Merge: remove any existing entry for this PR, then append
+          jq --argjson new "$NEW_ENTRY" \
+            '[.[] | select(.pr != $new.pr)] + [$new]' \
+            /tmp/existing-pending.json > /tmp/pending.json
+
+          echo "Pending changesets:"
+          jq '.' /tmp/pending.json
+
+      - name: Create release branch and version
+        if: steps.analysis.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+
+          # Always start fresh from main
+          git checkout main
+          git pull origin main
+          git branch -D release/next 2>/dev/null || true
+          git checkout -b release/next
+
+          # Create changeset files for ALL pending PRs
+          jq -c '.[]' /tmp/pending.json | while read -r entry; do
+            PR_NUM=$(echo "$entry" | jq -r '.pr')
+            DESC=$(echo "$entry" | jq -r '.description')
+            PACKAGES=$(echo "$entry" | jq -r '.packages')
+
+            CHANGESET_ID="auto-pr-${PR_NUM}"
+
+            # Build changeset frontmatter
+            {
+              echo "---"
+              echo "$PACKAGES" | jq -r 'to_entries[] | "\"\(.key)\": \(.value)"'
+              echo "---"
+              echo ""
+              echo "$DESC"
+            } > ".changeset/${CHANGESET_ID}.md"
+
+            echo "Created .changeset/${CHANGESET_ID}.md"
+          done
+
+          # Save _pending.json to track accumulated changesets
+          cp /tmp/pending.json _pending.json
+
+          # Commit changesets + pending tracker
+          git add .changeset/ _pending.json
+          git commit -m "chore: add changesets for pending PRs"
+
+          # Run version to consume changesets and bump packages
+          bun run version
+
+          # Commit version updates (changeset files are consumed/deleted by version)
+          git add -A
+          git commit -m "chore: version packages" || echo "No version changes to commit"
+
+          # Force push (we always rebuild from main)
+          git push --force-with-lease -u origin release/next
+
+      - name: Create or update release PR
+        if: steps.analysis.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXISTING_PR: ${{ steps.existing.outputs.pr_number }}
+        run: |
+          # Build PR body with all source PRs listed
+          SOURCE_PRS=$(jq -r '.[] | "- #\(.pr): \(.title)"' /tmp/pending.json)
+          PR_COUNT=$(jq '. | length' /tmp/pending.json)
+          PACKAGES_AFFECTED=$(jq -r '[.[].packages | keys[]] | unique | join(", ")' /tmp/pending.json)
+
+          PR_BODY=$(cat <<EOF
+          ## Release
+
+          **Packages**: ${PACKAGES_AFFECTED}
+          **Source PRs** (${PR_COUNT}):
+          ${SOURCE_PRS}
+
+          Merge this PR to publish updated packages to npm.
+
+          ---
+          *Auto-generated by changeset-agent*
+          EOF
+          )
+
+          if [ -n "$EXISTING_PR" ]; then
+            # Update existing PR body (branch was force-pushed, so diff is already updated)
+            gh pr edit "$EXISTING_PR" \
+              --title "chore: release packages" \
+              --body "$PR_BODY"
+            echo "✅ Updated release PR #${EXISTING_PR}"
+          else
+            # Create new PR
+            gh pr create \
+              --title "chore: release packages" \
+              --body "$PR_BODY" \
+              --base main \
+              --head release/next
+            echo "✅ Created new release PR"
+          fi
 
       - name: Summary
         run: |
@@ -74,5 +242,4 @@ jobs:
           echo "Analyzed PR #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
           echo "- Title: ${{ github.event.pull_request.title }}" >> $GITHUB_STEP_SUMMARY
           echo "- Author: @${{ github.event.pull_request.user.login }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Check the logs above to see if a changeset PR was created." >> $GITHUB_STEP_SUMMARY
+          echo "- Changeset needed: ${{ steps.analysis.outputs.needed }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.workflows/agent-changeset.yaml
+++ b/.workflows/agent-changeset.yaml
@@ -2,20 +2,12 @@ agents:
   changeset_analyzer:
     model: deepseek:deepseek-chat
     system_prompt: |
-      You are a changeset analyzer and release manager for a monorepo using changesets.
+      You are a changeset analyzer for a monorepo using changesets.
+      You analyze merged PRs and determine which packages need version bumps.
+      You produce structured JSON output — you do NOT create branches, PRs, or run git commands.
 
-      Your task is to:
-      1. Analyze PR changes to determine which packages are affected
-      2. Determine the appropriate version bump type (patch/minor/major) based on:
-         - Commit messages (conventional commits: fix/feat/BREAKING CHANGE)
-         - PR description and title
-         - Code changes (API changes, breaking changes)
-      3. Generate changeset file
-      4. Run `bun run version` to update package versions and CHANGELOGs
-      5. Create a Version PR with all changes ready for review and merge
-
-      Guidelines:
-      - patch: bug fixes, documentation, internal refactors
+      Version bump guidelines:
+      - patch: bug fixes, documentation updates, internal refactors
       - minor: new features, new exports (backward compatible)
       - major: breaking changes, removed APIs, changed behavior
 
@@ -23,45 +15,23 @@ agents:
       - This project is in 0.x development (pre-1.0)
       - During 0.x: ALWAYS use "minor" for breaking changes (NOT "major")
       - This keeps versions in 0.x range (e.g., 0.4.0 -> 0.5.0, NOT 1.0.0)
-      - Breaking changes in 0.x are expected and acceptable
 
-      - Look for keywords: "BREAKING", "breaking change", "feat:", "fix:", etc.
-      - Multiple packages can be affected by one PR
-      - If no changeset is needed (e.g., docs only, config only), say so explicitly
-
-      Output format:
-      1. Analysis summary (which packages, what type of change)
-      2. Bash commands to create changeset, update versions, and create PR
-
-      Important:
-      - Only generate changeset if code changes affect published packages
-      - Skip if changes are only in .github/, docs/, or config files
-      - Use the standard changeset format
-      - After creating changeset, run `bun run version` to consume it and update versions
-      - Create a PR with version updates ready for review
-      - When this PR is merged, packages will be published automatically
+      Look for keywords: "BREAKING", "breaking change", "feat:", "fix:", etc.
+      Multiple packages can be affected by one PR.
 
 context:
   provider: memory
 
 setup:
-  # Get repository default branch
-  - shell: |
-      gh repo view "$GITHUB_REPOSITORY" --json defaultBranchRef --jq '.defaultBranchRef.name'
-    as: default_branch
-
-  # Get the merged PR number (passed from GitHub Actions)
-  - shell: |
-      if [ -z "$PR_NUMBER" ]; then
-        echo "Error: PR_NUMBER environment variable is required"
-        exit 1
-      fi
-      echo "$PR_NUMBER"
+  - shell: echo "$PR_NUMBER"
     as: pr_number
+
+  - shell: echo "$GITHUB_REPOSITORY"
+    as: repo
 
   # Get PR information
   - shell: |
-      gh pr view "${{ pr_number }}" --repo "$GITHUB_REPOSITORY" \
+      gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
         --json title,body,author,labels,commits \
         --jq '{
           title: .title,
@@ -74,43 +44,33 @@ setup:
 
   # Get changed files
   - shell: |
-      gh pr view "${{ pr_number }}" --repo "$GITHUB_REPOSITORY" \
+      gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
         --json files --jq '.files[].path'
     as: changed_files
 
   # Check for existing changesets in the merged PR
   - shell: |
-      CHANGESETS=$(gh pr view "${{ pr_number }}" --repo "$GITHUB_REPOSITORY" \
-        --json files --jq '.files[] | select(.path | startswith(".changeset/")) | .path')
-
-      if [ -n "$CHANGESETS" ]; then
-        echo "Existing changesets found:"
-        echo "$CHANGESETS"
-        echo "has_changeset=true"
+      CHANGESETS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+        --json files --jq '[.files[] | select(.path | startswith(".changeset/")) | .path] | length')
+      if [ "$CHANGESETS" -gt 0 ]; then
+        echo "true"
       else
-        echo "No changesets found in PR"
-        echo "has_changeset=false"
+        echo "false"
       fi
-    as: existing_changesets
+    as: has_existing_changeset
 
-  # List packages in monorepo (dynamically from workspaces)
+  # List packages in monorepo
   - shell: |
       if [ ! -f "package.json" ]; then
         echo "No package.json found"
         exit 0
       fi
-
-      # Get workspace patterns from package.json
       WORKSPACE_PATTERNS=$(jq -r '.workspaces // [] | if type == "array" then .[] else .packages[]? end' package.json 2>/dev/null)
-
       if [ -z "$WORKSPACE_PATTERNS" ]; then
         echo "No workspaces configured"
         exit 0
       fi
-
-      # Find and list all packages
       echo "$WORKSPACE_PATTERNS" | while read -r pattern; do
-        # Expand glob pattern (e.g., "packages/*" -> packages/agent-worker, etc.)
         for pkg_json in ${pattern}/package.json; do
           if [ -f "$pkg_json" ]; then
             jq -r '.name // empty' "$pkg_json" 2>/dev/null
@@ -120,13 +80,11 @@ setup:
     as: packages
 
 kickoff: |
-  @changeset_analyzer Analyze merged PR #${{ pr_number }} to determine if a changeset should be generated.
+  @changeset_analyzer Analyze merged PR #${{ pr_number }} and determine if a changeset is needed.
 
   ## Context
 
-  **Repository**: $GITHUB_REPOSITORY
-  **PR Number**: ${{ pr_number }}
-  **Default Branch**: ${{ default_branch }}
+  **Has existing changeset in PR**: ${{ has_existing_changeset }}
 
   ## PR Information
   ```json
@@ -138,111 +96,48 @@ kickoff: |
   ${{ changed_files }}
   ```
 
-  ## Existing Changesets
-  ```
-  ${{ existing_changesets }}
-  ```
-
   ## Available Packages
   ```
   ${{ packages }}
   ```
 
-  ## How to Analyze
+  ## Instructions
 
-  **Use Bash tool to view diffs as needed**:
-
-  ```bash
-  # View full PR diff
-  gh pr diff ${{ pr_number }} --repo $GITHUB_REPOSITORY
-
-  # View specific file diff
-  gh pr diff ${{ pr_number }} --repo $GITHUB_REPOSITORY -- path/to/file.ts
-
-  # View commit messages in detail
-  gh pr view ${{ pr_number }} --repo $GITHUB_REPOSITORY --json commits --jq '.commits[].commit.message'
-  ```
-
-  This gives you access to full, untruncated diffs with complete context.
-
-  ## Task
-
-  1. **Check if changeset is needed**:
-     - If `has_changeset=true` in existing changesets, STOP - changeset already exists
-     - If changes only affect non-package code (.github/, docs/, root config), STOP - no changeset needed
-     - Otherwise, proceed to generate changeset
-
-  2. **Analyze the changes**:
-     - Which packages are affected? (check changed_files against packages/)
-     - What type of change? (patch/minor/major)
-     - Evidence: commit messages, PR title/body, code diff
-
-  3. **Generate changeset and update versions** (if needed):
-     - Create a properly formatted changeset file
-     - Run `bun run version` to consume changeset and update package.json/CHANGELOG.md
-     - Create a PR with all version updates
-
-  4. **Execute commands** (if changeset is needed):
+  1. If `has_existing_changeset` is `true`, the PR already included a changeset. Write:
      ```bash
-     # Generate a unique changeset ID
-     CHANGESET_ID="auto-$(date +%Y%m%d-%H%M%S)"
-
-     # Create changeset file with proper format
-     cat > .changeset/${CHANGESET_ID}.md << 'EOF'
-     ---
-     "package-name": patch|minor|major
-     ---
-
-     Brief description of the change (from PR title/commits)
+     cat > /tmp/changeset-result.json << 'EOF'
+     { "needed": false, "reason": "PR already contains a changeset" }
      EOF
-
-     # Create a new branch for version PR
-     git checkout -b release/auto-${{ pr_number }}
-
-     # Commit the changeset
-     git add .changeset/${CHANGESET_ID}.md
-     git commit -m "chore: add changeset for PR #${{ pr_number }}"
-
-     # Run version to update package.json and CHANGELOG.md
-     bun run version
-
-     # Commit version updates (changeset file will be deleted by `bun run version`)
-     git add -A
-     git commit -m "chore: version packages"
-
-     # Push the branch
-     git push -u origin release/auto-${{ pr_number }}
-
-     # Create PR with analysis details
-     gh pr create \
-       --title "chore: release packages (from PR #${{ pr_number }})" \
-       --body "🤖 Auto-generated version bump for merged PR #${{ pr_number }}
-
-     ## Analysis
-     - **Affected packages**: [list the packages]
-     - **Version bump**: [patch/minor/major]
-     - **Reason**: [brief explanation based on commits/PR]
-
-     ## Changes
-     - Updated package.json versions
-     - Updated CHANGELOG.md files
-     - Changeset has been consumed
-
-     ## Next Steps
-     Merge this PR to publish packages to npm.
-
-     ---
-     *Generated by changeset-agent*
-     *Source: #${{ pr_number }}*" \
-       --base ${{ default_branch }}
      ```
 
-  **Important**:
-  - Only proceed if changeset is actually needed (no existing changeset + package code changed)
-  - Use correct package names from the packages list
-  - Provide detailed reasoning in your analysis
-  - Include the PR title/description context in the changeset
-  - Execute all bash commands using the Bash tool
-  - `bun run version` will consume the changeset and delete it
-  - The created PR will be ready to merge for publishing
-  - If any command fails, report the error clearly and stop
+  2. If changes only affect non-package files (.github/, docs/, root config, .memory/), write:
+     ```bash
+     cat > /tmp/changeset-result.json << 'EOF'
+     { "needed": false, "reason": "Changes don't affect any published packages" }
+     EOF
+     ```
+
+  3. Otherwise, analyze the changes. View the diff if needed:
+     ```bash
+     gh pr diff ${{ pr_number }} --repo ${{ repo }}
+     ```
+
+     Then write your analysis:
+     ```bash
+     cat > /tmp/changeset-result.json << 'EOF'
+     {
+       "needed": true,
+       "packages": {
+         "package-name": "patch|minor"
+       },
+       "description": "Brief description of the change for CHANGELOG"
+     }
+     EOF
+     ```
+
+  Rules:
+  - The `packages` field must use exact package names from the "Available Packages" list
+  - The `description` field should be a concise CHANGELOG entry (one line)
+  - Remember: during 0.x, use "minor" for breaking changes (not "major")
+  - The JSON must be valid — the CI will parse it to create the changeset
+  - You ONLY write JSON. The CI handles branch creation, versioning, and PR creation.

--- a/.workflows/agent-review.yaml
+++ b/.workflows/agent-review.yaml
@@ -1,27 +1,22 @@
 agents:
   reviewer:
     model: deepseek:deepseek-chat
-    system_prompt: prompts/reviewer.md
+    system_prompt: |
+      You are a precise code reviewer. You analyze diffs and produce structured JSON output.
+      Focus on: bugs, security issues, logic errors, bad patterns, and notable improvements.
+      Be constructive. Reference specific files and line numbers.
 
 context:
   provider: memory
 
-# Configuration (can be overridden via environment variables)
-config:
-  # Maximum number of commits to show in incremental reviews
-  max_commits_display: ${MAX_COMMITS_DISPLAY:-10}
-  # Review focus: 'incremental' (new changes only) or 'full' (always review all changes)
-  review_mode: ${REVIEW_MODE:-incremental}
-
 setup:
-  # Capture environment variables for use in kickoff
   - shell: echo "$PR_NUMBER"
     as: pr_number
 
   - shell: echo "$GITHUB_REPOSITORY"
     as: repo
 
-  # Write PR info to file instead of loading into context
+  # Write PR metadata to file (avoids context overflow)
   - shell: |
       gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
         --json title,body,baseRefName,headRefName,author,additions,deletions,changedFiles \
@@ -29,145 +24,94 @@ setup:
       echo "/tmp/pr-info.json"
     as: pr_info_file
 
-  # DON'T load pr_diff here - it's too large and causes context overflow
-  # Agent will fetch diffs on-demand using gh pr diff commands
-
   - shell: gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path'
     as: changed_files
 
-  # Find existing review comment or create new one
+  # Write the appropriate diff to file
+  # Incremental: only changes between BEFORE_SHA and AFTER_SHA
+  # Initial: full PR diff
   - shell: |
-      set -e  # Exit on error
-
-      EXISTING=$(gh api repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments \
-        --jq '.[] | select(.body | startswith("<!-- agent-review -->")) | .id' 2>/dev/null | head -1 || true)
-
-      if [ -n "$EXISTING" ]; then
-        echo "$EXISTING"
-      else
-        gh api repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments \
-          -f body='<!-- agent-review -->
-      > ⏳ **Reviewing...**' --jq '.id' 2>&1 || echo ""
-      fi
-    as: comment_id
-
-  # Determine review type based on GitHub trigger (more reliable than content parsing)
-  - shell: |
-      # synchronize = new commits pushed to existing PR = incremental
-      # opened/reopened = initial review
       if [ "$TRIGGER_TYPE" = "synchronize" ] && [ -n "$BEFORE_SHA" ] && [ -n "$AFTER_SHA" ]; then
+        gh api "repos/$GITHUB_REPOSITORY/compare/$BEFORE_SHA...$AFTER_SHA" \
+          -H "Accept: application/vnd.github.v3.diff" > /tmp/review-diff.txt 2>/dev/null || true
         echo "incremental"
       else
+        gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > /tmp/review-diff.txt 2>/dev/null || true
         echo "initial"
       fi
     as: review_type
 
-  # Extract and format commit info for incremental reviews
+  # New commits list (incremental only, for context)
   - shell: |
       if [ "$TRIGGER_TYPE" = "synchronize" ] && [ -n "$BEFORE_SHA" ] && [ -n "$AFTER_SHA" ]; then
-        # Format commits as markdown list
-        gh api repos/$GITHUB_REPOSITORY/compare/$BEFORE_SHA...$AFTER_SHA \
+        gh api "repos/$GITHUB_REPOSITORY/compare/$BEFORE_SHA...$AFTER_SHA" \
           --jq '.commits[] | "- `\(.sha[0:7])` \(.commit.message | split("\n")[0])"' 2>/dev/null || echo ""
       else
         echo ""
       fi
-    as: formatted_commits
-
-  # Calculate file statistics
-  - shell: |
-      # Get all stats in one call
-      gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-        --json additions,deletions,changedFiles \
-        --jq '"+\(.additions)/-\(.deletions) in \(.changedFiles) files"'
-    as: file_stats
-
-  # Get commit range for incremental reviews
-  - shell: |
-      if [ "$TRIGGER_TYPE" = "synchronize" ] && [ -n "$BEFORE_SHA" ] && [ -n "$AFTER_SHA" ]; then
-        echo "$BEFORE_SHA...$AFTER_SHA"
-      else
-        echo ""
-      fi
-    as: commit_range
+    as: new_commits
 
 kickoff: |
-  @reviewer Review code changes for PR #${{ pr_number }} in repository ${{ repo }}.
+  @reviewer Review PR #${{ pr_number }} in ${{ repo }}.
 
-  ## PR Information (on-demand)
-
-  **PR info is available at**: `${{ pr_info_file }}`
-
-  Read it when needed:
-  ```bash
-  cat ${{ pr_info_file }} | jq .
-  ```
+  ## Review Type: ${{ review_type }}
 
   ## Changed Files
   ```
   ${{ changed_files }}
   ```
 
-  ## How to Review
-
-  **Fetch information on-demand using Bash tool**:
-
-  ```bash
-  # Read PR info (title, description, stats)
-  cat ${{ pr_info_file }} | jq .
-
-  # View full PR diff
-  gh pr diff ${{ pr_number }} --repo ${{ repo }}
-
-  # View specific file diff
-  gh pr diff ${{ pr_number }} --repo ${{ repo }} -- path/to/file.ts
+  ## New Commits
+  ```
+  ${{ new_commits }}
   ```
 
-  **Your Task**:
-  1. Use Bash tool to view relevant diffs (you'll see full context, not truncated)
-  2. Analyze code quality, potential bugs, and best practices
-  3. Provide specific feedback with file:line references
-  4. Be constructive and actionable
+  ## Instructions
 
-  Write your analysis to /tmp/review-content.md with:
-  - **Summary**: Brief overview
-  - **Issues Found**: List with severity and locations
-  - **Good Practices**: Positive highlights (if any)
+  1. Read the PR metadata:
+     ```bash
+     cat ${{ pr_info_file }} | jq .
+     ```
 
-  Then run this script to format and post the review:
-  ```bash
-  # Generate timestamp
-  TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M UTC")
+  2. Read the diff to review:
+     ```bash
+     cat /tmp/review-diff.txt
+     ```
 
-  # Get file stats
-  FILE_STATS=$(gh pr view ${{ pr_number }} --repo ${{ repo }} --json additions,deletions,changedFiles --jq '"+\(.additions)/-\(.deletions) in \(.changedFiles) files"')
+  3. If the diff is large, read specific files:
+     ```bash
+     # View a specific file's changes from the diff
+     grep -A 100 "^diff --git a/path/to/file" /tmp/review-diff.txt
+     ```
 
-  # Build review comment (avoid sed with multiline content)
-  {
-    echo '<!-- agent-review -->'
-    echo '🤖 **Automated Code Review**'
-    echo "*Generated by agent-worker for PR #${{ pr_number }} • [View workflow](https://github.com/${{ repo }}/blob/main/.workflows/agent-review.yaml)*"
-    echo ''
-    echo '---'
-    echo ''
-    cat /tmp/review-content.md
-    echo ''
-    echo '---'
-    echo '<details>'
-    echo '<summary>📋 Review Details</summary>'
-    echo ''
-    echo "- **PR**: #${{ pr_number }}"
-    echo "- **Timestamp**: $TIMESTAMP"
-    echo "- **Stats**: $FILE_STATS"
-    echo ''
-    echo '</details>'
-  } > /tmp/review.md
+  4. Write your analysis as JSON to `/tmp/review-result.json`:
+     ```bash
+     cat > /tmp/review-result.json << 'REVIEW_EOF'
+     {
+       "summary": "Brief overview of the changes and their quality",
+       "issues": [
+         {
+           "severity": "error|warning|suggestion",
+           "file": "path/to/file.ts",
+           "line": 42,
+           "message": "Description of the issue"
+         }
+       ],
+       "highlights": [
+         "Positive things worth mentioning"
+       ]
+     }
+     REVIEW_EOF
+     ```
 
-  # Post or update the comment
-  COMMENT_ID="${{ comment_id }}"
-  if [ -n "$COMMENT_ID" ] && [ "$COMMENT_ID" != "" ]; then
-    gh api repos/${{ repo }}/issues/comments/$COMMENT_ID \
-      -X PATCH -F body=@/tmp/review.md
-  else
-    gh pr comment ${{ pr_number }} --repo ${{ repo }} --body-file /tmp/review.md
-  fi
-  ```
+  Severity guide:
+  - **error**: bugs, security issues, broken logic, data loss risks
+  - **warning**: potential problems, bad patterns, missing edge cases
+  - **suggestion**: style improvements, readability, minor optimizations
+
+  Rules:
+  - If no issues found, use `"issues": []`
+  - Always include file paths and line numbers for issues
+  - For incremental reviews, focus ONLY on the new changes in the diff
+  - Be specific and actionable — vague feedback is not helpful
+  - The JSON must be valid — the CI will parse it to post the review


### PR DESCRIPTION
- test.yml: add explicit `permissions: { contents: read }` (was inheriting
  broad defaults despite only needing read access)
- release.yml: remove unnecessary `pull-requests: write` (release job only
  publishes to npm and creates git tags, never interacts with PRs)

https://claude.ai/code/session_01M595AUJTgy8AUz9BrP3cUH