### PR TITLE
fix(display-pretty): render stream messages as log entries instead of note boxes

### DIFF
--- a/packages/agent-worker/src/workflow/display-pretty.ts
+++ b/packages/agent-worker/src/workflow/display-pretty.ts
@@ -120,6 +120,22 @@ function processEntry(entry: Message, state: PrettyDisplayState, agentNames: str
     return;
   }
 
+  // Stream entries (backend streaming output: tool calls, assistant/user messages)
+  if (kind === "stream") {
+    const color = getAgentColor(from, agentNames);
+    const agent = from.includes(":") ? from.split(":").pop()! : from;
+
+    if (content.startsWith("STARTING ") || content.startsWith("CALL ")) {
+      p.log.message(`${color(agent)} ${content}`, { symbol: pc.cyan("▶") });
+    } else if (content.startsWith("Assistant: ")) {
+      const text = content.slice("Assistant: ".length);
+      p.log.message(`${color(agent)} ${text}`, { symbol: pc.cyan("◆") });
+    } else {
+      p.log.message(`${color(agent)} ${pc.dim(content)}`, { symbol: pc.dim("│") });
+    }
+    return;
+  }
+
   // Log entries (operational messages)
   if (kind === "log") {
     if (content.includes("Running workflow:")) {


### PR DESCRIPTION
Stream messages (kind="stream") were falling through to the agent message
handler and displaying as p.note() boxes. Add dedicated handler that uses
p.log.message() with appropriate symbols: ▶ for tool calls, ◆ for assistant
messages, │ for other stream output.

https://claude.ai/code/session_01V9zWWJJtohLwKACeFCusEg