### PR TITLE
fix: use Node 24 for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
The npm CLI bundled with older Node versions only supports OIDC for
provenance signing, not for publish authentication. Node 24's npm
fully supports OIDC trusted publishing, allowing authentication
without NPM_TOKEN. Also restores registry-url as shown in npm's
official trusted publishing documentation.

https://claude.ai/code/session_01CTQFoZRfiyEh5P7HAtd6QD