### PR TITLE
fix: configure npm OIDC auth for Trusted Publisher in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         run: bun install
 
@@ -54,6 +59,7 @@ jobs:
           echo "new_tags=$NEW_TAGS" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Push tags
         if: steps.publish.outputs.new_tags != ''


### PR DESCRIPTION
Add actions/setup-node with registry-url to configure .npmrc for the
npm registry, and set NPM_CONFIG_PROVENANCE=true to enable the OIDC
authentication flow. Without these, npm never attempts OIDC auth and
fails with ENEEDAUTH even though id-token: write is granted.

https://claude.ai/code/session_01VehU7gRL5UMdWDmcz29KA8