### PR TITLE
feat: support manual trigger for release workflow

### DIFF
--- a/.github/workflows/agent-workflow.yml
+++ b/.github/workflows/agent-workflow.yml
@@ -106,18 +106,18 @@ jobs:
           PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
           REPO="${{ github.repository }}"
 
-          # Find existing review comment
-          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --jq '.[] | select(.body | startswith("<!-- agent-review -->")) | .id' 2>/dev/null | head -1 || true)
+          # Find existing review comment (completed review, not a placeholder)
+          OLD_COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.body | startswith("<!-- agent-review -->")) | .id' 2>/dev/null | tail -1 || true)
 
-          if [ -n "$COMMENT_ID" ]; then
-            # Update existing comment with "reviewing" status
-            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
-              -X PATCH -f body='<!-- agent-review -->
-          > ⏳ **Re-reviewing** (new changes detected)...'
+          if [ -n "$OLD_COMMENT_ID" ]; then
+            # Previous review exists — create a new comment instead of replacing
+            COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -f body='<!-- agent-review -->
+          > ⏳ **Re-reviewing** (new changes detected)...' --jq '.id')
             echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
           else
-            # Create new placeholder
+            # First review — create new placeholder
             COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
               -f body='<!-- agent-review -->
           > ⏳ **Reviewing...**' --jq '.id')

--- a/.github/workflows/agent-workflow.yml
+++ b/.github/workflows/agent-workflow.yml
@@ -164,6 +164,8 @@ jobs:
         if: always() && steps.parse.outputs.command == 'agent-review' && steps.resolve.outputs.file != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEFORE_SHA: ${{ steps.pr.outputs.before_sha }}
+          AFTER_SHA: ${{ steps.pr.outputs.after_sha }}
         run: |
           PR_NUMBER="${{ steps.pr.outputs.pr_number }}"
           REPO="${{ github.repository }}"
@@ -204,6 +206,19 @@ jobs:
           ERROR_COUNT=$(jq '[.issues // [] | .[] | select(.severity == "error")] | length' /tmp/review-result.json)
           WARNING_COUNT=$(jq '[.issues // [] | .[] | select(.severity == "warning")] | length' /tmp/review-result.json)
           SUGGESTION_COUNT=$(jq '[.issues // [] | .[] | select(.severity == "suggestion")] | length' /tmp/review-result.json)
+
+          # Fetch commits included in this review
+          if [ "$REVIEW_TYPE" = "synchronize" ] && [ -n "$BEFORE_SHA" ] && [ -n "$AFTER_SHA" ]; then
+            # Re-review: show only new commits since last review
+            COMMITS=$(gh api "repos/$REPO/compare/${BEFORE_SHA}...${AFTER_SHA}" \
+              --jq '.commits[] | "\(.sha[0:7]) \(.commit.message | split("\n") | .[0])"' 2>/dev/null || true)
+            COMMIT_LABEL="New commits"
+          else
+            # Initial review: show all PR commits
+            COMMITS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate \
+              --jq '.[] | "\(.sha[0:7]) \(.commit.message | split("\n") | .[0])"' 2>/dev/null || true)
+            COMMIT_LABEL="Commits"
+          fi
 
           # Build review comment
           {
@@ -250,6 +265,16 @@ jobs:
             echo "- **Timestamp**: ${TIMESTAMP}"
             echo "- **Stats**: ${FILE_STATS}"
             echo ''
+            if [ -n "$COMMITS" ]; then
+              echo "**${COMMIT_LABEL}:**"
+              echo ''
+              echo "$COMMITS" | while IFS= read -r line; do
+                SHA="${line%% *}"
+                MSG="${line#* }"
+                echo "- \`${SHA}\` ${MSG}"
+              done
+              echo ''
+            fi
             echo '</details>'
           } > /tmp/review-comment.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     name: Release
     # Run on manual dispatch, or when a PR starting with "release/" is merged
-    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
     branches:
@@ -11,8 +12,8 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    # Only run when a PR starting with "release/" is merged
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    # Run on manual dispatch, or when a PR starting with "release/" is merged
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Add workflow_dispatch event to allow manual releases from the GitHub
Actions UI. The job condition is updated so it runs either on manual
dispatch or when a release/ PR is merged, preserving existing behavior.

https://claude.ai/code/session_01C6VAJG8FwJq33XKqnTtMs7