### PR TITLE
feat: add local CLI tools setup for third-party model integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ npm-debug.log*
 .memory/sessions/
 .memory/context.md
 
+# Local CLI binaries (large, downloadable)
+.local/bin/claude-bin
+
 # Test files and directories
 test-skills.ts
 test-skills-cli.ts

--- a/.local/README.md
+++ b/.local/README.md
@@ -60,11 +60,11 @@ Codex CLI deprecated `wire_api = "chat"` (Chat Completions API) and now requires
 
 ### 3. Cursor Agent CLI (v2026.01.28) - Cannot Use Third-Party Models
 
-**Binary**: `~/.local/bin/cursor-agent` (symlinked to `~/.local/bin/agent`)
+**Binary**: `~/.local/bin/agent` (also available as `cursor agent` subcommand)
 
 **Status**: **LOCKED TO CURSOR INFRASTRUCTURE**. No way to point at custom API endpoints.
 
-The CLI only accepts Cursor's pre-configured models (gpt-5, sonnet-4, etc.) via `--model` flag. There is no `--base-url` or custom provider configuration. Authentication requires a Cursor subscription via `cursor-agent login`.
+The CLI only accepts Cursor's pre-configured models (gpt-5, sonnet-4, etc.) via `--model` flag. There is no `--base-url` or custom provider configuration. Authentication requires a Cursor subscription via `cursor agent login`.
 
 ### 4. OpenCode (v1.1.59) - Best Option for DeepSeek
 

--- a/.local/README.md
+++ b/.local/README.md
@@ -1,0 +1,83 @@
+# Local CLI Tools for Third-Party Model Integration
+
+This directory contains locally installed CLI agents configured to work with third-party models (DeepSeek).
+
+## Installed Tools
+
+### 1. Claude Code (v2.1.39) - Works with DeepSeek
+
+**Binary**: `.local/bin/claude-bin` (213MB standalone ELF binary)
+**Wrappers**:
+- `claude-ds` - Pre-configured for DeepSeek backend
+- `claude-local` - Plain wrapper (configure via env vars)
+
+**Usage**:
+```bash
+# Add to PATH for this session
+export PATH="$PWD/.local/bin:$PATH"
+
+# Use DeepSeek backend directly
+claude-ds
+
+# Or configure manually
+ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic" \
+ANTHROPIC_AUTH_TOKEN="$DEEPSEEK_API_KEY" \
+ANTHROPIC_API_KEY="" \
+ANTHROPIC_MODEL="deepseek-chat" \
+claude-local
+```
+
+**How it works**: DeepSeek provides an Anthropic-compatible API endpoint at `https://api.deepseek.com/anthropic`. Claude Code sends all requests there instead of to Anthropic.
+
+**Key environment variables**:
+| Variable | Purpose |
+|---|---|
+| `ANTHROPIC_BASE_URL` | API endpoint (set to DeepSeek's Anthropic endpoint) |
+| `ANTHROPIC_AUTH_TOKEN` | Auth token (use DeepSeek API key) |
+| `ANTHROPIC_API_KEY` | Must be `""` to prevent Anthropic auth conflicts |
+| `ANTHROPIC_MODEL` | Model name (`deepseek-chat`) |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Model for haiku alias |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Model for sonnet alias |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | Model for opus alias |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `1` to prevent background Anthropic requests |
+| `API_TIMEOUT_MS` | Timeout in ms (use `600000` for slower models) |
+
+**Verified working**: API calls succeed, tool use works (TodoWrite, Read, Bash, Glob, Skill). Note that DeepSeek does NOT support: image inputs, MCP tools, web search.
+
+### 2. Codex CLI (v0.98.0) - Broken for DeepSeek
+
+**Binary**: `/opt/node22/bin/codex` (installed globally via npm)
+**Config**: `~/.codex/config.toml`
+
+**Status**: **NOT WORKING** with DeepSeek as of Feb 2026.
+
+Codex CLI deprecated `wire_api = "chat"` (Chat Completions API) and now requires `wire_api = "responses"` (OpenAI Responses API). DeepSeek does not support the Responses API (`/v1/responses` returns 404).
+
+**Workarounds**:
+1. Use a proxy (LiteLLM/ZenMux) that translates Responses API to Chat Completions
+2. Pin an older Codex version that still supports `wire_api = "chat"`
+3. Wait for DeepSeek to add Responses API support
+
+### 3. Cursor Agent CLI (v2026.01.28) - Cannot Use Third-Party Models
+
+**Binary**: `~/.local/bin/cursor-agent` (symlinked to `~/.local/bin/agent`)
+
+**Status**: **LOCKED TO CURSOR INFRASTRUCTURE**. No way to point at custom API endpoints.
+
+The CLI only accepts Cursor's pre-configured models (gpt-5, sonnet-4, etc.) via `--model` flag. There is no `--base-url` or custom provider configuration. Authentication requires a Cursor subscription via `cursor-agent login`.
+
+## Summary
+
+| CLI | Third-Party Model Support | DeepSeek Status |
+|-----|---------------------------|-----------------|
+| Claude Code | Via `ANTHROPIC_BASE_URL` env var | **Working** |
+| Codex CLI | Via `config.toml` providers | **Broken** (Responses API required) |
+| Cursor Agent | None | **Not possible** |
+
+## Alternative Approaches
+
+For broader third-party model support, consider:
+- **OpenRouter** (`openrouter.ai/api`): 400+ models, Anthropic API-compatible "skin"
+- **LiteLLM** (`litellm`): Self-hosted proxy, 100+ providers, translates API formats
+- **claude-code-router**: Purpose-built Claude Code proxy with multi-provider support
+- **OpenCode** (`open-code.ai`): Open-source terminal agent with native multi-provider support

--- a/.local/README.md
+++ b/.local/README.md
@@ -66,18 +66,47 @@ Codex CLI deprecated `wire_api = "chat"` (Chat Completions API) and now requires
 
 The CLI only accepts Cursor's pre-configured models (gpt-5, sonnet-4, etc.) via `--model` flag. There is no `--base-url` or custom provider configuration. Authentication requires a Cursor subscription via `cursor-agent login`.
 
+### 4. OpenCode (v1.1.59) - Best Option for DeepSeek
+
+**Binary**: `/opt/node22/bin/opencode` (installed globally via npm)
+**Config**: `opencode.json` (project root)
+
+**Status**: **WORKING PERFECTLY** with DeepSeek. Native support, zero friction.
+
+OpenCode (`sst/opencode`) is a Go-based open-source terminal agent with native support for 75+ providers including DeepSeek. Both `deepseek-chat` and `deepseek-reasoner` work out of the box.
+
+**Usage**:
+```bash
+# Non-interactive (pipe or positional prompt)
+echo "explain this code" | opencode run --model deepseek/deepseek-chat
+
+# Interactive TUI
+opencode --model deepseek/deepseek-chat
+
+# Use DeepSeek Reasoner (R1) for complex reasoning
+opencode run --model deepseek/deepseek-reasoner
+```
+
+**Config** (`opencode.json`):
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "deepseek": {
+      "options": { "apiKey": "{env:DEEPSEEK_API_KEY}" }
+    }
+  },
+  "model": "deepseek/deepseek-chat"
+}
+```
+
+**Verified working**: Text generation, reasoning (R1), tool use (bash commands). Responses in ~3 seconds.
+
 ## Summary
 
-| CLI | Third-Party Model Support | DeepSeek Status |
-|-----|---------------------------|-----------------|
-| Claude Code | Via `ANTHROPIC_BASE_URL` env var | **Working** |
-| Codex CLI | Via `config.toml` providers | **Broken** (Responses API required) |
-| Cursor Agent | None | **Not possible** |
-
-## Alternative Approaches
-
-For broader third-party model support, consider:
-- **OpenRouter** (`openrouter.ai/api`): 400+ models, Anthropic API-compatible "skin"
-- **LiteLLM** (`litellm`): Self-hosted proxy, 100+ providers, translates API formats
-- **claude-code-router**: Purpose-built Claude Code proxy with multi-provider support
-- **OpenCode** (`open-code.ai`): Open-source terminal agent with native multi-provider support
+| CLI | DeepSeek | Config Complexity | Tool Use | Recommended |
+|-----|----------|-------------------|----------|-------------|
+| **OpenCode** | Native support | Minimal | Working | **Best choice** |
+| Claude Code | Via env vars | Medium | Working | Good |
+| Codex CLI | Broken | - | - | Not usable |
+| Cursor Agent | Not possible | - | - | Not usable |

--- a/.local/bin/claude-ds
+++ b/.local/bin/claude-ds
@@ -13,6 +13,11 @@ if [ ! -x "$BINARY" ]; then
   echo "Downloaded Claude Code v$VERSION"
 fi
 
+if [ -z "${DEEPSEEK_API_KEY:-}" ]; then
+  echo "Error: DEEPSEEK_API_KEY is not set." >&2
+  exit 1
+fi
+
 export ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
 export ANTHROPIC_AUTH_TOKEN="${DEEPSEEK_API_KEY}"
 export ANTHROPIC_API_KEY=""

--- a/.local/bin/claude-ds
+++ b/.local/bin/claude-ds
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Claude Code with DeepSeek backend
+# Uses DeepSeek's Anthropic-compatible API endpoint
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BINARY="$SCRIPT_DIR/claude-bin"
+
+# Auto-download binary if missing
+if [ ! -x "$BINARY" ]; then
+  echo "Claude Code binary not found. Downloading..."
+  GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+  VERSION=$(curl -fsSL "$GCS_BUCKET/latest")
+  curl -fsSL "$GCS_BUCKET/$VERSION/linux-x64/claude" -o "$BINARY" && chmod +x "$BINARY"
+  echo "Downloaded Claude Code v$VERSION"
+fi
+
+export ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+export ANTHROPIC_AUTH_TOKEN="${DEEPSEEK_API_KEY}"
+export ANTHROPIC_API_KEY=""
+export ANTHROPIC_MODEL="deepseek-chat"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="deepseek-chat"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="deepseek-chat"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="deepseek-chat"
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+export API_TIMEOUT_MS=600000
+
+exec "$BINARY" "$@"

--- a/.local/bin/claude-local
+++ b/.local/bin/claude-local
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Local Claude Code standalone binary (configure via env vars)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BINARY="$SCRIPT_DIR/claude-bin"
+
+# Auto-download binary if missing
+if [ ! -x "$BINARY" ]; then
+  echo "Claude Code binary not found. Downloading..."
+  GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+  VERSION=$(curl -fsSL "$GCS_BUCKET/latest")
+  curl -fsSL "$GCS_BUCKET/$VERSION/linux-x64/claude" -o "$BINARY" && chmod +x "$BINARY"
+  echo "Downloaded Claude Code v$VERSION"
+fi
+
+exec "$BINARY" "$@"

--- a/.memory/notes/2026-02-12-cli-third-party-model-research.md
+++ b/.memory/notes/2026-02-12-cli-third-party-model-research.md
@@ -33,18 +33,39 @@ DeepSeek 提供了 Anthropic 兼容端点 `https://api.deepseek.com/anthropic`�
 
 **已知限制**：DeepSeek 不支持 image inputs、MCP tools、web search。
 
-### Codex CLI v0.98.0 — 不可用
+### Codex CLI v0.98.0 — 需要代理
 
-`wire_api = "chat"`（Chat Completions API）已被废弃，必须用 `wire_api = "responses"`（OpenAI Responses API）。DeepSeek 的 `/v1/responses` 返回 404。
+`wire_api = "chat"`（Chat Completions API）已被废弃，必须用 `wire_api = "responses"`（OpenAI Responses API）。DeepSeek 原生 `/v1/responses` 返回 404。
 
-**变通方案**：
-1. LiteLLM/ZenMux 代理翻译 Responses → Chat Completions
-2. 降级到旧版 Codex（仍支持 chat wire_api）
-3. 等 DeepSeek 支持 Responses API
+**可用方案**：
+1. **ZenMux**（已确认可用）— 支持 Responses API 的代理。配置 `wire_api = "responses"` + ZenMux base_url。已知问题：`reasoning_effort` 参数在带 `openai/` 前缀的模型下不转发。
+2. **Vercel AI Gateway** — 支持 OpenAI 兼容端点，可代理 100+ 模型。Responses API 支持未明确文档化。
+3. **LiteLLM** — 确认支持 Responses API，可桥接 Anthropic Claude 和 Google Gemini。
+4. **Azure OpenAI** — 确认支持 Responses API（含 Foundry Models: DeepSeek、Grok）。
+
+**不可用方案**：
+- DeepSeek 原生 API（不支持 Responses API）
+- 降级旧版 Codex（`wire_api = "chat"` 已硬性废弃）
+
+**Codex 配置示例**（ZenMux）：
+```toml
+[model_providers.zenmux]
+name = "ZenMux"
+base_url = "https://zenmux.ai/api/v1"
+env_key = "ZENMUX_API_KEY"
+wire_api = "responses"
+```
 
 ### Cursor Agent CLI v2026.01.28 — 无法使用第三方模型
 
-完全锁定在 Cursor 基础设施。`--model` 只接受预置模型（gpt-5, sonnet-4 等），无 `--base-url` 或自定义 provider 配置。需要 Cursor 订阅才能认证。
+完全锁定在 Cursor 基础设施。`--model` 只接受预置模型（gpt-5, sonnet-4 等），无 `--base-url` 或自定义 provider 配置。
+
+**认证方式**：
+1. `agent login` — 浏览器交互式认证，token 存 OS keyring
+2. `CURSOR_API_KEY` 环境变量 — key 从 https://cursor.com/dashboard?tab=background-agents 获取
+3. `--api-key` 命令行参数
+
+**要求**：需要 Cursor 付费订阅（Pro $20/月起）。Free 计划 API key 不支持 Background Agent API。
 
 ## 产出
 
