### PR TITLE
fix: increase cursor backend default timeout from 120s to 300s

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:
@@ -7,7 +7,43 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Lint
+        working-directory: packages/agent-worker
+        run: bun run lint
+
+      - name: Format check
+        working-directory: packages/agent-worker
+        run: bun run format:check
+
+      - name: Type check
+        working-directory: packages/agent-worker
+        run: bun run typecheck
+
+  build:
+    name: Build & Test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/packages/agent-worker/docs/backends.md
+++ b/packages/agent-worker/docs/backends.md
@@ -52,7 +52,7 @@ getBackendByType() → Backend
 | Option | Default | Description |
 |--------|---------|-------------|
 | `model` | `sonnet-4.5` | Model identifier |
-| `timeout` | 120s | Command timeout |
+| `timeout` | 300s | Command timeout |
 | `workspace` | - | Contains `.cursor/mcp.json` |
 
 **MCP config**: JSON at `<workspace>/.cursor/mcp.json`
@@ -127,7 +127,7 @@ agents:
 | MCP config location | `.cursor/mcp.json` | `--mcp-config <path>` | `.codex/config.yaml` | N/A |
 | System prompt | (in message) | `--append-system-prompt` | (in message) | `system` param |
 | Session resume | No | `--continue` / `--resume` | `--resume` | N/A |
-| Default timeout | 120s | 300s | 300s | N/A |
+| Default timeout | 300s | 300s | 300s | N/A |
 
 ---
 

--- a/packages/agent-worker/docs/backends.md
+++ b/packages/agent-worker/docs/backends.md
@@ -67,13 +67,13 @@ getBackendByType() → Backend
 
 ### Claude Code (`claude`)
 
-**Command**: `claude -p --dangerously-skip-permissions <message> [--model <model>] [--mcp-config <path>] [--append-system-prompt <text>]`
+**Command**: `claude -p --dangerously-skip-permissions --output-format stream-json <message> [--model <model>] [--mcp-config <path>] [--append-system-prompt <text>]`
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `model` | `sonnet` | Model identifier |
-| `timeout` | 300s | Command timeout |
-| `outputFormat` | `text` | `text` \| `json` \| `stream-json` |
+| `timeout` | 300s | Idle timeout (resets on output) |
+| `outputFormat` | `stream-json` | `text` \| `json` \| `stream-json` |
 | `mcpConfigPath` | - | MCP config file path |
 
 **MCP config**: JSON via `--mcp-config <path>` flag (per-invocation, not project-level)
