### PR TITLE
fix(agent-worker): add repository field to fix npm publish provenance error

### DIFF
--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -93,5 +93,10 @@
     "@ai-sdk/xai": {
       "optional": true
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidessen/moniro.git",
+    "directory": "packages/agent-worker"
   }
 }


### PR DESCRIPTION
Add missing repository field to package.json to resolve E422 error during npm publish:
"Error verifying sigstore provenance bundle: Failed to validate repository information"

The repository field is required for npm provenance validation when publishing from GitHub Actions.

https://claude.ai/code/session_01AQbSG1YcLN8safFzENT9Ad