@@ -86,15 +107,44 @@ Go 语言构建的开源终端 agent（`sst/opencode`），原生支持 75+ prov
 
 ## 总结对比
 
-| CLI | DeepSeek | 配置难度 | 工具使用 | 推荐度 |
-|-----|----------|----------|----------|--------|
-| OpenCode | 原生支持 | 极简 | 正常 | ★★★★★ |
-| Claude Code | 通过 env vars | 中等 | 正常 | ★★★★ |
-| Codex CLI | 不可用 | - | - | ★ |
-| Cursor Agent | 不可能 | - | - | ✗ |
+| CLI | DeepSeek | 配置难度 | 工具使用 | E2E 方案 |
+|-----|----------|----------|----------|----------|
+| OpenCode | 原生支持 | 极简 | 正常 | `DEEPSEEK_API_KEY` |
+| Claude Code | 通过 env vars | 中等 | 正常 | `DEEPSEEK_API_KEY` |
+| Codex CLI | 需代理 (ZenMux) | 中等 | 正常 | `OPENAI_API_KEY` / `ZENMUX_API_KEY` |
+| Cursor Agent | 不可能 | - | - | `CURSOR_API_KEY`（付费） |
+
+## 安装方式验证（2026-02-12 官网确认）
+
+| CLI | 推荐安装方式 | 备选 | 命令 | 版本 |
+|-----|-------------|------|------|------|
+| Claude Code | `curl -fsSL https://claude.ai/install.sh \| bash` | `brew install --cask claude-code` | `claude` | 2.1.38 |
+| Codex CLI | `npm i -g @openai/codex` | `brew install --cask codex`、GitHub Release binary | `codex` | 0.98.0 |
+| Cursor Agent | `curl -fsS https://cursor.com/install \| bash` | - | `agent` / `cursor-agent` | 2026.01.28 |
+| OpenCode | `curl -fsSL https://opencode.ai/install \| bash` | `npm i -g opencode-ai@latest`、`brew install anomalyco/tap/opencode` | `opencode` | 1.1.59 |
+
+**注意**：
+- Cursor CLI 命令已改为 `agent`（`cursor-agent` 仍然兼容，指向同一 binary）
+- Claude Code npm 安装已废弃，`npm i -g @anthropic-ai/claude-code` 仍可用但不推荐
+- Codex CLI 也提供了 GitHub Release 的 binary 下载
+
+## E2E 测试方案
+
+| Backend | 模型/Provider | 认证 | 状态 |
+|---------|--------------|------|------|
+| Claude Code | DeepSeek via `ANTHROPIC_BASE_URL` | `DEEPSEEK_API_KEY` | 可用但从 claude session 内运行会挂起 |
+| OpenCode | `deepseek/deepseek-chat` | `DEEPSEEK_API_KEY` | 可用 |
+| Codex CLI | OpenAI 或 ZenMux 代理 | `OPENAI_API_KEY` 或 `ZENMUX_API_KEY` | 需要测试 |
+| Cursor Agent | Cursor 预置模型 | `CURSOR_API_KEY`（付费） | 需要测试 |
+
+**文件**：
+- `packages/agent-worker/scripts/e2e-setup.sh` — CLI 安装和环境检查
+- `packages/agent-worker/test/e2e/backends.test.ts` — 真实 API E2E 测试
+- `bun run test:e2e` — 运行 E2E 测试
+- `bun run e2e:setup` — 安装和检查环境
 
 ## 待调研
 
-- LiteLLM 代理方案 — 为 Codex CLI 提供 Responses API 翻译
+- ~~LiteLLM 代理方案 — 为 Codex CLI 提供 Responses API 翻译~~ → ZenMux 已确认可用
 - OpenRouter — 统一 API 代理
 - OpenCode 高级功能 — MCP 集成、multi-agent、LSP

--- a/.memory/notes/2026-02-12-cli-third-party-model-research.md
+++ b/.memory/notes/2026-02-12-cli-third-party-model-research.md
@@ -120,11 +120,11 @@ Go 语言构建的开源终端 agent（`sst/opencode`），原生支持 75+ prov
 |-----|-------------|------|------|------|
 | Claude Code | `curl -fsSL https://claude.ai/install.sh \| bash` | `brew install --cask claude-code` | `claude` | 2.1.38 |
 | Codex CLI | `npm i -g @openai/codex` | `brew install --cask codex`、GitHub Release binary | `codex` | 0.98.0 |
-| Cursor Agent | `curl -fsS https://cursor.com/install \| bash` | - | `agent` / `cursor-agent` | 2026.01.28 |
+| Cursor Agent | `curl -fsS https://cursor.com/install \| bash` | - | `agent` / `cursor agent` | 2026.01.28 |
 | OpenCode | `curl -fsSL https://opencode.ai/install \| bash` | `npm i -g opencode-ai@latest`、`brew install anomalyco/tap/opencode` | `opencode` | 1.1.59 |
 
 **注意**：
-- Cursor CLI 命令已改为 `agent`（`cursor-agent` 仍然兼容，指向同一 binary）
+- Cursor CLI 命令已改为 `agent`（`cursor agent` 子命令仍然兼容）
 - Claude Code npm 安装已废弃，`npm i -g @anthropic-ai/claude-code` 仍可用但不推荐
 - Codex CLI 也提供了 GitHub Release 的 binary 下载
 

--- a/.memory/notes/2026-02-12-cli-third-party-model-research.md
+++ b/.memory/notes/2026-02-12-cli-third-party-model-research.md
@@ -109,10 +109,10 @@ Go 语言构建的开源终端 agent（`sst/opencode`），原生支持 75+ prov
 
 | CLI | DeepSeek | 配置难度 | 工具使用 | E2E 方案 |
 |-----|----------|----------|----------|----------|
-| OpenCode | 原生支持 | 极简 | 正常 | `DEEPSEEK_API_KEY` |
-| Claude Code | 通过 env vars | 中等 | 正常 | `DEEPSEEK_API_KEY` |
-| Codex CLI | 需代理 (ZenMux) | 中等 | 正常 | `OPENAI_API_KEY` / `ZENMUX_API_KEY` |
-| Cursor Agent | 不可能 | - | - | `CURSOR_API_KEY`（付费） |
+| OpenCode | 原生支持 | 极简 | 正常 | `DEEPSEEK_API_KEY` → deepseek/deepseek-chat |
+| Claude Code | 通过 env vars | 中等 | 正常 | `DEEPSEEK_API_KEY` → deepseek-chat |
+| Codex CLI | 需代理 | 中等 | 正常 | `AI_GATEWAY_API_KEY` → Vercel AI Gateway → google/gemini-2.0-flash |
+| Cursor Agent | 不可能 | - | - | `CURSOR_API_KEY`（付费）→ composer-1 |
 
 ## 安装方式验证（2026-02-12 官网确认）
 
@@ -130,12 +130,21 @@ Go 语言构建的开源终端 agent（`sst/opencode`），原生支持 75+ prov
 
 ## E2E 测试方案
 
-| Backend | 模型/Provider | 认证 | 状态 |
-|---------|--------------|------|------|
-| Claude Code | DeepSeek via `ANTHROPIC_BASE_URL` | `DEEPSEEK_API_KEY` | 可用但从 claude session 内运行会挂起 |
-| OpenCode | `deepseek/deepseek-chat` | `DEEPSEEK_API_KEY` | 可用 |
-| Codex CLI | OpenAI 或 ZenMux 代理 | `OPENAI_API_KEY` 或 `ZENMUX_API_KEY` | 需要测试 |
-| Cursor Agent | Cursor 预置模型 | `CURSOR_API_KEY`（付费） | 需要测试 |
+| Backend | 模型 | 认证 env var | 价格 | 状态 |
+|---------|------|-------------|------|------|
+| Claude Code | deepseek-chat | `DEEPSEEK_API_KEY` | $0.14/$0.28 per M | 可用（从 claude session 内运行会挂起） |
+| OpenCode | deepseek/deepseek-chat | `DEEPSEEK_API_KEY` | $0.14/$0.28 per M | **已验证通过** |
+| Codex CLI | google/gemini-2.0-flash | `AI_GATEWAY_API_KEY` | $0.10/$0.40 per M | 需要测试 |
+| Cursor Agent | composer-1 | `CURSOR_API_KEY` | Cursor 订阅 | 需要测试 |
+
+**Codex 代理选择**：Vercel AI Gateway（非 ZenMux）
+- Responses API 首批官方合作伙伴
+- 每月 $5 免费额度
+- 0% 加价（BYOK）
+- Gemini 2.0 Flash 价格接近 DeepSeek：$0.10/M input, $0.40/M output
+- 支持 tool calling、structured outputs
+
+**Cursor 模型选择**：composer-1（Cursor 自有模型）
 
 **文件**：
 - `packages/agent-worker/scripts/e2e-setup.sh` — CLI 安装和环境检查
@@ -145,6 +154,4 @@ Go 语言构建的开源终端 agent（`sst/opencode`），原生支持 75+ prov
 
 ## 待调研
 
-- ~~LiteLLM 代理方案 — 为 Codex CLI 提供 Responses API 翻译~~ → ZenMux 已确认可用
-- OpenRouter — 统一 API 代理
 - OpenCode 高级功能 — MCP 集成、multi-agent、LSP

--- a/.memory/notes/2026-02-12-cli-third-party-model-research.md
+++ b/.memory/notes/2026-02-12-cli-third-party-model-research.md
@@ -1,0 +1,100 @@
+# CLI Agent 第三方模型调研
+
+日期：2026-02-12
+会话：setup-local-claude-cli
+
+## 背景
+
+调研主流 CLI agent 工具（Claude Code、Codex CLI、Cursor Agent CLI）使用第三方模型（DeepSeek）的可行性。npm 安装方式已废弃，Claude Code 改用独立安装脚本。
+
+## 发现
+
+### Claude Code v2.1.39 — 可用
+
+DeepSeek 提供了 Anthropic 兼容端点 `https://api.deepseek.com/anthropic`，Claude Code 通过 `ANTHROPIC_BASE_URL` 环境变量即可指向。
+
+**验证结果**：
+- API 调用成功（debug 日志确认 `Stream started - received first chunk`）
+- 工具使用正常：TodoWrite, Read, Bash, Glob, Skill 全部工作
+- 每次 API 往返 ~3 秒
+- `--print` 模式下，CLAUDE.md 指令会触发大量 agent 操作，导致简单提示需要 2-3 分钟才输出
+
+**关键 env vars**：
+- `ANTHROPIC_BASE_URL` → `https://api.deepseek.com/anthropic`
+- `ANTHROPIC_AUTH_TOKEN` → DeepSeek API key
+- `ANTHROPIC_API_KEY` → `""` （防止冲突）
+- `ANTHROPIC_MODEL` → `deepseek-chat`
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` → `1`
+
+**安装方式变更**：
+- 旧：`npm i -g @anthropic-ai/claude-code`（已废弃）
+- 新：`curl -fsSL https://claude.ai/install.sh | bash`（下载到 `~/.local/bin/claude`）
+- 本项目：下载 standalone binary 到 `.local/bin/claude-bin`，用 wrapper 脚本配置
+
+**已知限制**：DeepSeek 不支持 image inputs、MCP tools、web search。
+
+### Codex CLI v0.98.0 — 不可用
+
+`wire_api = "chat"`（Chat Completions API）已被废弃，必须用 `wire_api = "responses"`（OpenAI Responses API）。DeepSeek 的 `/v1/responses` 返回 404。
+
+**变通方案**：
+1. LiteLLM/ZenMux 代理翻译 Responses → Chat Completions
+2. 降级到旧版 Codex（仍支持 chat wire_api）
+3. 等 DeepSeek 支持 Responses API
+
+### Cursor Agent CLI v2026.01.28 — 无法使用第三方模型
+
+完全锁定在 Cursor 基础设施。`--model` 只接受预置模型（gpt-5, sonnet-4 等），无 `--base-url` 或自定义 provider 配置。需要 Cursor 订阅才能认证。
+
+## 产出
+
+- `.local/bin/claude-ds` — DeepSeek 后端 wrapper（含自动下载）
+- `.local/bin/claude-local` — 通用 wrapper
+- `.local/README.md` — 完整文档
+- `.gitignore` 中排除了 213MB 的 binary
+
+### OpenCode v1.1.59 — 最佳选择
+
+Go 语言构建的开源终端 agent（`sst/opencode`），原生支持 75+ providers，包括 DeepSeek。
+
+**验证结果**：
+- `deepseek-chat` 和 `deepseek-reasoner` 均即开即用
+- 纯文本回复 ~3 秒、工具使用（bash 命令）正常
+- 配置极简：只需 `opencode.json` + `DEEPSEEK_API_KEY` 环境变量
+- 支持 `opencode run` 非交互模式 + TUI 交互模式
+
+**对比 Claude Code 的优势**：
+- 原生多 provider，不需要 hack env vars
+- Go 二进制启动快，无 Node.js 依赖
+- 配置文件 JSON 格式，清晰直观
+- 活跃社区（100k+ stars，GitHub 合作伙伴）
+
+**配置示例**（`opencode.json`）：
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "deepseek": {
+      "options": { "apiKey": "{env:DEEPSEEK_API_KEY}" }
+    }
+  },
+  "model": "deepseek/deepseek-chat"
+}
+```
+
+**安装**：`npm i -g opencode-ai@latest` 或 `curl -fsSL https://opencode.ai/install | bash`
+
+## 总结对比
+
+| CLI | DeepSeek | 配置难度 | 工具使用 | 推荐度 |
+|-----|----------|----------|----------|--------|
+| OpenCode | 原生支持 | 极简 | 正常 | ★★★★★ |
+| Claude Code | 通过 env vars | 中等 | 正常 | ★★★★ |
+| Codex CLI | 不可用 | - | - | ★ |
+| Cursor Agent | 不可能 | - | - | ✗ |
+
+## 待调研
+
+- LiteLLM 代理方案 — 为 Codex CLI 提供 Responses API 翻译
+- OpenRouter — 统一 API 代理
+- OpenCode 高级功能 — MCP 集成、multi-agent、LSP

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "deepseek": {
+      "options": {
+        "apiKey": "{env:DEEPSEEK_API_KEY}"
+      }
+    }
+  },
+  "model": "deepseek/deepseek-chat"
+}