@@ -83,17 +83,17 @@ getBackendByType() → Backend
 **Gotchas**:
 - MCP via flag, not project-level config (unlike Cursor/Codex)
 - System prompt via `--append-system-prompt` (appends, doesn't replace)
-- JSON response: tries `content` then `result` then raw
+- Timeout is idle-based: resets whenever the process produces output
+- Default stream-json output enables real-time progress (tool calls, cost)
 
 ### Codex (`codex exec`)
 
-**Command**: `codex exec --dangerously-bypass-approvals-and-sandbox <message> [--model <model>] [--json]`
+**Command**: `codex exec --full-auto --json --skip-git-repo-check <message> [--model <model>]`
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `model` | `gpt-5.2-codex` | Model identifier |
-| `timeout` | 300s | Command timeout |
-| `json` | false | Output as NDJSON events |
+| `timeout` | 300s | Idle timeout (resets on output) |
 
 **MCP config**: YAML at `<workspace>/.codex/config.yaml` (key: `mcp_servers`, snake_case)
 
@@ -104,6 +104,9 @@ getBackendByType() → Backend
 - Only backend using YAML for MCP config
 - Config key is `mcp_servers` (snake_case), not `mcpServers`
 - JSON mode returns NDJSON (newline-delimited), not single object
+- Event types differ from Cursor/Claude: `thread.started`, `item.completed`, `turn.completed`
+- Timeout is idle-based: resets whenever the process produces output
+- `--skip-git-repo-check` enables running in workspace dirs without git init
 
 ### Mock Backend
 

--- a/packages/agent-worker/docs/backends.md
+++ b/packages/agent-worker/docs/backends.md
@@ -52,7 +52,7 @@ getBackendByType() → Backend
 | Option | Default | Description |
 |--------|---------|-------------|
 | `model` | `sonnet-4.5` | Model identifier |
-| `timeout` | 300s | Command timeout |
+| `timeout` | 300s | Idle timeout (resets on output) |
 | `workspace` | - | Contains `.cursor/mcp.json` |
 
 **MCP config**: JSON at `<workspace>/.cursor/mcp.json`
@@ -62,6 +62,7 @@ getBackendByType() → Backend
 **Gotchas**:
 - stdin must be `'ignore'` — cursor-agent hangs otherwise
 - No system prompt flag; embedded in message
+- Timeout is idle-based: resets whenever the process produces output
 - Response is plain text only
 
 ### Claude Code (`claude`)
@@ -127,7 +128,7 @@ agents:
 | MCP config location | `.cursor/mcp.json` | `--mcp-config <path>` | `.codex/config.yaml` | N/A |
 | System prompt | (in message) | `--append-system-prompt` | (in message) | `system` param |
 | Session resume | No | `--continue` / `--resume` | `--resume` | N/A |
-| Default timeout | 300s | 300s | 300s | N/A |
+| Default idle timeout | 300s | 300s | 300s | N/A |
 
 ---
 

--- a/packages/agent-worker/src/backends/claude-code.ts
+++ b/packages/agent-worker/src/backends/claude-code.ts
@@ -14,7 +14,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Backend, BackendResponse } from "./types.ts";
 import { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
-import { createStreamParser, parseStreamResult } from "./stream-json.ts";
+import { createStreamParser, claudeAdapter, extractClaudeResult } from "./stream-json.ts";
 
 export interface ClaudeCodeOptions {
   /** Model to use (e.g., 'opus', 'sonnet') */
@@ -85,13 +85,13 @@ export class ClaudeCodeBackend implements Backend {
         timeout: this.options.timeout!,
         onStdout:
           outputFormat === "stream-json" && debugLog
-            ? createStreamParser(debugLog, "Claude")
+            ? createStreamParser(debugLog, "Claude", claudeAdapter)
             : undefined,
       });
 
       // Parse response based on output format
       if (outputFormat === "stream-json") {
-        return parseStreamResult(stdout);
+        return extractClaudeResult(stdout);
       }
 
       if (outputFormat === "json") {

--- a/packages/agent-worker/src/backends/claude-code.ts
+++ b/packages/agent-worker/src/backends/claude-code.ts
@@ -111,9 +111,7 @@ export class ClaudeCodeBackend implements Backend {
       return { content: stdout.trim() };
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
-        throw new Error(
-          `claude timed out after ${timeout}ms of inactivity`,
-        );
+        throw new Error(`claude timed out after ${timeout}ms of inactivity`);
       }
       if (error && typeof error === "object" && "exitCode" in error) {
         const execError = error as { exitCode?: number; stderr?: string; shortMessage?: string };

--- a/packages/agent-worker/src/backends/claude-code.ts
+++ b/packages/agent-worker/src/backends/claude-code.ts
@@ -76,13 +76,14 @@ export class ClaudeCodeBackend implements Backend {
     const cwd = this.options.workspace || this.options.cwd;
     const debugLog = this.options.debugLog;
     const outputFormat = this.options.outputFormat ?? "stream-json";
+    const timeout = this.options.timeout ?? 300000;
 
     try {
       const { stdout } = await execWithIdleTimeout({
         command: "claude",
         args,
         cwd,
-        timeout: this.options.timeout!,
+        timeout,
         onStdout:
           outputFormat === "stream-json" && debugLog
             ? createStreamParser(debugLog, "Claude", claudeAdapter)
@@ -111,7 +112,7 @@ export class ClaudeCodeBackend implements Backend {
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
         throw new Error(
-          `claude timed out after ${this.options.timeout}ms of inactivity`,
+          `claude timed out after ${timeout}ms of inactivity`,
         );
       }
       if (error && typeof error === "object" && "exitCode" in error) {

--- a/packages/agent-worker/src/backends/codex.ts
+++ b/packages/agent-worker/src/backends/codex.ts
@@ -15,7 +15,7 @@ import { join } from "node:path";
 import { stringify as yamlStringify } from "yaml";
 import type { Backend, BackendResponse } from "./types.ts";
 import { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
-import { createStreamParser, parseStreamResult } from "./stream-json.ts";
+import { createStreamParser, codexAdapter, extractCodexResult } from "./stream-json.ts";
 
 export interface CodexOptions {
   /** Model to use (e.g., 'gpt-5.2-codex') */
@@ -77,10 +77,10 @@ export class CodexBackend implements Backend {
         args,
         cwd,
         timeout: this.options.timeout!,
-        onStdout: debugLog ? createStreamParser(debugLog, "Codex") : undefined,
+        onStdout: debugLog ? createStreamParser(debugLog, "Codex", codexAdapter) : undefined,
       });
 
-      return parseStreamResult(stdout);
+      return extractCodexResult(stdout);
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
         throw new Error(

--- a/packages/agent-worker/src/backends/codex.ts
+++ b/packages/agent-worker/src/backends/codex.ts
@@ -84,9 +84,7 @@ export class CodexBackend implements Backend {
       return extractCodexResult(stdout);
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
-        throw new Error(
-          `codex timed out after ${timeout}ms of inactivity`,
-        );
+        throw new Error(`codex timed out after ${timeout}ms of inactivity`);
       }
       if (error && typeof error === "object" && "exitCode" in error) {
         const execError = error as { exitCode?: number; stderr?: string; shortMessage?: string };
@@ -119,13 +117,7 @@ export class CodexBackend implements Backend {
     // --full-auto: auto-approve with workspace-write sandbox
     // --json: JSONL event output for progress parsing
     // --skip-git-repo-check: allow running outside git repos (workspace dirs)
-    const args: string[] = [
-      "exec",
-      "--full-auto",
-      "--json",
-      "--skip-git-repo-check",
-      message,
-    ];
+    const args: string[] = ["exec", "--full-auto", "--json", "--skip-git-repo-check", message];
 
     if (this.options.model) {
       args.push("--model", this.options.model);

--- a/packages/agent-worker/src/backends/codex.ts
+++ b/packages/agent-worker/src/backends/codex.ts
@@ -70,13 +70,14 @@ export class CodexBackend implements Backend {
     // Use workspace as cwd if set
     const cwd = this.options.workspace || this.options.cwd;
     const debugLog = this.options.debugLog;
+    const timeout = this.options.timeout ?? 300000;
 
     try {
       const { stdout } = await execWithIdleTimeout({
         command: "codex",
         args,
         cwd,
-        timeout: this.options.timeout!,
+        timeout,
         onStdout: debugLog ? createStreamParser(debugLog, "Codex", codexAdapter) : undefined,
       });
 
@@ -84,7 +85,7 @@ export class CodexBackend implements Backend {
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
         throw new Error(
-          `codex timed out after ${this.options.timeout}ms of inactivity`,
+          `codex timed out after ${timeout}ms of inactivity`,
         );
       }
       if (error && typeof error === "object" && "exitCode" in error) {

--- a/packages/agent-worker/src/backends/cursor.ts
+++ b/packages/agent-worker/src/backends/cursor.ts
@@ -1,6 +1,6 @@
 /**
  * Cursor CLI backend
- * Uses `cursor-agent -p` for non-interactive mode
+ * Uses `cursor-agent -p` for non-interactive mode with stream-json output
  *
  * MCP Configuration:
  * Cursor uses project-level MCP config via .cursor/mcp.json in the workspace.
@@ -61,6 +61,10 @@ export class CursorBackend implements Backend {
     const { command, args } = this.buildCommand(message);
     // Use workspace as cwd if set, otherwise fall back to cwd option
     const cwd = this.options.workspace || this.options.cwd;
+    const debugLog = this.options.debugLog;
+
+    // Line buffer for stream-json parsing
+    let lineBuf = "";
 
     try {
       const { stdout } = await execWithIdleTimeout({
@@ -68,9 +72,30 @@ export class CursorBackend implements Backend {
         args,
         cwd,
         timeout: this.options.timeout!,
+        onStdout: debugLog
+          ? (chunk) => {
+              // Parse stream-json lines for progress reporting
+              lineBuf += chunk;
+              const lines = lineBuf.split("\n");
+              // Keep incomplete last line in buffer
+              lineBuf = lines.pop() ?? "";
+
+              for (const line of lines) {
+                if (!line.trim()) continue;
+                try {
+                  const event = JSON.parse(line);
+                  const progress = formatCursorEvent(event);
+                  if (progress) debugLog(progress);
+                } catch {
+                  // Not JSON — ignore
+                }
+              }
+            }
+          : undefined,
       });
 
-      return { content: stdout.trim() };
+      // Parse stream-json result: extract final result from last JSON line
+      return parseCursorStreamResult(stdout);
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
         throw new Error(
@@ -114,7 +139,14 @@ export class CursorBackend implements Backend {
     // Use 'cursor-agent -p' command
     // --force: auto-approve all operations (required for non-interactive)
     // --approve-mcps: auto-approve MCP servers (required for workflow MCP tools)
-    const args: string[] = ["-p", "--force", "--approve-mcps", message];
+    // --output-format=stream-json: structured output for progress parsing
+    const args: string[] = [
+      "-p",
+      "--force",
+      "--approve-mcps",
+      "--output-format=stream-json",
+      message,
+    ];
 
     if (this.options.model) {
       args.push("--model", this.options.model);
@@ -122,4 +154,96 @@ export class CursorBackend implements Backend {
 
     return { command: "cursor-agent", args };
   }
+}
+
+// ==================== Stream-JSON Parsing ====================
+
+/**
+ * Format a cursor stream-json event into a human-readable progress message.
+ * Returns null for events that don't need to be shown.
+ */
+function formatCursorEvent(event: Record<string, unknown>): string | null {
+  const type = event.type as string;
+
+  if (type === "system" && event.subtype === "init") {
+    const model = (event.model as string) || "unknown";
+    return `Cursor initialized (model: ${model})`;
+  }
+
+  if (type === "assistant") {
+    const message = event.message as { content?: Array<Record<string, unknown>> } | undefined;
+    if (!message?.content) return null;
+
+    // Report tool calls
+    const toolCalls = message.content.filter((c) => c.type === "tool_use");
+    if (toolCalls.length > 0) {
+      return toolCalls
+        .map((tc) => `CALL ${tc.name}(${formatToolArgs(tc.input)})`)
+        .join("\n");
+    }
+
+    return null; // Skip plain text assistant messages (will be in final result)
+  }
+
+  if (type === "result") {
+    const duration = event.duration_ms as number | undefined;
+    if (duration) {
+      return `Cursor completed (${(duration / 1000).toFixed(1)}s)`;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Format tool call arguments for logging (truncated)
+ */
+function formatToolArgs(input: unknown): string {
+  if (!input || typeof input !== "object") return "";
+  try {
+    const str = JSON.stringify(input);
+    return str.length > 100 ? str.slice(0, 100) + "..." : str;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Parse cursor stream-json output to extract the final result.
+ * Falls back to raw stdout if parsing fails.
+ */
+function parseCursorStreamResult(stdout: string): BackendResponse {
+  const lines = stdout.trim().split("\n");
+
+  // Find the result event (last line with type=result)
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const event = JSON.parse(lines[i]!);
+      if (event.type === "result" && event.result) {
+        return { content: event.result };
+      }
+    } catch {
+      // Not JSON — skip
+    }
+  }
+
+  // Fallback: find last assistant message
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const event = JSON.parse(lines[i]!);
+      if (event.type === "assistant" && event.message?.content) {
+        const textParts = event.message.content
+          .filter((c: Record<string, unknown>) => c.type === "text")
+          .map((c: Record<string, unknown>) => c.text);
+        if (textParts.length > 0) {
+          return { content: textParts.join("\n") };
+        }
+      }
+    } catch {
+      // Not JSON — skip
+    }
+  }
+
+  // Final fallback: return raw stdout
+  return { content: stdout.trim() };
 }

--- a/packages/agent-worker/src/backends/cursor.ts
+++ b/packages/agent-worker/src/backends/cursor.ts
@@ -14,7 +14,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Backend, BackendResponse } from "./types.ts";
 import { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
-import { createStreamParser, parseStreamResult } from "./stream-json.ts";
+import { createStreamParser, claudeAdapter, extractClaudeResult } from "./stream-json.ts";
 
 export interface CursorOptions {
   /** Model to use */
@@ -70,10 +70,10 @@ export class CursorBackend implements Backend {
         args,
         cwd,
         timeout: this.options.timeout!,
-        onStdout: debugLog ? createStreamParser(debugLog, "Cursor") : undefined,
+        onStdout: debugLog ? createStreamParser(debugLog, "Cursor", claudeAdapter) : undefined,
       });
 
-      return parseStreamResult(stdout);
+      return extractClaudeResult(stdout);
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
         throw new Error(

--- a/packages/agent-worker/src/backends/cursor.ts
+++ b/packages/agent-worker/src/backends/cursor.ts
@@ -33,7 +33,7 @@ export class CursorBackend implements Backend {
 
   constructor(options: CursorOptions = {}) {
     this.options = {
-      timeout: 120000, // 2 minute default
+      timeout: 300000, // 5 minute default (matches claude/codex)
       ...options,
     };
   }

--- a/packages/agent-worker/src/backends/cursor.ts
+++ b/packages/agent-worker/src/backends/cursor.ts
@@ -14,6 +14,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Backend, BackendResponse } from "./types.ts";
 import { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
+import { createStreamParser, parseStreamResult } from "./stream-json.ts";
 
 export interface CursorOptions {
   /** Model to use */
@@ -63,39 +64,16 @@ export class CursorBackend implements Backend {
     const cwd = this.options.workspace || this.options.cwd;
     const debugLog = this.options.debugLog;
 
-    // Line buffer for stream-json parsing
-    let lineBuf = "";
-
     try {
       const { stdout } = await execWithIdleTimeout({
         command,
         args,
         cwd,
         timeout: this.options.timeout!,
-        onStdout: debugLog
-          ? (chunk) => {
-              // Parse stream-json lines for progress reporting
-              lineBuf += chunk;
-              const lines = lineBuf.split("\n");
-              // Keep incomplete last line in buffer
-              lineBuf = lines.pop() ?? "";
-
-              for (const line of lines) {
-                if (!line.trim()) continue;
-                try {
-                  const event = JSON.parse(line);
-                  const progress = formatCursorEvent(event);
-                  if (progress) debugLog(progress);
-                } catch {
-                  // Not JSON — ignore
-                }
-              }
-            }
-          : undefined,
+        onStdout: debugLog ? createStreamParser(debugLog, "Cursor") : undefined,
       });
 
-      // Parse stream-json result: extract final result from last JSON line
-      return parseCursorStreamResult(stdout);
+      return parseStreamResult(stdout);
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
         throw new Error(
@@ -154,96 +132,4 @@ export class CursorBackend implements Backend {
 
     return { command: "cursor-agent", args };
   }
-}
-
-// ==================== Stream-JSON Parsing ====================
-
-/**
- * Format a cursor stream-json event into a human-readable progress message.
- * Returns null for events that don't need to be shown.
- */
-function formatCursorEvent(event: Record<string, unknown>): string | null {
-  const type = event.type as string;
-
-  if (type === "system" && event.subtype === "init") {
-    const model = (event.model as string) || "unknown";
-    return `Cursor initialized (model: ${model})`;
-  }
-
-  if (type === "assistant") {
-    const message = event.message as { content?: Array<Record<string, unknown>> } | undefined;
-    if (!message?.content) return null;
-
-    // Report tool calls
-    const toolCalls = message.content.filter((c) => c.type === "tool_use");
-    if (toolCalls.length > 0) {
-      return toolCalls
-        .map((tc) => `CALL ${tc.name}(${formatToolArgs(tc.input)})`)
-        .join("\n");
-    }
-
-    return null; // Skip plain text assistant messages (will be in final result)
-  }
-
-  if (type === "result") {
-    const duration = event.duration_ms as number | undefined;
-    if (duration) {
-      return `Cursor completed (${(duration / 1000).toFixed(1)}s)`;
-    }
-  }
-
-  return null;
-}
-
-/**
- * Format tool call arguments for logging (truncated)
- */
-function formatToolArgs(input: unknown): string {
-  if (!input || typeof input !== "object") return "";
-  try {
-    const str = JSON.stringify(input);
-    return str.length > 100 ? str.slice(0, 100) + "..." : str;
-  } catch {
-    return "";
-  }
-}
-
-/**
- * Parse cursor stream-json output to extract the final result.
- * Falls back to raw stdout if parsing fails.
- */
-function parseCursorStreamResult(stdout: string): BackendResponse {
-  const lines = stdout.trim().split("\n");
-
-  // Find the result event (last line with type=result)
-  for (let i = lines.length - 1; i >= 0; i--) {
-    try {
-      const event = JSON.parse(lines[i]!);
-      if (event.type === "result" && event.result) {
-        return { content: event.result };
-      }
-    } catch {
-      // Not JSON — skip
-    }
-  }
-
-  // Fallback: find last assistant message
-  for (let i = lines.length - 1; i >= 0; i--) {
-    try {
-      const event = JSON.parse(lines[i]!);
-      if (event.type === "assistant" && event.message?.content) {
-        const textParts = event.message.content
-          .filter((c: Record<string, unknown>) => c.type === "text")
-          .map((c: Record<string, unknown>) => c.text);
-        if (textParts.length > 0) {
-          return { content: textParts.join("\n") };
-        }
-      }
-    } catch {
-      // Not JSON — skip
-    }
-  }
-
-  // Final fallback: return raw stdout
-  return { content: stdout.trim() };
 }

--- a/packages/agent-worker/src/backends/cursor.ts
+++ b/packages/agent-worker/src/backends/cursor.ts
@@ -80,9 +80,7 @@ export class CursorBackend implements Backend {
       return extractClaudeResult(stdout);
     } catch (error) {
       if (error instanceof IdleTimeoutError) {
-        throw new Error(
-          `cursor agent timed out after ${timeout}ms of inactivity`,
-        );
+        throw new Error(`cursor agent timed out after ${timeout}ms of inactivity`);
       }
       if (error && typeof error === "object" && "exitCode" in error) {
         const execError = error as { exitCode?: number; stderr?: string; shortMessage?: string };

--- a/packages/agent-worker/src/backends/idle-timeout.ts
+++ b/packages/agent-worker/src/backends/idle-timeout.ts
@@ -42,7 +42,7 @@ export async function execWithIdleTimeout(options: IdleTimeoutOptions): Promise<
   const timeout = Math.max(options.timeout, MIN_TIMEOUT_MS);
 
   let idleTimedOut = false;
-  let timer: ReturnType<typeof setTimeout>;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   let stdout = "";
   let stderr = "";
 

--- a/packages/agent-worker/src/backends/idle-timeout.ts
+++ b/packages/agent-worker/src/backends/idle-timeout.ts
@@ -34,8 +34,12 @@ export interface IdleTimeoutResult {
  * The timeout resets every time the process writes to stdout or stderr.
  * If the process goes silent for longer than `timeout` ms, it's killed.
  */
+/** Minimum idle timeout to prevent accidental instant kills */
+const MIN_TIMEOUT_MS = 1000;
+
 export async function execWithIdleTimeout(options: IdleTimeoutOptions): Promise<IdleTimeoutResult> {
-  const { command, args, cwd, timeout, onStdout } = options;
+  const { command, args, cwd, onStdout } = options;
+  const timeout = Math.max(options.timeout, MIN_TIMEOUT_MS);
 
   let idleTimedOut = false;
   let timer: ReturnType<typeof setTimeout>;

--- a/packages/agent-worker/src/backends/idle-timeout.ts
+++ b/packages/agent-worker/src/backends/idle-timeout.ts
@@ -1,0 +1,106 @@
+/**
+ * Idle timeout for CLI subprocess execution
+ *
+ * Unlike a hard timeout (kill after N ms total), an idle timeout only fires
+ * when the process produces no stdout/stderr output for the configured duration.
+ * This allows long-running agent tasks to continue as long as they're actively
+ * producing output (tool calls, analysis, etc.).
+ */
+
+import { execa } from "execa";
+import type { ResultPromise } from "execa";
+
+export interface IdleTimeoutOptions {
+  /** Command to run */
+  command: string;
+  /** Command arguments */
+  args: string[];
+  /** Working directory */
+  cwd?: string;
+  /** Idle timeout in ms — kill process if no output for this duration */
+  timeout: number;
+}
+
+export interface IdleTimeoutResult {
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Execute a command with idle timeout.
+ *
+ * The timeout resets every time the process writes to stdout or stderr.
+ * If the process goes silent for longer than `timeout` ms, it's killed.
+ */
+export async function execWithIdleTimeout(options: IdleTimeoutOptions): Promise<IdleTimeoutResult> {
+  const { command, args, cwd, timeout } = options;
+
+  let idleTimedOut = false;
+  let timer: ReturnType<typeof setTimeout>;
+  let stdout = "";
+  let stderr = "";
+
+  // IMPORTANT: stdin must be 'ignore' to prevent CLI agents from hanging
+  // See: https://forum.cursor.com/t/node-js-spawn-with-cursor-agent-hangs-and-exits-with-code-143-after-timeout/133709
+  const subprocess: ResultPromise = execa(command, args, {
+    cwd,
+    stdin: "ignore",
+    // No timeout — we manage it via idle detection
+    // Use buffer: false so we get streaming data events
+    buffer: false,
+  });
+
+  const resetTimer = () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      idleTimedOut = true;
+      subprocess.kill();
+    }, timeout);
+  };
+
+  // Collect output and reset timer on each chunk
+  subprocess.stdout?.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString();
+    resetTimer();
+  });
+
+  subprocess.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+    resetTimer();
+  });
+
+  // Start initial timer
+  resetTimer();
+
+  try {
+    await subprocess;
+    clearTimeout(timer);
+    return { stdout: stdout.trimEnd(), stderr: stderr.trimEnd() };
+  } catch (error) {
+    clearTimeout(timer);
+
+    if (idleTimedOut) {
+      throw new IdleTimeoutError(timeout, stdout, stderr);
+    }
+
+    // Re-throw original error
+    throw error;
+  }
+}
+
+/**
+ * Error thrown when a process is killed due to idle timeout
+ */
+export class IdleTimeoutError extends Error {
+  readonly timeout: number;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(timeout: number, stdout: string, stderr: string) {
+    super(`Process idle timed out after ${timeout}ms of inactivity`);
+    this.name = "IdleTimeoutError";
+    this.timeout = timeout;
+    this.stdout = stdout;
+    this.stderr = stderr;
+  }
+}

--- a/packages/agent-worker/src/backends/index.ts
+++ b/packages/agent-worker/src/backends/index.ts
@@ -9,6 +9,7 @@ export { CursorBackend, type CursorOptions } from "./cursor.ts";
 export { SdkBackend, type SdkBackendOptions } from "./sdk.ts";
 export { MockAIBackend, createMockBackend } from "./mock.ts";
 export { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
+export { formatStreamEvent, createStreamParser, parseStreamResult } from "./stream-json.ts";
 
 import type { Backend, BackendType } from "./types.ts";
 import { getModelForBackend } from "./types.ts";

--- a/packages/agent-worker/src/backends/index.ts
+++ b/packages/agent-worker/src/backends/index.ts
@@ -9,7 +9,16 @@ export { CursorBackend, type CursorOptions } from "./cursor.ts";
 export { SdkBackend, type SdkBackendOptions } from "./sdk.ts";
 export { MockAIBackend, createMockBackend } from "./mock.ts";
 export { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
-export { formatStreamEvent, createStreamParser, parseStreamResult } from "./stream-json.ts";
+export {
+  type StreamEvent,
+  type EventAdapter,
+  formatEvent,
+  claudeAdapter,
+  codexAdapter,
+  extractClaudeResult,
+  extractCodexResult,
+  createStreamParser,
+} from "./stream-json.ts";
 
 import type { Backend, BackendType } from "./types.ts";
 import { getModelForBackend } from "./types.ts";

--- a/packages/agent-worker/src/backends/index.ts
+++ b/packages/agent-worker/src/backends/index.ts
@@ -8,6 +8,7 @@ export { CodexBackend, type CodexOptions } from "./codex.ts";
 export { CursorBackend, type CursorOptions } from "./cursor.ts";
 export { SdkBackend, type SdkBackendOptions } from "./sdk.ts";
 export { MockAIBackend, createMockBackend } from "./mock.ts";
+export { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
 
 import type { Backend, BackendType } from "./types.ts";
 import { getModelForBackend } from "./types.ts";

--- a/packages/agent-worker/src/backends/stream-json.ts
+++ b/packages/agent-worker/src/backends/stream-json.ts
@@ -45,10 +45,7 @@ export type EventAdapter = (raw: Record<string, unknown>) => StreamEvent | null;
  * backend-specific raw JSON. Format-specific conversion is handled
  * by the EventAdapter.
  */
-export function formatEvent(
-  event: StreamEvent,
-  backendName: string,
-): string | null {
+export function formatEvent(event: StreamEvent, backendName: string): string | null {
   switch (event.kind) {
     case "init": {
       const details: string[] = [];
@@ -59,10 +56,7 @@ export function formatEvent(
 
     case "tool_call": {
       // CALL prefix causes the runner to promote this to always-visible
-      const truncated =
-        event.args.length > 100
-          ? event.args.slice(0, 100) + "..."
-          : event.args;
+      const truncated = event.args.length > 100 ? event.args.slice(0, 100) + "..." : event.args;
       return `CALL ${event.name}(${truncated})`;
     }
 
@@ -100,9 +94,7 @@ export const claudeAdapter: EventAdapter = (raw) => {
   }
 
   if (type === "assistant") {
-    const message = raw.message as
-      | { content?: Array<Record<string, unknown>> }
-      | undefined;
+    const message = raw.message as { content?: Array<Record<string, unknown>> } | undefined;
     if (!message?.content) return null;
 
     // Extract tool calls
@@ -217,9 +209,7 @@ export const codexAdapter: EventAdapter = (raw) => {
   }
 
   if (type === "turn.completed") {
-    const usage = raw.usage as
-      | { input_tokens?: number; output_tokens?: number }
-      | undefined;
+    const usage = raw.usage as { input_tokens?: number; output_tokens?: number } | undefined;
     return {
       kind: "completed",
       usage: usage

--- a/packages/agent-worker/src/backends/stream-json.ts
+++ b/packages/agent-worker/src/backends/stream-json.ts
@@ -1,0 +1,156 @@
+/**
+ * Stream-JSON event parsing for CLI backends
+ *
+ * Both cursor-agent and claude CLI support --output-format=stream-json,
+ * which outputs newline-delimited JSON events. This module provides shared
+ * parsing for progress reporting and result extraction.
+ *
+ * Event types:
+ *   system/init  → agent initialized with model info
+ *   assistant    → model response (may include tool_use content)
+ *   result       → final result with duration and cost
+ */
+
+import type { BackendResponse } from "./types.ts";
+
+// ==================== Progress Formatting ====================
+
+/**
+ * Format a stream-json event into a human-readable progress message.
+ * Returns null for events that don't need to be shown.
+ *
+ * @param event - Parsed JSON event object
+ * @param backendName - Backend name for display (e.g., "Cursor", "Claude")
+ */
+export function formatStreamEvent(
+  event: Record<string, unknown>,
+  backendName: string,
+): string | null {
+  const type = event.type as string;
+
+  if (type === "system" && event.subtype === "init") {
+    const model = (event.model as string) || "unknown";
+    return `${backendName} initialized (model: ${model})`;
+  }
+
+  if (type === "assistant") {
+    const message = event.message as { content?: Array<Record<string, unknown>> } | undefined;
+    if (!message?.content) return null;
+
+    // Report tool calls — prefixed with CALL so the runner promotes them to always-visible
+    const toolCalls = message.content.filter((c) => c.type === "tool_use");
+    if (toolCalls.length > 0) {
+      return toolCalls
+        .map((tc) => `CALL ${tc.name}(${formatToolArgs(tc.input)})`)
+        .join("\n");
+    }
+
+    return null; // Skip plain text assistant messages (will be in final result)
+  }
+
+  if (type === "result") {
+    const duration = event.duration_ms as number | undefined;
+    const cost = event.total_cost_usd as number | undefined;
+    const parts = [backendName, "completed"];
+    const details: string[] = [];
+    if (duration) details.push(`${(duration / 1000).toFixed(1)}s`);
+    if (cost) details.push(`$${cost.toFixed(4)}`);
+    if (details.length > 0) parts.push(`(${details.join(", ")})`);
+    return parts.join(" ");
+  }
+
+  return null;
+}
+
+/**
+ * Format tool call arguments for logging (truncated)
+ */
+function formatToolArgs(input: unknown): string {
+  if (!input || typeof input !== "object") return "";
+  try {
+    const str = JSON.stringify(input);
+    return str.length > 100 ? str.slice(0, 100) + "..." : str;
+  } catch {
+    return "";
+  }
+}
+
+// ==================== Stream Line Parser ====================
+
+/**
+ * Create a line-buffered stream-json parser.
+ *
+ * Accumulates stdout chunks and emits parsed progress messages
+ * via the debugLog callback. Handles partial lines across chunks.
+ */
+export function createStreamParser(
+  debugLog: (message: string) => void,
+  backendName: string,
+): (chunk: string) => void {
+  let lineBuf = "";
+
+  return (chunk: string) => {
+    lineBuf += chunk;
+    const lines = lineBuf.split("\n");
+    // Keep incomplete last line in buffer
+    lineBuf = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        const progress = formatStreamEvent(event, backendName);
+        if (progress) debugLog(progress);
+      } catch {
+        // Not JSON — ignore
+      }
+    }
+  };
+}
+
+// ==================== Result Extraction ====================
+
+/**
+ * Parse stream-json output to extract the final result.
+ * Falls back to raw stdout if parsing fails.
+ *
+ * Searches for:
+ * 1. A result event with type=result and a result field
+ * 2. The last assistant message with text content
+ * 3. Raw stdout as final fallback
+ */
+export function parseStreamResult(stdout: string): BackendResponse {
+  const lines = stdout.trim().split("\n");
+
+  // Find the result event (last line with type=result)
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const event = JSON.parse(lines[i]!);
+      if (event.type === "result" && event.result) {
+        return { content: event.result };
+      }
+    } catch {
+      // Not JSON — skip
+    }
+  }
+
+  // Fallback: find last assistant message
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const event = JSON.parse(lines[i]!);
+      if (event.type === "assistant" && event.message?.content) {
+        const textParts = event.message.content
+          .filter((c: Record<string, unknown>) => c.type === "text")
+          .map((c: Record<string, unknown>) => c.text);
+        if (textParts.length > 0) {
+          return { content: textParts.join("\n") };
+        }
+      }
+    } catch {
+      // Not JSON — skip
+    }
+  }
+
+  // Final fallback: return raw stdout
+  return { content: stdout.trim() };
+}

--- a/packages/agent-worker/src/backends/stream-json.ts
+++ b/packages/agent-worker/src/backends/stream-json.ts
@@ -1,166 +1,150 @@
 /**
  * Stream-JSON event parsing for CLI backends
  *
- * Cursor/Claude use --output-format=stream-json, Codex uses --json.
- * All output newline-delimited JSON events but with different schemas.
+ * Each CLI backend outputs a different JSON event format:
+ * - Cursor/Claude: --output-format=stream-json (system/init, assistant, result)
+ * - Codex: --json (thread.started, item.completed, turn.completed)
  *
- * Cursor/Claude events:
- *   system/init  → agent initialized with model info
- *   assistant    → model response (may include tool_use content)
- *   result       → final result with duration and cost
- *
- * Codex events:
- *   thread.started  → session initialized
- *   turn.started    → new turn begins
- *   item.completed  → agent_message (text) or function_call (tool)
- *   turn.completed  → turn done with usage stats
+ * Rather than forcing a shared parser, we define a standard internal
+ * StreamEvent type and provide per-format adapters to convert native
+ * events into it. Each backend explicitly chooses its adapter.
  */
 
 import type { BackendResponse } from "./types.ts";
 
-// ==================== Progress Formatting ====================
+// ==================== Standard Event Types ====================
 
 /**
- * Format a stream-json event into a human-readable progress message.
- * Returns null for events that don't need to be shown.
- *
- * @param event - Parsed JSON event object
- * @param backendName - Backend name for display (e.g., "Cursor", "Claude")
+ * Standard internal event representation.
+ * Each backend adapter converts native JSON events to this format.
  */
-export function formatStreamEvent(
-  event: Record<string, unknown>,
+export type StreamEvent =
+  | { kind: "init"; model?: string; sessionId?: string }
+  | { kind: "tool_call"; name: string; args: string }
+  | {
+      kind: "completed";
+      durationMs?: number;
+      costUsd?: number;
+      usage?: { input: number; output: number };
+    };
+
+/**
+ * Converts a raw JSON event object to a standard StreamEvent.
+ * Returns null for events that don't map to a standard event
+ * (e.g., plain text messages — those are extracted by result extractors).
+ */
+export type EventAdapter = (raw: Record<string, unknown>) => StreamEvent | null;
+
+// ==================== Standard Display Formatting ====================
+
+/**
+ * Format a standard StreamEvent into a human-readable progress message.
+ * Returns null if the event doesn't need display.
+ *
+ * This function only knows about StreamEvent — it never touches
+ * backend-specific raw JSON. Format-specific conversion is handled
+ * by the EventAdapter.
+ */
+export function formatEvent(
+  event: StreamEvent,
   backendName: string,
 ): string | null {
-  const type = event.type as string;
+  switch (event.kind) {
+    case "init": {
+      const details: string[] = [];
+      if (event.model) details.push(`model: ${event.model}`);
+      if (event.sessionId) details.push(`session: ${event.sessionId}`);
+      return `${backendName} initialized${details.length > 0 ? ` (${details.join(", ")})` : ""}`;
+    }
 
-  if (type === "system" && event.subtype === "init") {
-    const model = (event.model as string) || "unknown";
-    return `${backendName} initialized (model: ${model})`;
+    case "tool_call": {
+      // CALL prefix causes the runner to promote this to always-visible
+      const truncated =
+        event.args.length > 100
+          ? event.args.slice(0, 100) + "..."
+          : event.args;
+      return `CALL ${event.name}(${truncated})`;
+    }
+
+    case "completed": {
+      const parts = [backendName, "completed"];
+      const details: string[] = [];
+      if (event.durationMs) details.push(`${(event.durationMs / 1000).toFixed(1)}s`);
+      if (event.costUsd) details.push(`$${event.costUsd.toFixed(4)}`);
+      if (event.usage) details.push(`${event.usage.input} in, ${event.usage.output} out`);
+      if (details.length > 0) parts.push(`(${details.join(", ")})`);
+      return parts.join(" ");
+    }
+  }
+}
+
+// ==================== Claude/Cursor Adapter ====================
+
+/**
+ * Adapter for Claude/Cursor stream-json format.
+ *
+ * Events:
+ *   { type: "system", subtype: "init", model: "..." }
+ *   { type: "assistant", message: { content: [{ type: "tool_use", name, input }] } }
+ *   { type: "result", duration_ms: N, total_cost_usd: N }
+ */
+export const claudeAdapter: EventAdapter = (raw) => {
+  const type = raw.type as string;
+
+  if (type === "system" && raw.subtype === "init") {
+    return {
+      kind: "init",
+      model: (raw.model as string) || undefined,
+      sessionId: raw.session_id as string | undefined,
+    };
   }
 
   if (type === "assistant") {
-    const message = event.message as { content?: Array<Record<string, unknown>> } | undefined;
+    const message = raw.message as
+      | { content?: Array<Record<string, unknown>> }
+      | undefined;
     if (!message?.content) return null;
 
-    // Report tool calls — prefixed with CALL so the runner promotes them to always-visible
+    // Extract tool calls
     const toolCalls = message.content.filter((c) => c.type === "tool_use");
     if (toolCalls.length > 0) {
-      return toolCalls
-        .map((tc) => `CALL ${tc.name}(${formatToolArgs(tc.input)})`)
-        .join("\n");
+      // Return first tool call as a StreamEvent
+      // (multiple tool calls in one message are rare; formatEvent is called per event)
+      const tc = toolCalls[0]!;
+      return {
+        kind: "tool_call",
+        name: (tc.name as string) || "unknown",
+        args: formatToolInput(tc.input),
+      };
     }
 
-    return null; // Skip plain text assistant messages (will be in final result)
-  }
-
-  if (type === "result") {
-    const duration = event.duration_ms as number | undefined;
-    const cost = event.total_cost_usd as number | undefined;
-    const parts = [backendName, "completed"];
-    const details: string[] = [];
-    if (duration) details.push(`${(duration / 1000).toFixed(1)}s`);
-    if (cost) details.push(`$${cost.toFixed(4)}`);
-    if (details.length > 0) parts.push(`(${details.join(", ")})`);
-    return parts.join(" ");
-  }
-
-  // ---- Codex events ----
-
-  if (type === "thread.started") {
-    const threadId = event.thread_id as string | undefined;
-    return `${backendName} initialized${threadId ? ` (thread: ${threadId.slice(0, 8)}...)` : ""}`;
-  }
-
-  if (type === "item.completed") {
-    const item = event.item as Record<string, unknown> | undefined;
-    if (!item) return null;
-
-    // Tool call
-    if (item.type === "function_call") {
-      const name = (item.name as string) || "unknown";
-      const args = item.arguments as string | undefined;
-      const truncated = args && args.length > 100 ? args.slice(0, 100) + "..." : (args ?? "");
-      return `CALL ${name}(${truncated})`;
-    }
-
-    // Skip agent_message — will be extracted by parseStreamResult
+    // Plain text assistant messages — no standard event (extracted by result extractor)
     return null;
   }
 
-  if (type === "turn.completed") {
-    const usage = event.usage as { input_tokens?: number; output_tokens?: number } | undefined;
-    if (usage) {
-      return `${backendName} turn completed (${usage.input_tokens ?? 0} in, ${usage.output_tokens ?? 0} out)`;
-    }
-    return `${backendName} turn completed`;
+  if (type === "result") {
+    return {
+      kind: "completed",
+      durationMs: raw.duration_ms as number | undefined,
+      costUsd: raw.total_cost_usd as number | undefined,
+    };
   }
 
   return null;
-}
+};
 
 /**
- * Format tool call arguments for logging (truncated)
- */
-function formatToolArgs(input: unknown): string {
-  if (!input || typeof input !== "object") return "";
-  try {
-    const str = JSON.stringify(input);
-    return str.length > 100 ? str.slice(0, 100) + "..." : str;
-  } catch {
-    return "";
-  }
-}
-
-// ==================== Stream Line Parser ====================
-
-/**
- * Create a line-buffered stream-json parser.
+ * Extract final result from Claude/Cursor stream-json output.
  *
- * Accumulates stdout chunks and emits parsed progress messages
- * via the debugLog callback. Handles partial lines across chunks.
+ * Priority:
+ * 1. type=result with result field
+ * 2. Last assistant message with text content
+ * 3. Raw stdout fallback
  */
-export function createStreamParser(
-  debugLog: (message: string) => void,
-  backendName: string,
-): (chunk: string) => void {
-  let lineBuf = "";
-
-  return (chunk: string) => {
-    lineBuf += chunk;
-    const lines = lineBuf.split("\n");
-    // Keep incomplete last line in buffer
-    lineBuf = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        const event = JSON.parse(line);
-        const progress = formatStreamEvent(event, backendName);
-        if (progress) debugLog(progress);
-      } catch {
-        // Not JSON — ignore
-      }
-    }
-  };
-}
-
-// ==================== Result Extraction ====================
-
-/**
- * Parse stream-json output to extract the final result.
- * Handles both Cursor/Claude and Codex event formats.
- * Falls back to raw stdout if parsing fails.
- *
- * Searches for (in priority order):
- * 1. Cursor/Claude: type=result with result field
- * 2. Codex: item.completed with item.type=agent_message (last one)
- * 3. Cursor/Claude: last assistant message with text content
- * 4. Raw stdout as final fallback
- */
-export function parseStreamResult(stdout: string): BackendResponse {
+export function extractClaudeResult(stdout: string): BackendResponse {
   const lines = stdout.trim().split("\n");
 
-  // 1. Cursor/Claude: find result event
+  // 1. Find result event
   for (let i = lines.length - 1; i >= 0; i--) {
     try {
       const event = JSON.parse(lines[i]!);
@@ -168,23 +152,11 @@ export function parseStreamResult(stdout: string): BackendResponse {
         return { content: event.result };
       }
     } catch {
-      // Not JSON — skip
+      // Not JSON
     }
   }
 
-  // 2. Codex: find last agent_message item
-  for (let i = lines.length - 1; i >= 0; i--) {
-    try {
-      const event = JSON.parse(lines[i]!);
-      if (event.type === "item.completed" && event.item?.type === "agent_message" && event.item?.text) {
-        return { content: event.item.text };
-      }
-    } catch {
-      // Not JSON — skip
-    }
-  }
-
-  // 3. Cursor/Claude: find last assistant message
+  // 2. Last assistant message
   for (let i = lines.length - 1; i >= 0; i--) {
     try {
       const event = JSON.parse(lines[i]!);
@@ -197,10 +169,153 @@ export function parseStreamResult(stdout: string): BackendResponse {
         }
       }
     } catch {
-      // Not JSON — skip
+      // Not JSON
     }
   }
 
-  // 4. Final fallback: return raw stdout
+  // 3. Raw stdout
   return { content: stdout.trim() };
+}
+
+// ==================== Codex Adapter ====================
+
+/**
+ * Adapter for Codex --json format.
+ *
+ * Events:
+ *   { type: "thread.started", thread_id: "..." }
+ *   { type: "item.completed", item: { type: "function_call", name, arguments } }
+ *   { type: "item.completed", item: { type: "agent_message", text } }  → skipped (result only)
+ *   { type: "turn.completed", usage: { input_tokens, output_tokens } }
+ */
+export const codexAdapter: EventAdapter = (raw) => {
+  const type = raw.type as string;
+
+  if (type === "thread.started") {
+    const threadId = raw.thread_id as string | undefined;
+    return {
+      kind: "init",
+      sessionId: threadId ? `${threadId.slice(0, 8)}...` : undefined,
+    };
+  }
+
+  if (type === "item.completed") {
+    const item = raw.item as Record<string, unknown> | undefined;
+    if (!item) return null;
+
+    // Tool call
+    if (item.type === "function_call") {
+      return {
+        kind: "tool_call",
+        name: (item.name as string) || "unknown",
+        args: (item.arguments as string) ?? "",
+      };
+    }
+
+    // agent_message — skip (extracted by result extractor)
+    return null;
+  }
+
+  if (type === "turn.completed") {
+    const usage = raw.usage as
+      | { input_tokens?: number; output_tokens?: number }
+      | undefined;
+    return {
+      kind: "completed",
+      usage: usage
+        ? {
+            input: usage.input_tokens ?? 0,
+            output: usage.output_tokens ?? 0,
+          }
+        : undefined,
+    };
+  }
+
+  return null;
+};
+
+/**
+ * Extract final result from Codex --json output.
+ *
+ * Priority:
+ * 1. Last item.completed with item.type=agent_message
+ * 2. Raw stdout fallback
+ */
+export function extractCodexResult(stdout: string): BackendResponse {
+  const lines = stdout.trim().split("\n");
+
+  // 1. Find last agent_message
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const event = JSON.parse(lines[i]!);
+      if (
+        event.type === "item.completed" &&
+        event.item?.type === "agent_message" &&
+        event.item?.text
+      ) {
+        return { content: event.item.text };
+      }
+    } catch {
+      // Not JSON
+    }
+  }
+
+  // 2. Raw stdout
+  return { content: stdout.trim() };
+}
+
+// ==================== Stream Line Parser ====================
+
+/**
+ * Create a line-buffered stream parser.
+ *
+ * Accumulates stdout chunks, parses each line through the given adapter,
+ * and emits formatted progress messages via debugLog.
+ *
+ * @param debugLog - Callback for progress messages
+ * @param backendName - Display name (e.g., "Cursor", "Claude", "Codex")
+ * @param adapter - Format-specific adapter to convert raw JSON → StreamEvent
+ */
+export function createStreamParser(
+  debugLog: (message: string) => void,
+  backendName: string,
+  adapter: EventAdapter,
+): (chunk: string) => void {
+  let lineBuf = "";
+
+  return (chunk: string) => {
+    lineBuf += chunk;
+    const lines = lineBuf.split("\n");
+    // Keep incomplete last line in buffer
+    lineBuf = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const raw = JSON.parse(line);
+        const event = adapter(raw);
+        if (event) {
+          const progress = formatEvent(event, backendName);
+          if (progress) debugLog(progress);
+        }
+      } catch {
+        // Not JSON — ignore
+      }
+    }
+  };
+}
+
+// ==================== Helpers ====================
+
+/**
+ * Format tool call input for display (truncated JSON string)
+ */
+function formatToolInput(input: unknown): string {
+  if (!input || typeof input !== "object") return "";
+  try {
+    const str = JSON.stringify(input);
+    return str.length > 100 ? str.slice(0, 100) + "..." : str;
+  } catch {
+    return "";
+  }
 }

--- a/packages/agent-worker/src/cli/index.ts
+++ b/packages/agent-worker/src/cli/index.ts
@@ -8,7 +8,7 @@
 // In debug mode (--debug or -d), show everything for troubleshooting
 const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
-process.stderr.write = function(chunk: string | Uint8Array, ...args: unknown[]): boolean {
+process.stderr.write = function (chunk: string | Uint8Array, ...args: unknown[]): boolean {
   const isDebugMode = process.argv.includes("--debug") || process.argv.includes("-d");
   if (isDebugMode) {
     const message = typeof chunk === "string" ? chunk : chunk.toString();

--- a/packages/agent-worker/src/cli/index.ts
+++ b/packages/agent-worker/src/cli/index.ts
@@ -8,11 +8,11 @@
 // In debug mode (--debug or -d), show everything for troubleshooting
 const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
-process.stderr.write = function (chunk: string | Uint8Array, ...args: unknown[]): boolean {
+process.stderr.write = function (chunk: string | Uint8Array, ...rest: unknown[]): boolean {
   const isDebugMode = process.argv.includes("--debug") || process.argv.includes("-d");
   if (isDebugMode) {
     const message = typeof chunk === "string" ? chunk : chunk.toString();
-    return originalStderrWrite(message, ...args) as boolean;
+    return (originalStderrWrite as Function).call(process.stderr, message, ...rest) as boolean;
   }
   // Normal mode: suppress stderr completely
   return true;

--- a/packages/agent-worker/src/workflow/controller/backend.ts
+++ b/packages/agent-worker/src/workflow/controller/backend.ts
@@ -16,15 +16,24 @@ import { createMockBackend } from "@/backends/mock.ts";
  */
 export function getBackendByType(
   backendType: "sdk" | "claude" | "cursor" | "codex" | "mock",
-  options?: { model?: string; debugLog?: (msg: string) => void },
+  options?: { model?: string; debugLog?: (msg: string) => void; timeout?: number },
 ): Backend {
   if (backendType === "mock") {
     return createMockBackend(options?.debugLog);
   }
 
+  const backendOptions: Record<string, unknown> = {};
+  if (options?.timeout) {
+    backendOptions.timeout = options.timeout;
+  }
+  if (options?.debugLog) {
+    backendOptions.debugLog = options.debugLog;
+  }
+
   return createBackend({
     type: backendType,
     model: options?.model,
+    ...(Object.keys(backendOptions).length > 0 ? { options: backendOptions } : {}),
   } as Parameters<typeof createBackend>[0]);
 }
 

--- a/packages/agent-worker/src/workflow/controller/types.ts
+++ b/packages/agent-worker/src/workflow/controller/types.ts
@@ -65,6 +65,8 @@ export interface AgentControllerConfig {
   onRunComplete?: (result: AgentRunResult) => void;
   /** Log function (debug level — only shown with --debug) */
   log?: (message: string) => void;
+  /** Info log function (always shown — for key lifecycle events) */
+  infoLog?: (message: string) => void;
   /** Error log function (always shown — for failures, missing API keys, etc.) */
   errorLog?: (message: string) => void;
   /** Enable feedback tool in agent prompts */

--- a/packages/agent-worker/src/workflow/display.ts
+++ b/packages/agent-worker/src/workflow/display.ts
@@ -55,14 +55,7 @@ const C = {
 
   // Agent colors — cycle through distinct hues
   agents: isTTY
-    ? [
-        chalk.cyan,
-        chalk.yellow,
-        chalk.magenta,
-        chalk.green,
-        chalk.blue,
-        chalk.redBright,
-      ]
+    ? [chalk.cyan, chalk.yellow, chalk.magenta, chalk.green, chalk.blue, chalk.redBright]
     : Array(6).fill((s: string) => s),
 
   // System messages

--- a/packages/agent-worker/src/workflow/interpolate.ts
+++ b/packages/agent-worker/src/workflow/interpolate.ts
@@ -11,7 +11,11 @@
 
 export interface VariableContext {
   /** Task output variables */
-  [key: string]: string | undefined | Record<string, string | undefined> | { name: string; tag: string; instance?: string };
+  [key: string]:
+    | string
+    | undefined
+    | Record<string, string | undefined>
+    | { name: string; tag: string; instance?: string };
 
   /** Environment variables (accessed via env.VAR) */
   env?: Record<string, string | undefined>;

--- a/packages/agent-worker/src/workflow/layout-log.ts
+++ b/packages/agent-worker/src/workflow/layout-log.ts
@@ -138,12 +138,12 @@ export function formatTimelineLog(
 
   // Agent colors - cycle through distinct colors
   const agentColors = [
-    chalk.cyan,     // workflow, system
-    chalk.yellow,   // agent 1
-    chalk.magenta,  // agent 2
-    chalk.green,    // agent 3
-    chalk.blue,     // agent 4
-    chalk.redBright,// agent 5
+    chalk.cyan, // workflow, system
+    chalk.yellow, // agent 1
+    chalk.magenta, // agent 2
+    chalk.green, // agent 3
+    chalk.blue, // agent 4
+    chalk.redBright, // agent 5
   ];
 
   // Assign color based on common agent names
@@ -219,8 +219,7 @@ export function recommendLogStyle(useCase: {
   avgMessageLength?: number;
   isInteractive?: boolean;
 }): LogLayoutStyle {
-  const { messageCount = 0, agentCount = 0, avgMessageLength = 0, isInteractive = true } =
-    useCase;
+  const { messageCount = 0, agentCount = 0, avgMessageLength = 0, isInteractive = true } = useCase;
 
   // Many messages from few agents → timeline
   if (messageCount > 50 && agentCount <= 3) {

--- a/packages/agent-worker/src/workflow/runner.ts
+++ b/packages/agent-worker/src/workflow/runner.ts
@@ -594,6 +594,7 @@ export async function runWorkflowWithControllers(
         backend = getBackendByType(agentDef.backend, {
           model: agentDef.model,
           debugLog: backendDebugLog,
+          timeout: agentDef.timeout,
         });
       } else if (agentDef.model) {
         backend = getBackendForModel(agentDef.model, { debugLog: backendDebugLog });

--- a/packages/agent-worker/src/workflow/runner.ts
+++ b/packages/agent-worker/src/workflow/runner.ts
@@ -621,6 +621,7 @@ export async function runWorkflowWithControllers(
         backend,
         pollInterval,
         log: (msg) => controllerLogger.debug(msg),
+        infoLog: (msg) => controllerLogger.info(msg),
         errorLog: (msg) => controllerLogger.error(msg),
         feedback: feedbackEnabled,
       });

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -61,6 +61,9 @@ export interface AgentDefinition {
 
   /** Maximum tool call steps per turn */
   max_steps?: number;
+
+  /** Backend timeout in milliseconds (overrides backend default) */
+  timeout?: number;
 }
 
 // ==================== Setup Task ====================

--- a/packages/agent-worker/test/cli-backends.test.ts
+++ b/packages/agent-worker/test/cli-backends.test.ts
@@ -92,7 +92,7 @@ describe('Mock CLI', () => {
 describe('CursorBackend with Mock', () => {
   // Create a backend that uses our mock CLI (with stream-json format)
   class MockCursorBackend extends CursorBackend {
-    protected override buildCommand(message: string): { command: string; args: string[] } {
+    protected override async buildCommand(message: string): Promise<{ command: string; args: string[] }> {
       // Use bun to run mock-cli.ts instead of actual cursor-agent
       // Include --output-format=stream-json to match real buildCommand behavior
       return {
@@ -130,10 +130,8 @@ describe('CursorBackend with Mock', () => {
     // Create backend with very short timeout
     const backend = new MockCursorBackend({ timeout: 100 })
 
-    // Override to use timeout mock
-    const originalBuild = backend['buildCommand'].bind(backend)
-    backend['buildCommand'] = (message: string) => {
-      originalBuild(message)
+    // Override to use timeout mock (plain text, no stream-json)
+    backend['buildCommand'] = async (message: string) => {
       return {
         command: 'bun',
         args: [MOCK_CLI_PATH, 'cursor-agent', '-p', message],

--- a/packages/agent-worker/test/cli-backends.test.ts
+++ b/packages/agent-worker/test/cli-backends.test.ts
@@ -158,14 +158,22 @@ describe('CursorBackend with Mock', () => {
 
 describe('Idle Timeout', () => {
   test('kills process that produces no output', async () => {
-    await expect(
-      execWithIdleTimeout({
-        command: 'bun',
-        args: [MOCK_CLI_PATH, 'cursor-agent', '-p', 'test'],
-        timeout: 100,
-      })
-    ).rejects.toThrow(IdleTimeoutError)
-  }, { env: { MOCK_TIMEOUT: '1' } })
+    const original = process.env.MOCK_TIMEOUT
+    process.env.MOCK_TIMEOUT = '1'
+
+    try {
+      await expect(
+        execWithIdleTimeout({
+          command: 'bun',
+          args: [MOCK_CLI_PATH, 'cursor-agent', '-p', 'test'],
+          timeout: 1500,
+        })
+      ).rejects.toThrow(IdleTimeoutError)
+    } finally {
+      if (original === undefined) delete process.env.MOCK_TIMEOUT
+      else process.env.MOCK_TIMEOUT = original
+    }
+  })
 
   test('resets timer on output — slow process completes', async () => {
     // Process outputs 5 chunks with 50ms between each

--- a/packages/agent-worker/test/cli-backends.test.ts
+++ b/packages/agent-worker/test/cli-backends.test.ts
@@ -8,7 +8,6 @@ import { describe, test, expect } from 'bun:test'
 import { spawn } from 'node:child_process'
 import { join } from 'node:path'
 import { CursorBackend } from '../src/backends/cursor.ts'
-import { CodexBackend } from '../src/backends/codex.ts'
 import { execWithIdleTimeout, IdleTimeoutError } from '../src/backends/idle-timeout.ts'
 import {
   formatEvent,
@@ -390,24 +389,7 @@ describe('Codex Adapter', () => {
   })
 })
 
-describe('CodexBackend with Mock', () => {
-  // Create a backend that uses our mock CLI
-  class MockCodexBackend extends CodexBackend {
-    private buildArgsMethod = (this as any).__proto__.__proto__; // access parent
-
-    send(message: string, options?: { system?: string }): Promise<import('../src/backends/types.ts').BackendResponse> {
-      // Monkey-patch: override the codex command to use mock CLI
-      const origBuildArgs = (this as any).buildArgs.bind(this);
-      (this as any).buildArgs = (msg: string) => {
-        const args = origBuildArgs(msg);
-        return args;
-      };
-      // We can't easily override the command in codex like cursor's buildCommand,
-      // so we use a different approach via the exec utility
-      return super.send(message, options);
-    }
-  }
-
+describe('Codex Mock CLI', () => {
   test('mock CLI outputs codex JSON format', async () => {
     const result = await runMockCli(['codex', 'exec', '--json', '--skip-git-repo-check', '2+2=?'])
     expect(result.exitCode).toBe(0)

--- a/packages/agent-worker/test/mock-cli.ts
+++ b/packages/agent-worker/test/mock-cli.ts
@@ -4,6 +4,7 @@
  *
  * Usage:
  *   bun test/mock-cli.ts cursor-agent -p "hello"
+ *   bun test/mock-cli.ts cursor agent -p "hello"
  *   bun test/mock-cli.ts claude -p "hello"
  *   bun test/mock-cli.ts codex "hello"
  *
@@ -17,8 +18,13 @@
 
 const args = process.argv.slice(2)
 
-// Parse command name (cursor-agent, claude, codex)
-const command = args[0]
+// Parse command name (cursor-agent, cursor agent, claude, codex)
+// Normalize "cursor agent" → "cursor-agent"
+let command = args[0]
+if (command === 'cursor' && args[1] === 'agent') {
+  command = 'cursor-agent'
+  args.splice(1, 1) // remove 'agent' so arg parsing stays consistent
+}
 
 // Environment configuration
 const delay = parseInt(process.env.MOCK_DELAY_MS || '100', 10)

--- a/packages/agent-worker/test/mock-cli.ts
+++ b/packages/agent-worker/test/mock-cli.ts
@@ -122,10 +122,10 @@ const outputFormat = args.find(a => a.startsWith('--output-format='))?.split('='
 if (outputFormat === 'stream-json') {
   // Output JSON format like cursor-agent does
   const sessionId = crypto.randomUUID()
-  console.log(JSON.stringify({ type: 'system', subtype: 'init', session_id: sessionId }))
+  console.log(JSON.stringify({ type: 'system', subtype: 'init', model: 'Mock Model', session_id: sessionId }))
   console.log(JSON.stringify({ type: 'user', message: { role: 'user', content: [{ type: 'text', text: message }] }, session_id: sessionId }))
   console.log(JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: response }] }, session_id: sessionId }))
-  console.log(JSON.stringify({ type: 'result', subtype: 'success', result: response, session_id: sessionId }))
+  console.log(JSON.stringify({ type: 'result', subtype: 'success', result: response, duration_ms: delay, session_id: sessionId }))
 } else {
   // Plain text output
   console.log(response)

--- a/packages/agent-worker/test/mock-cli.ts
+++ b/packages/agent-worker/test/mock-cli.ts
@@ -24,6 +24,8 @@ const command = args[0]
 const delay = parseInt(process.env.MOCK_DELAY_MS || '100', 10)
 const shouldFail = process.env.MOCK_FAIL === '1'
 const shouldTimeout = process.env.MOCK_TIMEOUT === '1'
+const slowOutputChunks = parseInt(process.env.MOCK_SLOW_OUTPUT_CHUNKS || '0', 10)
+const slowOutputIntervalMs = parseInt(process.env.MOCK_SLOW_OUTPUT_INTERVAL_MS || '50', 10)
 const exitCode = parseInt(process.env.MOCK_EXIT_CODE || '0', 10)
 const customResponse = process.env.MOCK_RESPONSE
 
@@ -47,6 +49,17 @@ if (args.includes('--help')) {
 if (shouldTimeout) {
   // Do nothing, just hang
   await new Promise(() => {})
+}
+
+// Simulate slow output (chunks of text with delays between them)
+// Used to test idle timeout reset behavior
+if (slowOutputChunks > 0) {
+  for (let i = 0; i < slowOutputChunks; i++) {
+    process.stdout.write(`chunk ${i + 1}\n`)
+    await new Promise(resolve => setTimeout(resolve, slowOutputIntervalMs))
+  }
+  process.stdout.write('done\n')
+  process.exit(0)
 }
 
 // Extract message from args

--- a/packages/agent-worker/test/session.test.ts
+++ b/packages/agent-worker/test/session.test.ts
@@ -1221,7 +1221,6 @@ describe('CLI backend implementations', () => {
 
     const backend = new CodexBackend({
       model: 'o3',
-      approvalMode: 'full-auto',
     })
 
     expect(backend.type).toBe('codex')


### PR DESCRIPTION
The cursor backend had a 2-minute default timeout while claude and codex
backends both default to 5 minutes. Large workflow tasks (e.g., analyzing
80+ files) consistently timed out with the cursor backend.

Changes:
- Increase CursorBackend default timeout from 120s to 300s (matching others)
- Add `timeout` field to AgentDefinition for per-agent workflow config
- Wire timeout through getBackendByType → createBackend pipeline
- Update docs to reflect new default

https://claude.ai/code/session_01WoDXbNDHGgANijBBLhg4nE