### PR TITLE
fix: configure npm authentication for changeset publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Build packages
         run: bun run build
 
+      - name: Configure npm authentication
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish packages
         run: bun run release
         env:


### PR DESCRIPTION
changeset publish calls npm publish internally, which requires
an .npmrc file to use the NPM_TOKEN for registry authentication.
Without it, npm errors with ENEEDAUTH.

https://claude.ai/code/session_01GsW4AjjwSZL9TQu9wQyFdm