--- a/packages/agent-worker/CHANGELOG.md
+++ b/packages/agent-worker/CHANGELOG.md
@@ -255,6 +255,6 @@
   - `sdk`: Vercel AI SDK (default)
   - `claude`: Claude Code CLI (`claude -p` for non-interactive mode)
   - `codex`: OpenAI Codex CLI (`codex exec`)
-  - `cursor`: Cursor Agent CLI (`cursor-agent -p`)
+  - `cursor`: Cursor Agent CLI (`cursor agent -p`)
   - New `agent-worker backends` command to check CLI tool availability
   - Unified model specification across all backends with `createBackend()`

--- a/packages/agent-worker/CHANGELOG.md
+++ b/packages/agent-worker/CHANGELOG.md
@@ -60,7 +60,7 @@
 
   **New Providers & Capabilities:**
 
-  - **Minimax CN Provider**: Added `minimax_cn` provider with dedicated `MINIMAX_CN_API_KEY` environment variable support
+  - **MiniMax Base URL Override**: MiniMax provider now supports `MINIMAX_BASE_URL` env var for CN endpoint (`https://api.minimaxi.com/anthropic/v1`)
   - **Scheduled Wakeup**: Agent sessions can now be scheduled to wake up at specific times using cron expressions
   - **Project-local Context**: Support for project-local context directories via `--context-dir` flag
 

--- a/packages/agent-worker/docs/backends.md
+++ b/packages/agent-worker/docs/backends.md
@@ -203,11 +203,21 @@ npm i -g @openai/codex
 # Or: brew install --cask codex
 
 # Required env — Codex requires Responses API (wire_api="responses")
-# Option 1: OpenAI directly
+# Option 1: Vercel AI Gateway (recommended — $0.10/$0.40 per M tokens, $5/month free)
+export AI_GATEWAY_API_KEY="..."
+# E2E model: google/gemini-2.0-flash (cheapest with full tool use support)
+# Option 2: OpenAI directly
 export OPENAI_API_KEY="sk-..."
-# Option 2: ZenMux proxy (supports Responses API, bridges to other providers)
-export ZENMUX_API_KEY="..."
-# Note: DeepSeek not directly compatible (no Responses API support)
+# Note: DeepSeek not compatible (no Responses API support)
+
+# ~/.codex/config.toml for Vercel AI Gateway:
+# model = "google/gemini-2.0-flash"
+# model_provider = "vercel"
+# [model_providers.vercel]
+# name = "Vercel AI Gateway"
+# base_url = "https://ai-gateway.vercel.sh/v1"
+# env_key = "AI_GATEWAY_API_KEY"
+# wire_api = "responses"
 ```
 
 ### Cursor Agent

--- a/packages/agent-worker/docs/backends.md
+++ b/packages/agent-worker/docs/backends.md
@@ -46,9 +46,9 @@ getBackendByType() → Backend
          └── buildCommand → execa(command, args, { cwd, stdin: 'ignore', timeout })
 ```
 
-### Cursor (`cursor-agent`)
+### Cursor (`cursor agent`)
 
-**Command**: `cursor-agent -p --force --approve-mcps <message> [--model <model>]`
+**Command**: `cursor agent -p --force --approve-mcps <message> [--model <model>]`
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -61,7 +61,7 @@ getBackendByType() → Backend
 **Model map**: `sonnet` → `sonnet-4.5`, `opus` → `opus-4.5`, `claude-sonnet-4-5` → `sonnet-4.5`
 
 **Gotchas**:
-- stdin must be `'ignore'` — cursor-agent hangs otherwise
+- stdin must be `'ignore'` — cursor agent hangs otherwise
 - No system prompt flag; embedded in message
 - Timeout is idle-based: resets whenever the process produces output
 - Response is plain text only
@@ -150,7 +150,7 @@ agents:
 
 | Feature | Cursor | Claude | Codex | OpenCode | Mock |
 |---------|--------|--------|-------|----------|------|
-| Command | `cursor-agent` | `claude` | `codex exec` | `opencode run` | (in-process) |
+| Command | `cursor agent` | `claude` | `codex exec` | `opencode run` | (in-process) |
 | Auto-approval | `--force --approve-mcps` | `--dangerously-skip-permissions` | `--full-auto` | (auto in run mode) | N/A |
 | MCP config format | JSON | JSON | YAML | JSON | Direct socket |
 | MCP config location | `.cursor/mcp.json` | `--mcp-config <path>` | `.codex/config.yaml` | `opencode.json` | N/A |
@@ -222,7 +222,7 @@ export OPENAI_API_KEY="sk-..."
 
 ### Cursor Agent
 ```bash
-# Install (command installs as `agent`, also available as `cursor-agent`)
+# Install (command installs as `agent`, also available as `cursor agent`)
 curl -fsS https://cursor.com/install | bash
 
 # Required env — get key from https://cursor.com/dashboard?tab=background-agents

--- a/packages/agent-worker/docs/backends.md
+++ b/packages/agent-worker/docs/backends.md
@@ -182,40 +182,55 @@ Each backend needs specific installation and configuration before E2E tests can 
 
 ### Claude Code
 ```bash
-# Install (standalone binary)
+# Install (recommended — auto-updates)
 curl -fsSL https://claude.ai/install.sh | bash
-# Or download directly
-GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
-VERSION=$(curl -fsSL "$GCS_BUCKET/latest")
-curl -fsSL "$GCS_BUCKET/$VERSION/linux-x64/claude" -o ~/.local/bin/claude && chmod +x ~/.local/bin/claude
+# Or: brew install --cask claude-code
 
-# Required env
+# Required env (native Anthropic)
 export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Alternative: use DeepSeek via Anthropic-compatible endpoint
+export ANTHROPIC_BASE_URL="https://api.deepseek.com/anthropic"
+export ANTHROPIC_AUTH_TOKEN="$DEEPSEEK_API_KEY"
+export ANTHROPIC_API_KEY=""
+export ANTHROPIC_MODEL="deepseek-chat"
 ```
 
 ### Codex CLI
 ```bash
+# Install
 npm i -g @openai/codex
-# Required env
+# Or: brew install --cask codex
+
+# Required env — Codex requires Responses API (wire_api="responses")
+# Option 1: OpenAI directly
 export OPENAI_API_KEY="sk-..."
+# Option 2: ZenMux proxy (supports Responses API, bridges to other providers)
+export ZENMUX_API_KEY="..."
+# Note: DeepSeek not directly compatible (no Responses API support)
 ```
 
 ### Cursor Agent
 ```bash
-curl -fsSL https://cursor.com/install | bash
-# Required env
-export CURSOR_API_KEY="..."  # or run: cursor-agent login
+# Install (command installs as `agent`, also available as `cursor-agent`)
+curl -fsS https://cursor.com/install | bash
+
+# Required env — get key from https://cursor.com/dashboard?tab=background-agents
+export CURSOR_API_KEY="sk_..."
+# Or authenticate interactively: agent login
+# Note: Requires paid Cursor subscription (Pro $20/month minimum)
+# Note: Cursor is locked to its own infrastructure, no third-party model support
 ```
 
 ### OpenCode
 ```bash
-npm i -g opencode-ai@latest
-# Or: curl -fsSL https://opencode.ai/install | bash
+# Install (recommended — auto-updates)
+curl -fsSL https://opencode.ai/install | bash
+# Or: npm i -g opencode-ai@latest
+# Or: brew install anomalyco/tap/opencode
 
 # Required env (for DeepSeek provider)
 export DEEPSEEK_API_KEY="sk-..."
-# Or for Anthropic provider
-export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
 ### Quick availability check

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -21,7 +21,9 @@
   "scripts": {
     "dev": "tsdown --watch",
     "build": "tsdown",
-    "test": "bun test",
+    "test": "bun test test/*.test.ts test/unit/",
+    "test:e2e": "bun test test/e2e/",
+    "e2e:setup": "bash scripts/e2e-setup.sh",
     "lint": "oxlint src",
     "lint:fix": "oxlint src --fix",
     "format": "oxfmt src",

--- a/packages/agent-worker/scripts/e2e-setup.sh
+++ b/packages/agent-worker/scripts/e2e-setup.sh
@@ -135,12 +135,13 @@ else
   warn "DEEPSEEK_API_KEY not set — Claude Code and OpenCode E2E tests will be skipped"
 fi
 
-if [[ -n "${OPENAI_API_KEY:-}" ]]; then
-  ok "OPENAI_API_KEY set (for Codex E2E)"
-elif [[ -n "${ZENMUX_API_KEY:-}" ]]; then
-  ok "ZENMUX_API_KEY set (for Codex E2E via ZenMux proxy)"
+if [[ -n "${AI_GATEWAY_API_KEY:-}" ]]; then
+  ok "AI_GATEWAY_API_KEY set (for Codex E2E via Vercel AI Gateway → Gemini 2.0 Flash)"
+elif [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  ok "OPENAI_API_KEY set (for Codex E2E via OpenAI directly)"
 else
-  warn "OPENAI_API_KEY / ZENMUX_API_KEY not set — Codex E2E tests will be skipped"
+  warn "AI_GATEWAY_API_KEY / OPENAI_API_KEY not set — Codex E2E tests will be skipped"
+  echo "       Get Vercel AI Gateway key from: https://vercel.com/docs/ai-gateway"
 fi
 
 if [[ -n "${CURSOR_API_KEY:-}" ]]; then

--- a/packages/agent-worker/scripts/e2e-setup.sh
+++ b/packages/agent-worker/scripts/e2e-setup.sh
@@ -80,13 +80,13 @@ fi
 # ─── Cursor Agent ─────────────────────────────────────────────
 echo ""
 echo "=== Cursor Agent ==="
-if command -v agent &>/dev/null || command -v cursor-agent &>/dev/null; then
-  CMD=$(command -v agent 2>/dev/null || command -v cursor-agent 2>/dev/null)
+if command -v agent &>/dev/null || command -v cursor &>/dev/null; then
+  CMD=$(command -v agent 2>/dev/null || command -v cursor 2>/dev/null)
   VERSION=$($CMD --version 2>/dev/null || echo "unknown")
   ok "cursor agent installed: $VERSION ($(basename $CMD))"
   ((AVAILABLE++))
 elif [[ "$CHECK_ONLY" == true ]]; then
-  fail "cursor agent not found (tried: agent, cursor-agent)"
+  fail "cursor agent not found (tried: agent, cursor)"
   ((MISSING++))
 else
   echo "Installing Cursor Agent..."

--- a/packages/agent-worker/scripts/e2e-setup.sh
+++ b/packages/agent-worker/scripts/e2e-setup.sh
@@ -80,19 +80,18 @@ fi
 # ─── Cursor Agent ─────────────────────────────────────────────
 echo ""
 echo "=== Cursor Agent ==="
-if command -v agent &>/dev/null || command -v cursor &>/dev/null; then
-  CMD=$(command -v agent 2>/dev/null || command -v cursor 2>/dev/null)
-  VERSION=$($CMD --version 2>/dev/null || echo "unknown")
-  ok "cursor agent installed: $VERSION ($(basename $CMD))"
+if command -v cursor &>/dev/null && cursor agent --version &>/dev/null 2>&1; then
+  VERSION=$(cursor agent --version 2>/dev/null || echo "unknown")
+  ok "cursor agent installed: $VERSION"
   ((AVAILABLE++))
 elif [[ "$CHECK_ONLY" == true ]]; then
-  fail "cursor agent not found (tried: agent, cursor)"
+  fail "cursor agent not found"
   ((MISSING++))
 else
   echo "Installing Cursor Agent..."
   curl -fsS https://cursor.com/install | bash
-  if command -v agent &>/dev/null; then
-    ok "cursor agent installed: $(agent --version 2>/dev/null)"
+  if command -v cursor &>/dev/null && cursor agent --version &>/dev/null 2>&1; then
+    ok "cursor agent installed: $(cursor agent --version 2>/dev/null)"
     ((AVAILABLE++))
   else
     fail "cursor agent installation failed"

--- a/packages/agent-worker/scripts/e2e-setup.sh
+++ b/packages/agent-worker/scripts/e2e-setup.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# E2E Backend Setup — install and verify all CLI backends
+#
+# Usage:
+#   ./scripts/e2e-setup.sh           # Install missing CLIs + check env vars
+#   ./scripts/e2e-setup.sh --check   # Check only, don't install
+#
+# Required env vars (set before running):
+#   DEEPSEEK_API_KEY   — for Claude Code (via DeepSeek) and OpenCode
+#   OPENAI_API_KEY     — for Codex CLI (optional, skipped if missing)
+#   CURSOR_API_KEY     — for Cursor Agent (optional, skipped if missing)
+
+set -uo pipefail
+
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=true
+fi
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+ok()   { printf "${GREEN}[OK]${NC}   %s\n" "$1"; }
+warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+fail() { printf "${RED}[FAIL]${NC} %s\n" "$1"; }
+
+MISSING=0
+AVAILABLE=0
+
+# ─── Claude Code ──────────────────────────────────────────────
+echo ""
+echo "=== Claude Code ==="
+if command -v claude &>/dev/null; then
+  VERSION=$(claude --version 2>/dev/null || echo "unknown")
+  ok "claude installed: $VERSION"
+  ((AVAILABLE++))
+elif [[ "$CHECK_ONLY" == true ]]; then
+  fail "claude not found"
+  ((MISSING++))
+else
+  echo "Installing Claude Code..."
+  curl -fsSL https://claude.ai/install.sh | bash
+  if command -v claude &>/dev/null; then
+    ok "claude installed: $(claude --version 2>/dev/null)"
+    ((AVAILABLE++))
+  else
+    fail "claude installation failed"
+    ((MISSING++))
+  fi
+fi
+
+# ─── Codex CLI ────────────────────────────────────────────────
+echo ""
+echo "=== Codex CLI ==="
+if command -v codex &>/dev/null; then
+  VERSION=$(codex --version 2>/dev/null || echo "unknown")
+  ok "codex installed: $VERSION"
+  ((AVAILABLE++))
+elif [[ "$CHECK_ONLY" == true ]]; then
+  fail "codex not found"
+  ((MISSING++))
+else
+  echo "Installing Codex CLI..."
+  npm i -g @openai/codex 2>/dev/null || {
+    warn "npm install failed, trying brew..."
+    brew install --cask codex 2>/dev/null || {
+      fail "codex installation failed"
+      ((MISSING++))
+    }
+  }
+  if command -v codex &>/dev/null; then
+    ok "codex installed: $(codex --version 2>/dev/null)"
+    ((AVAILABLE++))
+  fi
+fi
+
+# ─── Cursor Agent ─────────────────────────────────────────────
+echo ""
+echo "=== Cursor Agent ==="
+if command -v agent &>/dev/null || command -v cursor-agent &>/dev/null; then
+  CMD=$(command -v agent 2>/dev/null || command -v cursor-agent 2>/dev/null)
+  VERSION=$($CMD --version 2>/dev/null || echo "unknown")
+  ok "cursor agent installed: $VERSION ($(basename $CMD))"
+  ((AVAILABLE++))
+elif [[ "$CHECK_ONLY" == true ]]; then
+  fail "cursor agent not found (tried: agent, cursor-agent)"
+  ((MISSING++))
+else
+  echo "Installing Cursor Agent..."
+  curl -fsS https://cursor.com/install | bash
+  if command -v agent &>/dev/null; then
+    ok "cursor agent installed: $(agent --version 2>/dev/null)"
+    ((AVAILABLE++))
+  else
+    fail "cursor agent installation failed"
+    ((MISSING++))
+  fi
+fi
+
+# ─── OpenCode ─────────────────────────────────────────────────
+echo ""
+echo "=== OpenCode ==="
+if command -v opencode &>/dev/null; then
+  VERSION=$(opencode --version 2>/dev/null || echo "unknown")
+  ok "opencode installed: $VERSION"
+  ((AVAILABLE++))
+elif [[ "$CHECK_ONLY" == true ]]; then
+  fail "opencode not found"
+  ((MISSING++))
+else
+  echo "Installing OpenCode..."
+  curl -fsSL https://opencode.ai/install | bash 2>/dev/null || {
+    warn "curl install failed, trying npm..."
+    npm i -g opencode-ai@latest 2>/dev/null || {
+      fail "opencode installation failed"
+      ((MISSING++))
+    }
+  }
+  if command -v opencode &>/dev/null; then
+    ok "opencode installed: $(opencode --version 2>/dev/null)"
+    ((AVAILABLE++))
+  fi
+fi
+
+# ─── Environment Variables ────────────────────────────────────
+echo ""
+echo "=== Environment Variables ==="
+
+if [[ -n "${DEEPSEEK_API_KEY:-}" ]]; then
+  ok "DEEPSEEK_API_KEY set (for Claude Code + OpenCode E2E)"
+else
+  warn "DEEPSEEK_API_KEY not set — Claude Code and OpenCode E2E tests will be skipped"
+fi
+
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  ok "OPENAI_API_KEY set (for Codex E2E)"
+elif [[ -n "${ZENMUX_API_KEY:-}" ]]; then
+  ok "ZENMUX_API_KEY set (for Codex E2E via ZenMux proxy)"
+else
+  warn "OPENAI_API_KEY / ZENMUX_API_KEY not set — Codex E2E tests will be skipped"
+fi
+
+if [[ -n "${CURSOR_API_KEY:-}" ]]; then
+  ok "CURSOR_API_KEY set (for Cursor E2E — requires paid Cursor subscription)"
+else
+  warn "CURSOR_API_KEY not set — Cursor E2E tests will be skipped"
+  echo "       Get key from: https://cursor.com/dashboard?tab=background-agents"
+fi
+
+# ─── Summary ──────────────────────────────────────────────────
+echo ""
+echo "=== Summary ==="
+echo "CLIs available: $AVAILABLE/4"
+if [[ $MISSING -gt 0 ]]; then
+  echo "CLIs missing:   $MISSING"
+fi
+echo ""
+echo "To run E2E tests:"
+echo "  bun test test/e2e/"

--- a/packages/agent-worker/src/agent/config.ts
+++ b/packages/agent-worker/src/agent/config.ts
@@ -6,16 +6,19 @@
  */
 
 import type { BackendType } from "../backends/types.ts";
+import type { ProviderConfig } from "../workflow/types.ts";
 
 export interface AgentConfig {
   /** Agent name (unique within daemon) */
   name: string;
-  /** Model identifier (e.g., 'anthropic/claude-sonnet-4-5') */
+  /** Model identifier (e.g., 'anthropic/claude-sonnet-4-5' or just 'MiniMax-M2.5' when provider is set) */
   model: string;
   /** System prompt */
   system: string;
   /** Backend type */
   backend: BackendType;
+  /** Provider configuration — string (built-in) or object (custom endpoint) */
+  provider?: string | ProviderConfig;
   /** Workflow this agent belongs to */
   workflow: string;
   /** Workflow instance tag */

--- a/packages/agent-worker/src/agent/handle.ts
+++ b/packages/agent-worker/src/agent/handle.ts
@@ -50,6 +50,7 @@ export class LocalWorker implements WorkerHandle {
         system: config.system,
         tools: {},
         backend,
+        provider: config.provider,
       },
       restore,
     );

--- a/packages/agent-worker/src/agent/models.ts
+++ b/packages/agent-worker/src/agent/models.ts
@@ -243,6 +243,6 @@ export const FRONTIER_MODELS = {
   groq: ["meta-llama/llama-4-scout-17b-16e-instruct", "deepseek-r1-distill-llama-70b"],
   mistral: ["mistral-large-latest", "pixtral-large-latest", "magistral-medium-2506"],
   xai: ["grok-4", "grok-4-fast-reasoning"],
-  minimax: ["MiniMax-M2"],
+  minimax: ["MiniMax-M2.5", "MiniMax-M2"],
   glm: ["glm-5", "glm-4.7"],
 } as const;

--- a/packages/agent-worker/src/agent/models.ts
+++ b/packages/agent-worker/src/agent/models.ts
@@ -159,17 +159,13 @@ export async function createModelAsync(modelId: string): Promise<LanguageModel> 
     mistral: { package: "@ai-sdk/mistral", export: "mistral" },
     xai: { package: "@ai-sdk/xai", export: "xai" },
     // MiniMax uses Claude-compatible API
+    // Set MINIMAX_BASE_URL to override (e.g., "https://api.minimaxi.com/anthropic/v1" for CN)
     minimax: {
       package: "@ai-sdk/anthropic",
       export: "anthropic",
-      options: { baseURL: "https://api.minimax.io/anthropic/v1", apiKeyEnvVar: "MINIMAX_API_KEY" },
-    },
-    minimax_cn: {
-      package: "@ai-sdk/anthropic",
-      export: "anthropic",
       options: {
-        baseURL: "https://api.minimaxi.com/anthropic/v1",
-        apiKeyEnvVar: "MINIMAX_CN_API_KEY",
+        baseURL: process.env.MINIMAX_BASE_URL || "https://api.minimax.io/anthropic/v1",
+        apiKeyEnvVar: "MINIMAX_API_KEY",
       },
     },
   };

--- a/packages/agent-worker/src/agent/models.ts
+++ b/packages/agent-worker/src/agent/models.ts
@@ -159,12 +159,12 @@ export async function createModelAsync(modelId: string): Promise<LanguageModel> 
     mistral: { package: "@ai-sdk/mistral", export: "mistral" },
     xai: { package: "@ai-sdk/xai", export: "xai" },
     // MiniMax uses Claude-compatible API
-    // Set MINIMAX_BASE_URL to override (e.g., "https://api.minimaxi.com/anthropic/v1" for CN)
+    // Set MINIMAX_BASE_URL to override (e.g., "https://api.minimaxi.com" for CN)
     minimax: {
       package: "@ai-sdk/anthropic",
       export: "anthropic",
       options: {
-        baseURL: process.env.MINIMAX_BASE_URL || "https://api.minimax.io/anthropic/v1",
+        baseURL: `${(process.env.MINIMAX_BASE_URL || "https://api.minimax.io").replace(/\/+$/, "")}/anthropic/v1`,
         apiKeyEnvVar: "MINIMAX_API_KEY",
       },
     },

--- a/packages/agent-worker/src/agent/models.ts
+++ b/packages/agent-worker/src/agent/models.ts
@@ -168,6 +168,16 @@ export async function createModelAsync(modelId: string): Promise<LanguageModel> 
         apiKeyEnvVar: "MINIMAX_API_KEY",
       },
     },
+    // GLM (Zhipu) uses Claude-compatible API
+    // Set GLM_BASE_URL to override (default: "https://open.bigmodel.cn")
+    glm: {
+      package: "@ai-sdk/anthropic",
+      export: "anthropic",
+      options: {
+        baseURL: `${(process.env.GLM_BASE_URL || "https://open.bigmodel.cn").replace(/\/+$/, "")}/api/anthropic/v1`,
+        apiKeyEnvVar: "GLM_API_KEY",
+      },
+    },
   };
 
   const config = providerConfigs[provider];
@@ -189,7 +199,7 @@ export async function createModelAsync(modelId: string): Promise<LanguageModel> 
 
 /**
  * List of supported providers for direct access
- * Note: minimax uses Claude-compatible API via @ai-sdk/anthropic with custom baseURL
+ * Note: minimax and glm use Claude-compatible API via @ai-sdk/anthropic with custom baseURL
  */
 export const SUPPORTED_PROVIDERS = [
   "anthropic",
@@ -200,6 +210,7 @@ export const SUPPORTED_PROVIDERS = [
   "mistral",
   "xai",
   "minimax",
+  "glm",
 ] as const;
 
 export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
@@ -233,4 +244,5 @@ export const FRONTIER_MODELS = {
   mistral: ["mistral-large-latest", "pixtral-large-latest", "magistral-medium-2506"],
   xai: ["grok-4", "grok-4-fast-reasoning"],
   minimax: ["MiniMax-M2"],
+  glm: ["glm-5", "glm-4.7"],
 } as const;

--- a/packages/agent-worker/src/backends/idle-timeout.ts
+++ b/packages/agent-worker/src/backends/idle-timeout.ts
@@ -50,7 +50,7 @@ export async function execWithIdleTimeout(options: IdleTimeoutOptions): Promise<
   let isAborted = false;
 
   // IMPORTANT: stdin must be 'ignore' to prevent CLI agents from hanging
-  // See: https://forum.cursor.com/t/node-js-spawn-with-cursor-agent-hangs-and-exits-with-code-143-after-timeout/133709
+  // See: https://forum.cursor.com/t/node-js-spawn-with-cursor-agent-hangs/133709
   const subprocess: ResultPromise = execa(command, args, {
     cwd,
     stdin: "ignore",

--- a/packages/agent-worker/src/backends/index.ts
+++ b/packages/agent-worker/src/backends/index.ts
@@ -59,7 +59,11 @@ export function createBackend(
   switch (normalized.type) {
     case "default": {
       const provider = (normalized as { provider?: string | ProviderConfig }).provider;
-      return new SdkBackend({ model, maxTokens: (normalized as { maxTokens?: number }).maxTokens, provider });
+      return new SdkBackend({
+        model,
+        maxTokens: (normalized as { maxTokens?: number }).maxTokens,
+        provider,
+      });
     }
     case "claude":
       return new ClaudeCodeBackend({

--- a/packages/agent-worker/src/backends/index.ts
+++ b/packages/agent-worker/src/backends/index.ts
@@ -24,6 +24,7 @@ export {
 export { opencodeAdapter, extractOpenCodeResult } from "./opencode.ts";
 
 import type { Backend, BackendType } from "./types.ts";
+import type { ProviderConfig } from "../workflow/types.ts";
 import { getModelForBackend, normalizeBackendType } from "./model-maps.ts";
 import { ClaudeCodeBackend, type ClaudeCodeOptions } from "./claude-code.ts";
 import { CodexBackend, type CodexOptions } from "./codex.ts";
@@ -32,7 +33,7 @@ import { OpenCodeBackend, type OpenCodeOptions } from "./opencode.ts";
 import { SdkBackend } from "./sdk.ts";
 
 export type BackendOptions =
-  | { type: "default"; model?: string; maxTokens?: number }
+  | { type: "default"; model?: string; maxTokens?: number; provider?: string | ProviderConfig }
   | { type: "claude"; model?: string; options?: Omit<ClaudeCodeOptions, "model"> }
   | { type: "codex"; model?: string; options?: Omit<CodexOptions, "model"> }
   | { type: "cursor"; model?: string; options?: Omit<CursorOptions, "model"> }
@@ -56,8 +57,10 @@ export function createBackend(
   const model = getModelForBackend(normalized.model, normalized.type);
 
   switch (normalized.type) {
-    case "default":
-      return new SdkBackend({ model, maxTokens: (normalized as { maxTokens?: number }).maxTokens });
+    case "default": {
+      const provider = (normalized as { provider?: string | ProviderConfig }).provider;
+      return new SdkBackend({ model, maxTokens: (normalized as { maxTokens?: number }).maxTokens, provider });
+    }
     case "claude":
       return new ClaudeCodeBackend({
         ...(normalized as { options?: Record<string, unknown> }).options,

--- a/packages/agent-worker/src/backends/model-maps.ts
+++ b/packages/agent-worker/src/backends/model-maps.ts
@@ -8,7 +8,7 @@
 // ==================== Backend Type ====================
 
 /** Backend type (union of all supported backends) */
-export type BackendType = "default" | "claude" | "cursor" | "codex" | "mock";
+export type BackendType = "default" | "claude" | "cursor" | "codex" | "opencode" | "mock";
 
 /** Normalize backend type, mapping deprecated "sdk" to "default" */
 export function normalizeBackendType(type: string): BackendType {
@@ -25,6 +25,7 @@ export const BACKEND_DEFAULT_MODELS: Record<BackendType, string> = {
   claude: "sonnet",
   cursor: "sonnet-4.5",
   codex: "gpt-5.2-codex",
+  opencode: "deepseek/deepseek-chat",
 };
 
 /**
@@ -96,6 +97,26 @@ export const CODEX_MODEL_MAP: Record<string, string> = {
   "o3-mini": "o3-mini",
 };
 
+/**
+ * Model translation for OpenCode CLI backend
+ * OpenCode uses provider/model format natively
+ */
+export const OPENCODE_MODEL_MAP: Record<string, string> = {
+  // DeepSeek models
+  "deepseek-chat": "deepseek/deepseek-chat",
+  "deepseek-reasoner": "deepseek/deepseek-reasoner",
+  "deepseek/deepseek-chat": "deepseek/deepseek-chat",
+  "deepseek/deepseek-reasoner": "deepseek/deepseek-reasoner",
+  // Anthropic models (via OpenCode's anthropic provider)
+  sonnet: "anthropic/claude-sonnet-4-5-20250514",
+  opus: "anthropic/claude-opus-4-20250514",
+  "claude-sonnet-4-5": "anthropic/claude-sonnet-4-5-20250514",
+  "claude-opus-4": "anthropic/claude-opus-4-20250514",
+  // OpenAI models (via OpenCode's openai provider)
+  "gpt-5.2": "openai/gpt-5.2",
+  o3: "openai/o3",
+};
+
 // ==================== Model Translation ====================
 
 /**
@@ -124,6 +145,10 @@ export function getModelForBackend(model: string | undefined, backend: BackendTy
 
     case "codex":
       return CODEX_MODEL_MAP[model] || CODEX_MODEL_MAP[normalizedModel] || normalizedModel;
+
+    case "opencode":
+      // OpenCode uses provider/model format; preserve full model string if it has a slash
+      return OPENCODE_MODEL_MAP[model] || OPENCODE_MODEL_MAP[normalizedModel] || model;
 
     default:
       return normalizedModel;

--- a/packages/agent-worker/src/backends/opencode.ts
+++ b/packages/agent-worker/src/backends/opencode.ts
@@ -15,7 +15,11 @@ import { join } from "node:path";
 import type { Backend, BackendResponse } from "./types.ts";
 import { DEFAULT_IDLE_TIMEOUT } from "./types.ts";
 import { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
-import { createStreamParser, type StreamParserCallbacks, type EventAdapter } from "./stream-json.ts";
+import {
+  createStreamParser,
+  type StreamParserCallbacks,
+  type EventAdapter,
+} from "./stream-json.ts";
 
 export interface OpenCodeOptions {
   /** Model to use in provider/model format (e.g., 'deepseek/deepseek-chat') */
@@ -56,7 +60,11 @@ export class OpenCodeBackend implements Backend {
     // OpenCode uses { mcp: { name: { type: "local", command: [...] } } }
     const opencodeMcp: Record<string, unknown> = {};
     for (const [name, config] of Object.entries(mcpConfig.mcpServers)) {
-      const serverConfig = config as { command?: string; args?: string[]; env?: Record<string, string> };
+      const serverConfig = config as {
+        command?: string;
+        args?: string[];
+        env?: Record<string, string>;
+      };
       opencodeMcp[name] = {
         type: "local",
         command: [serverConfig.command, ...(serverConfig.args || [])],
@@ -222,9 +230,7 @@ export const opencodeAdapter: EventAdapter = (raw) => {
     return {
       kind: "completed",
       costUsd: cost,
-      usage: tokens
-        ? { input: tokens.input, output: tokens.output }
-        : undefined,
+      usage: tokens ? { input: tokens.input, output: tokens.output } : undefined,
     };
   }
 

--- a/packages/agent-worker/src/backends/opencode.ts
+++ b/packages/agent-worker/src/backends/opencode.ts
@@ -1,0 +1,258 @@
+/**
+ * OpenCode CLI backend
+ * Uses `opencode run` for non-interactive mode with JSON event output
+ *
+ * MCP Configuration:
+ * OpenCode uses project-level MCP config via opencode.json in the workspace.
+ * Use setWorkspace() to set up a dedicated workspace with MCP config.
+ *
+ * @see https://opencode.ai/docs/
+ */
+
+import { execa } from "execa";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Backend, BackendResponse } from "./types.ts";
+import { DEFAULT_IDLE_TIMEOUT } from "./types.ts";
+import { execWithIdleTimeout, IdleTimeoutError } from "./idle-timeout.ts";
+import { createStreamParser, type StreamParserCallbacks, type EventAdapter } from "./stream-json.ts";
+
+export interface OpenCodeOptions {
+  /** Model to use in provider/model format (e.g., 'deepseek/deepseek-chat') */
+  model?: string;
+  /** Working directory (defaults to workspace if set) */
+  cwd?: string;
+  /** Workspace directory for agent isolation */
+  workspace?: string;
+  /** Idle timeout in milliseconds — kills process if no output for this duration */
+  timeout?: number;
+  /** Stream parser callbacks (structured event output) */
+  streamCallbacks?: StreamParserCallbacks;
+}
+
+export class OpenCodeBackend implements Backend {
+  readonly type = "opencode" as const;
+  private options: OpenCodeOptions;
+
+  constructor(options: OpenCodeOptions = {}) {
+    this.options = {
+      timeout: DEFAULT_IDLE_TIMEOUT,
+      ...options,
+    };
+  }
+
+  /**
+   * Set up workspace directory with MCP config
+   * Creates opencode.json in the workspace with MCP server config
+   */
+  setWorkspace(workspaceDir: string, mcpConfig: { mcpServers: Record<string, unknown> }): void {
+    this.options.workspace = workspaceDir;
+
+    if (!existsSync(workspaceDir)) {
+      mkdirSync(workspaceDir, { recursive: true });
+    }
+
+    // Convert mcpServers to OpenCode's mcp format
+    // OpenCode uses { mcp: { name: { type: "local", command: [...] } } }
+    const opencodeMcp: Record<string, unknown> = {};
+    for (const [name, config] of Object.entries(mcpConfig.mcpServers)) {
+      const serverConfig = config as { command?: string; args?: string[]; env?: Record<string, string> };
+      opencodeMcp[name] = {
+        type: "local",
+        command: [serverConfig.command, ...(serverConfig.args || [])],
+        enabled: true,
+        ...(serverConfig.env ? { environment: serverConfig.env } : {}),
+      };
+    }
+
+    const opencodeConfig = {
+      $schema: "https://opencode.ai/config.json",
+      mcp: opencodeMcp,
+    };
+
+    const configPath = join(workspaceDir, "opencode.json");
+    writeFileSync(configPath, JSON.stringify(opencodeConfig, null, 2));
+  }
+
+  async send(message: string, _options?: { system?: string }): Promise<BackendResponse> {
+    const args = this.buildArgs(message);
+    const cwd = this.options.workspace || this.options.cwd;
+    const timeout = this.options.timeout ?? DEFAULT_IDLE_TIMEOUT;
+
+    try {
+      const { stdout } = await execWithIdleTimeout({
+        command: "opencode",
+        args,
+        cwd,
+        timeout,
+        onStdout: this.options.streamCallbacks
+          ? createStreamParser(this.options.streamCallbacks, "OpenCode", opencodeAdapter)
+          : undefined,
+      });
+
+      return extractOpenCodeResult(stdout);
+    } catch (error) {
+      if (error instanceof IdleTimeoutError) {
+        throw new Error(`opencode timed out after ${timeout}ms of inactivity`);
+      }
+      if (error && typeof error === "object" && "exitCode" in error) {
+        const execError = error as { exitCode?: number; stderr?: string; shortMessage?: string };
+        throw new Error(
+          `opencode failed (exit ${execError.exitCode}): ${execError.stderr || execError.shortMessage}`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      await execa("opencode", ["--version"], { stdin: "ignore", timeout: 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  getInfo(): { name: string; version?: string; model?: string } {
+    return {
+      name: "OpenCode CLI",
+      model: this.options.model,
+    };
+  }
+
+  private buildArgs(message: string): string[] {
+    // run: non-interactive mode
+    // --format json: NDJSON event output for progress parsing
+    const args: string[] = ["run", "--format", "json", message];
+
+    if (this.options.model) {
+      args.push("--model", this.options.model);
+    }
+
+    return args;
+  }
+}
+
+// ==================== OpenCode Event Types ====================
+
+/**
+ * OpenCode JSON event format
+ * Events: step_start, text, tool_use, step_finish
+ */
+export type OpenCodeEvent =
+  | {
+      type: "step_start";
+      sessionID: string;
+      part: { type: "step-start"; snapshot?: string };
+    }
+  | {
+      type: "text";
+      sessionID: string;
+      part: { type: "text"; text: string };
+    }
+  | {
+      type: "tool_use";
+      sessionID: string;
+      part: {
+        type: "tool";
+        callID: string;
+        tool: string;
+        state: {
+          status: string;
+          input?: Record<string, unknown>;
+          output?: string;
+        };
+      };
+    }
+  | {
+      type: "step_finish";
+      sessionID: string;
+      part: {
+        type: "step-finish";
+        reason: string;
+        cost?: number;
+        tokens?: {
+          total: number;
+          input: number;
+          output: number;
+          reasoning?: number;
+        };
+      };
+    };
+
+// ==================== OpenCode Adapter ====================
+
+/**
+ * Adapter for OpenCode --format json output.
+ *
+ * Events:
+ *   { type: "step_start", sessionID: "..." }
+ *   { type: "tool_use", part: { tool: "bash", state: { input: {...} } } }
+ *   { type: "text", part: { text: "..." } }            → skipped (result only)
+ *   { type: "step_finish", part: { cost, tokens } }
+ */
+export const opencodeAdapter: EventAdapter = (raw) => {
+  const event = raw as OpenCodeEvent;
+
+  if (event.type === "step_start") {
+    return {
+      kind: "init",
+      sessionId: event.sessionID,
+    };
+  }
+
+  if (event.type === "tool_use") {
+    const { tool, state } = event.part;
+    const args = state.input ? JSON.stringify(state.input) : "";
+    return {
+      kind: "tool_call",
+      name: tool,
+      args: args.length > 100 ? args.slice(0, 100) + "..." : args,
+    };
+  }
+
+  if (event.type === "text") {
+    // Text messages — skip (extracted by result extractor)
+    return { kind: "skip" };
+  }
+
+  if (event.type === "step_finish") {
+    const { cost, tokens } = event.part;
+    return {
+      kind: "completed",
+      costUsd: cost,
+      usage: tokens
+        ? { input: tokens.input, output: tokens.output }
+        : undefined,
+    };
+  }
+
+  return null;
+};
+
+/**
+ * Extract final result from OpenCode --format json output.
+ *
+ * Priority:
+ * 1. Last text event
+ * 2. Raw stdout fallback
+ */
+export function extractOpenCodeResult(stdout: string): BackendResponse {
+  const lines = stdout.trim().split("\n");
+
+  // 1. Find last text event
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const event = JSON.parse(lines[i]!);
+      if (event.type === "text" && event.part?.text) {
+        return { content: event.part.text };
+      }
+    } catch {
+      // Not JSON
+    }
+  }
+
+  // 2. Raw stdout
+  return { content: stdout.trim() };
+}

--- a/packages/agent-worker/src/backends/types.ts
+++ b/packages/agent-worker/src/backends/types.ts
@@ -10,6 +10,7 @@ export {
   CURSOR_MODEL_MAP,
   CLAUDE_MODEL_MAP,
   CODEX_MODEL_MAP,
+  OPENCODE_MODEL_MAP,
   getModelForBackend,
   normalizeBackendType,
 } from "./model-maps.ts";

--- a/packages/agent-worker/src/cli/client.ts
+++ b/packages/agent-worker/src/cli/client.ts
@@ -103,6 +103,7 @@ export function createAgent(body: {
   model: string;
   system: string;
   backend?: string;
+  provider?: string | { name: string; base_url?: string; api_key?: string };
   workflow?: string;
   tag?: string;
 }): Promise<ApiResponse> {

--- a/packages/agent-worker/src/cli/commands/agent.ts
+++ b/packages/agent-worker/src/cli/commands/agent.ts
@@ -73,7 +73,7 @@ export function registerAgentCommands(program: Command) {
     .option("-m, --model <model>", `Model identifier (default: ${getDefaultModel()})`)
     .addOption(
       new Option("-b, --backend <type>", "Backend type")
-        .choices(["default", "sdk", "claude", "codex", "cursor", "mock"])
+        .choices(["default", "sdk", "claude", "codex", "cursor", "opencode", "mock"])
         .default("default"),
     )
     .option("-s, --system <prompt>", "System prompt", "You are a helpful assistant.")

--- a/packages/agent-worker/src/cli/commands/info.ts
+++ b/packages/agent-worker/src/cli/commands/info.ts
@@ -11,8 +11,6 @@ const PROVIDER_API_KEYS: Record<string, { envVar: string; description: string }>
   groq: { envVar: "GROQ_API_KEY", description: "Groq" },
   mistral: { envVar: "MISTRAL_API_KEY", description: "Mistral" },
   xai: { envVar: "XAI_API_KEY", description: "xAI Grok" },
-  minimax: { envVar: "MINIMAX_API_KEY", description: "MiniMax" },
-  glm: { envVar: "GLM_API_KEY", description: "Zhipu GLM" },
 };
 
 export function registerInfoCommands(program: Command) {
@@ -47,6 +45,7 @@ export function registerInfoCommands(program: Command) {
       console.log(`  Provider only:   provider         (e.g., openai → ${gatewayExample})`);
       console.log(`  Gateway format:  provider/model   (e.g., ${gatewayExample})`);
       console.log(`  Direct format:   provider:model   (e.g., ${directExample})`);
+      console.log(`  Custom endpoint: --provider anthropic --base-url <url> --api-key '$KEY'`);
       console.log(`\nDefault: ${defaultModel} (when no model specified)`);
     });
 

--- a/packages/agent-worker/src/cli/commands/info.ts
+++ b/packages/agent-worker/src/cli/commands/info.ts
@@ -12,6 +12,7 @@ const PROVIDER_API_KEYS: Record<string, { envVar: string; description: string }>
   mistral: { envVar: "MISTRAL_API_KEY", description: "Mistral" },
   xai: { envVar: "XAI_API_KEY", description: "xAI Grok" },
   minimax: { envVar: "MINIMAX_API_KEY", description: "MiniMax" },
+  glm: { envVar: "GLM_API_KEY", description: "Zhipu GLM" },
 };
 
 export function registerInfoCommands(program: Command) {

--- a/packages/agent-worker/src/daemon/daemon.ts
+++ b/packages/agent-worker/src/daemon/daemon.ts
@@ -168,6 +168,7 @@ export async function startDaemon(
       model,
       system,
       backend = "default",
+      provider,
       workflow = "global",
       tag = "main",
     } = body as {
@@ -175,6 +176,7 @@ export async function startDaemon(
       model: string;
       system: string;
       backend?: BackendType;
+      provider?: string | { name: string; base_url?: string; api_key?: string };
       workflow?: string;
       tag?: string;
     };
@@ -192,6 +194,7 @@ export async function startDaemon(
       model,
       system,
       backend,
+      provider,
       workflow,
       tag,
       createdAt: new Date().toISOString(),

--- a/packages/agent-worker/src/workflow/controller/backend.ts
+++ b/packages/agent-worker/src/workflow/controller/backend.ts
@@ -5,6 +5,7 @@
 
 import type { Backend } from "@/backends/types.ts";
 import type { StreamParserCallbacks } from "@/backends/stream-json.ts";
+import type { ProviderConfig } from "@/workflow/types.ts";
 import { parseModel } from "@/backends/model-maps.ts";
 import { createBackend } from "@/backends/index.ts";
 import { createMockBackend } from "@/backends/mock.ts";
@@ -13,6 +14,8 @@ import { createMockBackend } from "@/backends/mock.ts";
 export interface WorkflowBackendOptions {
   model?: string;
   timeout?: number;
+  /** Provider configuration for custom endpoints */
+  provider?: string | ProviderConfig;
   /** Stream parser callbacks for structured event logging */
   streamCallbacks?: StreamParserCallbacks;
   /** Debug log for mock backend */
@@ -44,6 +47,7 @@ export function getBackendByType(
   return createBackend({
     type: backendType,
     model: options?.model,
+    ...(backendType === "default" && options?.provider ? { provider: options.provider } : {}),
     ...(Object.keys(backendOptions).length > 0 ? { options: backendOptions } : {}),
   } as Parameters<typeof createBackend>[0]);
 }
@@ -55,6 +59,11 @@ export function getBackendByType(
  * Prefer using getBackendByType with explicit backend field in workflow configs.
  */
 export function getBackendForModel(model: string, options?: WorkflowBackendOptions): Backend {
+  // If provider is set, model is a plain name — use SDK backend with provider config
+  if (options?.provider) {
+    return getBackendByType("default", { ...options, model });
+  }
+
   const { provider } = parseModel(model);
 
   switch (provider) {

--- a/packages/agent-worker/src/workflow/controller/backend.ts
+++ b/packages/agent-worker/src/workflow/controller/backend.ts
@@ -26,7 +26,7 @@ export interface WorkflowBackendOptions {
  * from backends/index.ts. Mock backend is handled specially (no model needed).
  */
 export function getBackendByType(
-  backendType: "default" | "claude" | "cursor" | "codex" | "mock",
+  backendType: "default" | "claude" | "cursor" | "codex" | "opencode" | "mock",
   options?: WorkflowBackendOptions,
 ): Backend {
   if (backendType === "mock") {

--- a/packages/agent-worker/src/workflow/parser.ts
+++ b/packages/agent-worker/src/workflow/parser.ts
@@ -337,6 +337,50 @@ function validateAgent(name: string, agent: unknown, errors: ValidationError[]):
   if (a.tools !== undefined && !Array.isArray(a.tools)) {
     errors.push({ path: `${path}.tools`, message: 'Optional field "tools" must be an array' });
   }
+
+  // Validate provider field
+  if (a.provider !== undefined) {
+    if (typeof a.provider === "string") {
+      // string form is valid
+    } else if (
+      typeof a.provider === "object" &&
+      a.provider !== null &&
+      !Array.isArray(a.provider)
+    ) {
+      const p = a.provider as Record<string, unknown>;
+      if (!p.name || typeof p.name !== "string") {
+        errors.push({
+          path: `${path}.provider.name`,
+          message: 'Field "provider.name" is required and must be a string',
+        });
+      }
+      if (p.base_url !== undefined && typeof p.base_url !== "string") {
+        errors.push({
+          path: `${path}.provider.base_url`,
+          message: 'Field "provider.base_url" must be a string',
+        });
+      }
+      if (p.api_key !== undefined && typeof p.api_key !== "string") {
+        errors.push({
+          path: `${path}.provider.api_key`,
+          message: 'Field "provider.api_key" must be a string',
+        });
+      }
+    } else {
+      errors.push({
+        path: `${path}.provider`,
+        message: 'Field "provider" must be a string or object with { name, base_url?, api_key? }',
+      });
+    }
+
+    // provider only works with default backend
+    if (CLI_BACKENDS.includes(backend) && backend !== "mock") {
+      errors.push({
+        path: `${path}.provider`,
+        message: `Field "provider" is ignored for CLI backend "${backend}" (only works with default backend)`,
+      });
+    }
+  }
 }
 
 /**

--- a/packages/agent-worker/src/workflow/parser.ts
+++ b/packages/agent-worker/src/workflow/parser.ts
@@ -304,7 +304,7 @@ function validateSetupTask(path: string, task: unknown, errors: ValidationError[
 }
 
 /** Backends that don't require an explicit model field */
-const CLI_BACKENDS = ["claude", "cursor", "codex", "mock"];
+const CLI_BACKENDS = ["claude", "cursor", "codex", "opencode", "mock"];
 
 function validateAgent(name: string, agent: unknown, errors: ValidationError[]): void {
   const path = `agents.${name}`;

--- a/packages/agent-worker/src/workflow/runner.ts
+++ b/packages/agent-worker/src/workflow/runner.ts
@@ -610,12 +610,14 @@ export async function runWorkflowWithControllers(
       } else if (agentDef.backend) {
         backend = getBackendByType(agentDef.backend, {
           model: agentDef.model,
+          provider: agentDef.provider,
           debugLog: (msg) => agentLogger.debug(msg),
           streamCallbacks,
           timeout: agentDef.timeout,
         });
       } else if (agentDef.model) {
         backend = getBackendForModel(agentDef.model, {
+          provider: agentDef.provider,
           debugLog: (msg) => agentLogger.debug(msg),
           streamCallbacks,
         });

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -41,14 +41,43 @@ export interface WorkflowFile {
   kickoff?: string;
 }
 
+// ==================== Provider Configuration ====================
+
+/**
+ * Custom provider configuration for API endpoint overrides.
+ * Allows pointing any compatible SDK at a different base URL.
+ *
+ * Examples:
+ *   provider: anthropic                    # string → built-in provider
+ *   provider:                              # object → custom endpoint
+ *     name: anthropic
+ *     base_url: https://api.minimax.io/anthropic/v1
+ *     api_key: $MINIMAX_API_KEY
+ */
+export interface ProviderConfig {
+  /** Provider SDK name (e.g., 'anthropic', 'openai') */
+  name: string;
+  /** Override base URL for the provider */
+  base_url?: string;
+  /** API key — env var reference with '$' prefix (e.g., '$MINIMAX_API_KEY') or literal value */
+  api_key?: string;
+}
+
 // ==================== Agent Definition ====================
 
 export interface AgentDefinition {
   /** Backend to use: 'default' (Vercel AI SDK), 'claude', 'cursor', 'codex', 'opencode', 'mock' (testing) */
   backend?: "default" | "claude" | "cursor" | "codex" | "opencode" | "mock";
 
-  /** Model identifier (e.g., 'anthropic/claude-sonnet-4-5'). Optional for CLI backends that have defaults. */
+  /** Model identifier. When provider is set, this is just the model name (e.g., 'MiniMax-M2.5').
+   *  Without provider, uses existing formats: 'provider/model', 'provider:model', or 'provider'. */
   model?: string;
+
+  /**
+   * Provider configuration — string (built-in name) or object (custom endpoint).
+   * When set, 'model' is just the model name without provider prefix.
+   */
+  provider?: string | ProviderConfig;
 
   /** System prompt - inline string or file path (optional) */
   system_prompt?: string;

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -44,8 +44,8 @@ export interface WorkflowFile {
 // ==================== Agent Definition ====================
 
 export interface AgentDefinition {
-  /** Backend to use: 'default' (Vercel AI SDK), 'claude', 'cursor', 'codex', 'mock' (testing) */
-  backend?: "default" | "claude" | "cursor" | "codex" | "mock";
+  /** Backend to use: 'default' (Vercel AI SDK), 'claude', 'cursor', 'codex', 'opencode', 'mock' (testing) */
+  backend?: "default" | "claude" | "cursor" | "codex" | "opencode" | "mock";
 
   /** Model identifier (e.g., 'anthropic/claude-sonnet-4-5'). Optional for CLI backends that have defaults. */
   model?: string;

--- a/packages/agent-worker/test/cli-backends.test.ts
+++ b/packages/agent-worker/test/cli-backends.test.ts
@@ -1,7 +1,7 @@
 /**
  * CLI Backend Tests
  *
- * Uses mock-cli.ts to simulate cursor-agent, claude, codex, and opencode CLIs
+ * Uses mock-cli.ts to simulate cursor agent, claude, codex, and opencode CLIs
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -51,19 +51,19 @@ async function runMockCli(
 
 describe('Mock CLI', () => {
   test('responds to --version', async () => {
-    const result = await runMockCli(['cursor-agent', '--version'])
+    const result = await runMockCli(['cursor', 'agent', '--version'])
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('1.0.0')
   })
 
   test('responds to simple message', async () => {
-    const result = await runMockCli(['cursor-agent', '-p', '2+2=?'])
+    const result = await runMockCli(['cursor', 'agent', '-p', '2+2=?'])
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toBe('4')
   })
 
   test('handles custom response via env', async () => {
-    const result = await runMockCli(['cursor-agent', '-p', 'anything'], {
+    const result = await runMockCli(['cursor', 'agent', '-p', 'anything'], {
       MOCK_RESPONSE: 'Custom response here',
     })
     expect(result.exitCode).toBe(0)
@@ -71,7 +71,7 @@ describe('Mock CLI', () => {
   })
 
   test('simulates failure', async () => {
-    const result = await runMockCli(['cursor-agent', '-p', 'test'], {
+    const result = await runMockCli(['cursor', 'agent', '-p', 'test'], {
       MOCK_FAIL: '1',
     })
     expect(result.exitCode).toBe(1)
@@ -79,7 +79,7 @@ describe('Mock CLI', () => {
   })
 
   test('outputs JSON format', async () => {
-    const result = await runMockCli(['cursor-agent', '-p', '2+2=?', '--output-format=stream-json'])
+    const result = await runMockCli(['cursor', 'agent', '-p', '2+2=?', '--output-format=stream-json'])
     expect(result.exitCode).toBe(0)
 
     const lines = result.stdout.split('\n')
@@ -95,11 +95,11 @@ describe('CursorBackend with Mock', () => {
   // Create a backend that uses our mock CLI (with stream-json format)
   class MockCursorBackend extends CursorBackend {
     protected override async buildCommand(message: string): Promise<{ command: string; args: string[] }> {
-      // Use bun to run mock-cli.ts instead of actual cursor-agent
+      // Use bun to run mock-cli.ts instead of actual cursor agent
       // Include --output-format=stream-json to match real buildCommand behavior
       return {
         command: 'bun',
-        args: [MOCK_CLI_PATH, 'cursor-agent', '-p', message, '--output-format=stream-json'],
+        args: [MOCK_CLI_PATH, 'cursor', 'agent', '-p', message, '--output-format=stream-json'],
       }
     }
   }
@@ -138,7 +138,7 @@ describe('CursorBackend with Mock', () => {
     backend['buildCommand'] = async (message: string) => {
       return {
         command: 'bun',
-        args: [MOCK_CLI_PATH, 'cursor-agent', '-p', message],
+        args: [MOCK_CLI_PATH, 'cursor', 'agent', '-p', message],
       }
     }
 
@@ -167,7 +167,7 @@ describe('Idle Timeout', () => {
       await expect(
         execWithIdleTimeout({
           command: 'bun',
-          args: [MOCK_CLI_PATH, 'cursor-agent', '-p', 'test'],
+          args: [MOCK_CLI_PATH, 'cursor', 'agent', '-p', 'test'],
           timeout: 1500,
         })
       ).rejects.toThrow(IdleTimeoutError)
@@ -188,7 +188,7 @@ describe('Idle Timeout', () => {
     try {
       const result = await execWithIdleTimeout({
         command: 'bun',
-        args: [MOCK_CLI_PATH, 'cursor-agent', '-p', 'test'],
+        args: [MOCK_CLI_PATH, 'cursor', 'agent', '-p', 'test'],
         timeout: 200,
       })
       expect(result.stdout).toContain('chunk 1')
@@ -205,7 +205,7 @@ describe('Idle Timeout', () => {
   test('fast process completes normally', async () => {
     const result = await execWithIdleTimeout({
       command: 'bun',
-      args: [MOCK_CLI_PATH, 'cursor-agent', '-p', '2+2=?'],
+      args: [MOCK_CLI_PATH, 'cursor', 'agent', '-p', '2+2=?'],
       timeout: 5000,
     })
     expect(result.stdout).toContain('4')
@@ -543,9 +543,9 @@ describe('OpenCodeBackend with Mock', () => {
 })
 
 describe('Backend Integration', () => {
-  test('mock CLI behaves like real cursor-agent', async () => {
+  test('mock CLI behaves like real cursor agent', async () => {
     // Test the exact command that CursorBackend would build
-    const result = await runMockCli(['cursor-agent', '-p', 'What is 2+2?'])
+    const result = await runMockCli(['cursor', 'agent', '-p', 'What is 2+2?'])
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toBe('4')
   })
@@ -558,7 +558,7 @@ describe('Backend Integration', () => {
     ]
 
     for (const { message, expected } of testCases) {
-      const result = await runMockCli(['cursor-agent', '-p', message])
+      const result = await runMockCli(['cursor', 'agent', '-p', message])
       expect(result.stdout).toContain(expected)
     }
   })

--- a/packages/agent-worker/test/cli-backends.test.ts
+++ b/packages/agent-worker/test/cli-backends.test.ts
@@ -8,7 +8,6 @@ import { describe, test, expect } from 'bun:test'
 import { spawn } from 'node:child_process'
 import { join } from 'node:path'
 import { CursorBackend } from '../src/backends/cursor.ts'
-import { OpenCodeBackend } from '../src/backends/opencode.ts'
 import { opencodeAdapter, extractOpenCodeResult } from '../src/backends/opencode.ts'
 import { execWithIdleTimeout, IdleTimeoutError } from '../src/backends/idle-timeout.ts'
 import {
@@ -517,12 +516,6 @@ describe('OpenCode Mock CLI', () => {
 })
 
 describe('OpenCodeBackend with Mock', () => {
-  class MockOpenCodeBackend extends OpenCodeBackend {
-    private buildArgsMethod(message: string): string[] {
-      return ['run', '--format', 'json', message]
-    }
-  }
-
   test('sends message and parses JSON result', async () => {
     // Use execWithIdleTimeout directly to test parsing
     const result = await runMockCli(['opencode', 'run', '--format', 'json', '2+2=?'])

--- a/packages/agent-worker/test/debug-cursor.ts
+++ b/packages/agent-worker/test/debug-cursor.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * Debug script to test cursor-agent behavior in different spawn configurations
+ * Debug script to test cursor agent behavior in different spawn configurations
  *
  * Run: bun test/debug-cursor.ts
  */
@@ -9,14 +9,14 @@ import { spawn, spawnSync } from 'node:child_process'
 
 const MESSAGE = '2+2=?'
 
-console.log('=== Testing cursor-agent spawn configurations ===\n')
+console.log('=== Testing cursor agent spawn configurations ===\n')
 
 // Test 1: Default spawn (no stdio specified)
 async function test1() {
   console.log('Test 1: Default spawn (no stdio)')
   return new Promise<void>((resolve) => {
     const start = Date.now()
-    const proc = spawn('cursor-agent', ['-p', MESSAGE])
+    const proc = spawn('cursor', ['agent', '-p', MESSAGE])
 
     let stdout = ''
     let stderr = ''
@@ -51,7 +51,7 @@ async function test2() {
   console.log('\nTest 2: With stdio: pipe')
   return new Promise<void>((resolve) => {
     const start = Date.now()
-    const proc = spawn('cursor-agent', ['-p', MESSAGE], {
+    const proc = spawn('cursor', ['agent', '-p', MESSAGE], {
       stdio: ['pipe', 'pipe', 'pipe'],
     })
 
@@ -85,7 +85,7 @@ async function test3() {
   console.log('\nTest 3: With stdin.end() immediately')
   return new Promise<void>((resolve) => {
     const start = Date.now()
-    const proc = spawn('cursor-agent', ['-p', MESSAGE], {
+    const proc = spawn('cursor', ['agent', '-p', MESSAGE], {
       stdio: ['pipe', 'pipe', 'pipe'],
     })
 
@@ -122,7 +122,7 @@ async function test4() {
   console.log('\nTest 4: With stdin ignored')
   return new Promise<void>((resolve) => {
     const start = Date.now()
-    const proc = spawn('cursor-agent', ['-p', MESSAGE], {
+    const proc = spawn('cursor', ['agent', '-p', MESSAGE], {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
 
@@ -156,7 +156,7 @@ async function test5() {
   console.log('\nTest 5: With stdio: inherit (TTY)')
   return new Promise<void>((resolve) => {
     const start = Date.now()
-    const proc = spawn('cursor-agent', ['-p', MESSAGE], {
+    const proc = spawn('cursor', ['agent', '-p', MESSAGE], {
       stdio: 'inherit',
     })
 
@@ -179,7 +179,7 @@ function test6() {
   console.log('\nTest 6: spawnSync')
   const start = Date.now()
   try {
-    const result = spawnSync('cursor-agent', ['-p', MESSAGE], {
+    const result = spawnSync('cursor', ['agent', '-p', MESSAGE], {
       timeout: 10000,
       encoding: 'utf-8',
     })
@@ -193,7 +193,7 @@ function test6() {
 
 // Run all tests
 async function main() {
-  console.log('cursor-agent location:', await getCommandPath('cursor-agent'))
+  console.log('cursor agent location:', await getCommandPath('cursor'))
   console.log('')
 
   await test1()

--- a/packages/agent-worker/test/e2e/backends.test.ts
+++ b/packages/agent-worker/test/e2e/backends.test.ts
@@ -7,6 +7,8 @@
  *     DEEPSEEK_API_KEY     — for Claude Code (via DeepSeek) and OpenCode
  *     AI_GATEWAY_API_KEY   — for Codex CLI via Vercel AI Gateway (Gemini 2.0 Flash)
  *     CURSOR_API_KEY       — for Cursor Agent (requires paid subscription)
+ *     MINIMAX_API_KEY      — for MiniMax (SDK, Claude-compatible API)
+ *     GLM_API_KEY          — for GLM/Zhipu (SDK, Claude-compatible API)
  *
  * Usage:
  *   # Run all E2E tests
@@ -31,6 +33,7 @@ import { ClaudeCodeBackend } from "../../src/backends/claude-code.ts";
 import { CodexBackend } from "../../src/backends/codex.ts";
 import { CursorBackend } from "../../src/backends/cursor.ts";
 import { OpenCodeBackend } from "../../src/backends/opencode.ts";
+import { SdkBackend } from "../../src/backends/sdk.ts";
 
 // Generous timeout for real API calls (2 minutes)
 const E2E_TIMEOUT = 120_000;
@@ -282,6 +285,54 @@ describe.skipIf(!hasCursor || !hasCursorKey)(
   },
 );
 
+// ─── MiniMax (SDK, Claude-compatible API) ────────────────────
+
+const hasMiniMaxKey = !!process.env.MINIMAX_API_KEY;
+
+describe.skipIf(!hasMiniMaxKey)(
+  "E2E: MiniMax (SDK)",
+  () => {
+    test(
+      "sends prompt and receives response (MiniMax-M2.5)",
+      async () => {
+        const backend = new SdkBackend({
+          model: "minimax:MiniMax-M2.5",
+        });
+
+        const result = await backend.send(PROMPT);
+        expect(result.content).toBeDefined();
+        expect(result.content.length).toBeGreaterThan(0);
+        expect(result.content).toContain("4");
+      },
+      E2E_TIMEOUT,
+    );
+  },
+);
+
+// ─── GLM / Zhipu (SDK, Claude-compatible API) ───────────────
+
+const hasGlmKey = !!process.env.GLM_API_KEY;
+
+describe.skipIf(!hasGlmKey)(
+  "E2E: GLM (SDK)",
+  () => {
+    test(
+      "sends prompt and receives response (glm-4.7)",
+      async () => {
+        const backend = new SdkBackend({
+          model: "glm:glm-4.7",
+        });
+
+        const result = await backend.send(PROMPT);
+        expect(result.content).toBeDefined();
+        expect(result.content.length).toBeGreaterThan(0);
+        expect(result.content).toContain("4");
+      },
+      E2E_TIMEOUT,
+    );
+  },
+);
+
 // ─── Availability Summary ────────────────────────────────────
 
 describe("E2E: Backend Availability", () => {
@@ -295,9 +346,13 @@ describe("E2E: Backend Availability", () => {
       AI_GATEWAY_API_KEY: hasGatewayKey ? "set" : "not set",
       OPENAI_API_KEY: hasOpenAIKey ? "set" : "not set",
       CURSOR_API_KEY: hasCursorKey ? "set" : "not set",
+      MINIMAX_API_KEY: hasMiniMaxKey ? "set" : "not set",
+      GLM_API_KEY: hasGlmKey ? "set" : "not set",
       SKIP_CLAUDE_E2E: skipClaudeE2E ? "yes (skipped)" : "no",
       "Codex model": CODEX_MODEL ?? "(OpenAI default)",
       "Cursor model": "composer-1",
+      "MiniMax model": "MiniMax-M2.5",
+      "GLM model": "glm-4.7",
     };
 
     console.log("\n=== E2E Backend Availability ===");

--- a/packages/agent-worker/test/e2e/backends.test.ts
+++ b/packages/agent-worker/test/e2e/backends.test.ts
@@ -1,0 +1,284 @@
+/**
+ * E2E Backend Tests — Real API calls against actual CLI backends
+ *
+ * Prerequisites:
+ *   - Run `scripts/e2e-setup.sh` to install CLIs
+ *   - Set env vars:
+ *     DEEPSEEK_API_KEY   — for Claude Code (via DeepSeek) and OpenCode
+ *     OPENAI_API_KEY     — for Codex CLI (optional, or use ZENMUX_API_KEY)
+ *     ZENMUX_API_KEY     — for Codex CLI via ZenMux proxy (optional)
+ *     CURSOR_API_KEY     — for Cursor Agent (optional)
+ *
+ * Usage:
+ *   # Run all E2E tests
+ *   DEEPSEEK_API_KEY=sk-... bun test test/e2e/
+ *
+ *   # Run specific backend
+ *   DEEPSEEK_API_KEY=sk-... bun test test/e2e/ -t "OpenCode"
+ *
+ * Notes:
+ *   - Claude Code E2E may hang when run from within a claude session.
+ *     Set SKIP_CLAUDE_E2E=1 to skip it.
+ *   - Codex requires Responses API (wire_api="responses"). ZenMux supports this.
+ *   - Cursor requires paid subscription + API key from cursor.com/dashboard
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ClaudeCodeBackend } from "../../src/backends/claude-code.ts";
+import { CodexBackend } from "../../src/backends/codex.ts";
+import { CursorBackend } from "../../src/backends/cursor.ts";
+import { OpenCodeBackend } from "../../src/backends/opencode.ts";
+
+// Generous timeout for real API calls (2 minutes)
+const E2E_TIMEOUT = 120_000;
+
+// Simple math prompt that produces a deterministic short answer
+const PROMPT = "What is 2+2? Reply with ONLY the number, nothing else.";
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+function cliAvailable(cmd: string): boolean {
+  try {
+    Bun.spawnSync([cmd, "--version"], { stdin: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeTmpDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), `e2e-${prefix}-`));
+}
+
+// ─── Claude Code (via DeepSeek) ──────────────────────────────
+
+const hasClaudeCli = cliAvailable("claude");
+const hasDeepSeekKey = !!process.env.DEEPSEEK_API_KEY;
+const skipClaudeE2E = !!process.env.SKIP_CLAUDE_E2E;
+
+describe.skipIf(!hasClaudeCli || !hasDeepSeekKey || skipClaudeE2E)(
+  "E2E: Claude Code (DeepSeek)",
+  () => {
+    let savedEnv: Record<string, string | undefined>;
+    let tmpDir: string;
+
+    beforeAll(() => {
+      // Save env and configure DeepSeek backend
+      savedEnv = {
+        ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+        ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+        ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:
+          process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
+        DISABLE_AUTOUPDATER: process.env.DISABLE_AUTOUPDATER,
+      };
+
+      process.env.ANTHROPIC_BASE_URL = "https://api.deepseek.com/anthropic";
+      process.env.ANTHROPIC_AUTH_TOKEN = process.env.DEEPSEEK_API_KEY;
+      process.env.ANTHROPIC_API_KEY = "";
+      process.env.ANTHROPIC_MODEL = "deepseek-chat";
+      process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
+      process.env.DISABLE_AUTOUPDATER = "1";
+
+      // Use temp dir as workspace to avoid CLAUDE.md triggering agent operations
+      tmpDir = makeTmpDir("claude");
+    });
+
+    afterAll(() => {
+      // Restore env
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch { /* ignore */ }
+    });
+
+    test(
+      "sends prompt and receives response",
+      async () => {
+        const backend = new ClaudeCodeBackend({
+          outputFormat: "text",
+          cwd: tmpDir,
+          appendSystemPrompt:
+            "You are a simple calculator. Reply with ONLY the number. No explanation. No tools.",
+          timeout: E2E_TIMEOUT,
+        });
+
+        const result = await backend.send(PROMPT);
+        expect(result.content).toBeDefined();
+        expect(result.content.length).toBeGreaterThan(0);
+        // Response should contain "4" somewhere
+        expect(result.content).toContain("4");
+      },
+      E2E_TIMEOUT,
+    );
+  },
+);
+
+// ─── OpenCode (via DeepSeek) ─────────────────────────────────
+
+const hasOpenCode = cliAvailable("opencode");
+
+describe.skipIf(!hasOpenCode || !hasDeepSeekKey)(
+  "E2E: OpenCode (DeepSeek)",
+  () => {
+    let tmpDir: string;
+
+    beforeAll(() => {
+      tmpDir = makeTmpDir("opencode");
+    });
+
+    afterAll(() => {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch { /* ignore */ }
+    });
+
+    test(
+      "sends prompt and receives response",
+      async () => {
+        const backend = new OpenCodeBackend({
+          model: "deepseek/deepseek-chat",
+          cwd: tmpDir,
+          timeout: E2E_TIMEOUT,
+        });
+
+        const result = await backend.send(PROMPT);
+        expect(result.content).toBeDefined();
+        expect(result.content.length).toBeGreaterThan(0);
+        expect(result.content).toContain("4");
+      },
+      E2E_TIMEOUT,
+    );
+  },
+);
+
+// ─── Codex CLI (OpenAI) ─────────────────────────────────────
+
+const hasCodex = cliAvailable("codex");
+const hasOpenAIKey = !!process.env.OPENAI_API_KEY;
+const hasZenMuxKey = !!process.env.ZENMUX_API_KEY;
+// Codex needs Responses API — either OpenAI directly or ZenMux proxy
+const hasCodexAuth = hasOpenAIKey || hasZenMuxKey;
+
+describe.skipIf(!hasCodex || !hasCodexAuth)(
+  "E2E: Codex CLI",
+  () => {
+    let tmpDir: string;
+    let savedEnv: Record<string, string | undefined>;
+
+    beforeAll(() => {
+      tmpDir = makeTmpDir("codex");
+
+      // If using ZenMux instead of OpenAI, set up env
+      if (hasZenMuxKey && !hasOpenAIKey) {
+        savedEnv = { OPENAI_API_KEY: process.env.OPENAI_API_KEY };
+        process.env.OPENAI_API_KEY = process.env.ZENMUX_API_KEY;
+      }
+    });
+
+    afterAll(() => {
+      if (savedEnv) {
+        for (const [key, value] of Object.entries(savedEnv)) {
+          if (value === undefined) delete process.env[key];
+          else process.env[key] = value;
+        }
+      }
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch { /* ignore */ }
+    });
+
+    test(
+      "sends prompt and receives response",
+      async () => {
+        const backend = new CodexBackend({
+          cwd: tmpDir,
+          timeout: E2E_TIMEOUT,
+        });
+
+        const result = await backend.send(PROMPT);
+        expect(result.content).toBeDefined();
+        expect(result.content.length).toBeGreaterThan(0);
+        expect(result.content).toContain("4");
+      },
+      E2E_TIMEOUT,
+    );
+  },
+);
+
+// ─── Cursor Agent ────────────────────────────────────────────
+
+const hasCursor =
+  cliAvailable("agent") || cliAvailable("cursor-agent");
+const hasCursorKey = !!process.env.CURSOR_API_KEY;
+
+describe.skipIf(!hasCursor || !hasCursorKey)(
+  "E2E: Cursor Agent",
+  () => {
+    let tmpDir: string;
+
+    beforeAll(() => {
+      tmpDir = makeTmpDir("cursor");
+    });
+
+    afterAll(() => {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch { /* ignore */ }
+    });
+
+    test(
+      "sends prompt and receives response",
+      async () => {
+        const backend = new CursorBackend({
+          cwd: tmpDir,
+          timeout: E2E_TIMEOUT,
+        });
+
+        const result = await backend.send(PROMPT);
+        expect(result.content).toBeDefined();
+        expect(result.content.length).toBeGreaterThan(0);
+        expect(result.content).toContain("4");
+      },
+      E2E_TIMEOUT,
+    );
+  },
+);
+
+// ─── Availability Summary ────────────────────────────────────
+
+describe("E2E: Backend Availability", () => {
+  test("reports which backends are testable", () => {
+    const status = {
+      "Claude Code CLI": hasClaudeCli ? "installed" : "missing",
+      "Codex CLI": hasCodex ? "installed" : "missing",
+      "Cursor Agent": hasCursor ? "installed" : "missing",
+      "OpenCode CLI": hasOpenCode ? "installed" : "missing",
+      DEEPSEEK_API_KEY: hasDeepSeekKey ? "set" : "not set",
+      OPENAI_API_KEY: hasOpenAIKey ? "set" : "not set",
+      ZENMUX_API_KEY: hasZenMuxKey ? "set" : "not set",
+      CURSOR_API_KEY: hasCursorKey ? "set" : "not set",
+      SKIP_CLAUDE_E2E: skipClaudeE2E ? "yes (skipped)" : "no",
+    };
+
+    console.log("\n=== E2E Backend Availability ===");
+    for (const [name, value] of Object.entries(status)) {
+      const icon = value === "installed" || value === "set" ? "+" : "-";
+      console.log(`  [${icon}] ${name}: ${value}`);
+    }
+    console.log("");
+
+    // This test always passes — it's just informational
+    expect(true).toBe(true);
+  });
+});

--- a/packages/agent-worker/test/e2e/backends.test.ts
+++ b/packages/agent-worker/test/e2e/backends.test.ts
@@ -7,8 +7,8 @@
  *     DEEPSEEK_API_KEY     — for Claude Code (via DeepSeek) and OpenCode
  *     AI_GATEWAY_API_KEY   — for Codex CLI via Vercel AI Gateway (Gemini 2.0 Flash)
  *     CURSOR_API_KEY       — for Cursor Agent (requires paid subscription)
- *     MINIMAX_API_KEY      — for MiniMax (SDK, Claude-compatible API)
- *     GLM_API_KEY          — for GLM/Zhipu (SDK, Claude-compatible API)
+ *     MINIMAX_API_KEY      — for MiniMax (SDK via Anthropic provider + custom endpoint)
+ *     GLM_API_KEY          — for GLM/Zhipu (SDK via Anthropic provider + custom endpoint)
  *
  * Usage:
  *   # Run all E2E tests
@@ -285,18 +285,23 @@ describe.skipIf(!hasCursor || !hasCursorKey)(
   },
 );
 
-// ─── MiniMax (SDK, Claude-compatible API) ────────────────────
+// ─── MiniMax (SDK via Anthropic provider + custom endpoint) ──
 
 const hasMiniMaxKey = !!process.env.MINIMAX_API_KEY;
 
 describe.skipIf(!hasMiniMaxKey)(
-  "E2E: MiniMax (SDK)",
+  "E2E: MiniMax (SDK, provider config)",
   () => {
     test(
       "sends prompt and receives response (MiniMax-M2.5)",
       async () => {
         const backend = new SdkBackend({
-          model: "minimax:MiniMax-M2.5",
+          model: "MiniMax-M2.5",
+          provider: {
+            name: "anthropic",
+            base_url: "https://api.minimax.io/anthropic/v1",
+            api_key: "$MINIMAX_API_KEY",
+          },
         });
 
         const result = await backend.send(PROMPT);
@@ -309,18 +314,23 @@ describe.skipIf(!hasMiniMaxKey)(
   },
 );
 
-// ─── GLM / Zhipu (SDK, Claude-compatible API) ───────────────
+// ─── GLM / Zhipu (SDK via Anthropic provider + custom endpoint)
 
 const hasGlmKey = !!process.env.GLM_API_KEY;
 
 describe.skipIf(!hasGlmKey)(
-  "E2E: GLM (SDK)",
+  "E2E: GLM (SDK, provider config)",
   () => {
     test(
       "sends prompt and receives response (glm-4.7)",
       async () => {
         const backend = new SdkBackend({
-          model: "glm:glm-4.7",
+          model: "glm-4.7",
+          provider: {
+            name: "anthropic",
+            base_url: "https://open.bigmodel.cn/api/anthropic/v1",
+            api_key: "$GLM_API_KEY",
+          },
         });
 
         const result = await backend.send(PROMPT);

--- a/packages/agent-worker/test/e2e/backends.test.ts
+++ b/packages/agent-worker/test/e2e/backends.test.ts
@@ -245,7 +245,7 @@ describe.skipIf(!hasCodex || !hasCodexAuth)(
 // ─── Cursor Agent ────────────────────────────────────────────
 
 const hasCursor =
-  cliAvailable("agent") || cliAvailable("cursor-agent");
+  cliAvailable("agent") || cliAvailable("cursor");
 const hasCursorKey = !!process.env.CURSOR_API_KEY;
 
 describe.skipIf(!hasCursor || !hasCursorKey)(

--- a/packages/agent-worker/test/mock-cli.ts
+++ b/packages/agent-worker/test/mock-cli.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env bun
 /**
- * Mock CLI for testing cursor-agent, claude, codex, and opencode backends
+ * Mock CLI for testing cursor agent, claude, codex, and opencode backends
  *
  * Usage:
- *   bun test/mock-cli.ts cursor-agent -p "hello"
  *   bun test/mock-cli.ts cursor agent -p "hello"
  *   bun test/mock-cli.ts claude -p "hello"
  *   bun test/mock-cli.ts codex "hello"
@@ -19,11 +18,11 @@
 
 const args = process.argv.slice(2)
 
-// Parse command name (cursor-agent, cursor agent, claude, codex)
-// Normalize "cursor agent" → "cursor-agent"
+// Parse command name (cursor agent, claude, codex)
+// Normalize "cursor agent" subcommand → "cursor"
 let command = args[0]
 if (command === 'cursor' && args[1] === 'agent') {
-  command = 'cursor-agent'
+  command = 'cursor'
   args.splice(1, 1) // remove 'agent' so arg parsing stays consistent
 }
 
@@ -46,7 +45,7 @@ if (args.includes('--version')) {
 if (args.includes('--help')) {
   console.log(`Mock CLI - simulates ${command || 'agent'} behavior for testing`)
   console.log('\nOptions:')
-  console.log('  -p <message>     Print mode (cursor-agent)')
+  console.log('  -p <message>     Print mode (cursor agent)')
   console.log('  --version        Show version')
   console.log('  --help           Show help')
   process.exit(0)
@@ -72,8 +71,8 @@ if (slowOutputChunks > 0) {
 // Extract message from args
 let message = ''
 
-if (command === 'cursor-agent') {
-  // cursor-agent -p "message" or cursor-agent "message" -p
+if (command === 'cursor') {
+  // cursor agent -p "message" or cursor agent "message" -p
   const pIndex = args.indexOf('-p')
   if (pIndex !== -1 && args[pIndex + 1]) {
     message = args[pIndex + 1]!

--- a/packages/agent-worker/test/session.test.ts
+++ b/packages/agent-worker/test/session.test.ts
@@ -1196,6 +1196,7 @@ describe('Backend factory', () => {
     expect(availability).toHaveProperty('claude')
     expect(availability).toHaveProperty('codex')
     expect(availability).toHaveProperty('cursor')
+    expect(availability).toHaveProperty('opencode')
     expect(availability.default).toBe(true) // Default backend is always available
   })
 
@@ -1203,8 +1204,8 @@ describe('Backend factory', () => {
     const { listBackends } = await import('../src/backends/index.ts')
 
     const backends = await listBackends()
-    expect(backends).toHaveLength(4)
-    expect(backends.map((b) => b.type)).toEqual(['default', 'claude', 'codex', 'cursor'])
+    expect(backends).toHaveLength(5)
+    expect(backends.map((b) => b.type)).toEqual(['default', 'claude', 'codex', 'cursor', 'opencode'])
     expect(backends[0]!.name).toBe('Vercel AI SDK')
   })
 })

--- a/packages/agent-worker/test/workflow-mock-backend.test.ts
+++ b/packages/agent-worker/test/workflow-mock-backend.test.ts
@@ -6,7 +6,7 @@
  * agent execution → channel communication → idle detection → completion.
  *
  * This tests the same code paths as runWorkflowWithControllers but with
- * mock backends instead of real CLIs (cursor-agent, claude).
+ * mock backends instead of real CLIs (cursor agent, claude).
  */
 
 import { describe, test, expect, afterEach } from 'bun:test'


### PR DESCRIPTION
Research and configure Claude Code, Codex CLI, and Cursor Agent CLI to
work with DeepSeek as a third-party model provider.

- Claude Code: Working via DeepSeek's Anthropic-compatible endpoint
- Codex CLI: Broken (wire_api="chat" deprecated, DeepSeek lacks Responses API)
- Cursor Agent: Not possible (locked to Cursor infrastructure)

Includes wrapper scripts with auto-download for Claude Code binary,
and comprehensive documentation of findings.

https://claude.ai/code/session_017cchdBtjBRoug6E6GJckve