### PR TITLE
fix(agent-worker): add startup timeout and support standalone cursor agent CLI

### DIFF
--- a/packages/agent-worker/examples/debug-cli-browser.yaml
+++ b/packages/agent-worker/examples/debug-cli-browser.yaml
@@ -1,0 +1,24 @@
+# Debug workflow: test CLI backend with a simple browser-like task
+# Tests cursor backend with standalone `agent` CLI
+#
+# Run: node dist/cli/index.mjs run examples/debug-cli-browser.yaml --debug
+name: debug-cli-browser
+
+agents:
+  checker:
+    backend: cursor
+    model: composer-1
+    system_prompt: |
+      You are a simple checker agent. Your job is to:
+      1. Read your inbox messages
+      2. Execute the requested check using bash tools
+      3. Report the result via channel_send
+      4. Acknowledge your inbox and exit
+
+      Keep responses brief. Do not ask questions - just do the work and report.
+
+context:
+  provider: memory
+
+kickoff: |
+  @checker Please run `curl -s -o /dev/null -w "%{http_code}" https://example.com || echo "failed"` and report the HTTP status code. If the command fails, just report "unreachable".

--- a/packages/agent-worker/src/backends/claude-code.ts
+++ b/packages/agent-worker/src/backends/claude-code.ts
@@ -127,6 +127,14 @@ export class ClaudeCodeBackend implements Backend {
       this.currentAbort = undefined;
 
       if (error instanceof IdleTimeoutError) {
+        // Distinguish startup timeout (no output at all) from idle timeout (output then silence)
+        if (error.stdout === "" && error.stderr === "") {
+          throw new Error(
+            `claude produced no output within ${error.timeout}ms. ` +
+              `This often happens when running nested 'claude -p' inside an existing Claude Code session. ` +
+              `Consider using the SDK backend (model: "anthropic/claude-sonnet-4-5") instead.`,
+          );
+        }
         throw new Error(`claude timed out after ${timeout}ms of inactivity`);
       }
       if (error && typeof error === "object" && "exitCode" in error) {

--- a/packages/agent-worker/src/backends/idle-timeout.ts
+++ b/packages/agent-worker/src/backends/idle-timeout.ts
@@ -57,9 +57,7 @@ export async function execWithIdleTimeout(options: IdleTimeoutOptions): Promise<
   const timeout = Math.max(options.timeout, MIN_TIMEOUT_MS);
   // Startup timeout: cap at idle timeout so short timeouts (e.g., tests) aren't overridden
   const rawStartup =
-    options.startupTimeout !== undefined
-      ? options.startupTimeout
-      : DEFAULT_STARTUP_TIMEOUT;
+    options.startupTimeout !== undefined ? options.startupTimeout : DEFAULT_STARTUP_TIMEOUT;
   const startupTimeout = rawStartup > 0 ? Math.min(rawStartup, timeout) : 0;
 
   let idleTimedOut = false;
@@ -156,9 +154,7 @@ export function execWithIdleTimeoutAbortable(options: IdleTimeoutOptions): {
   const timeout = Math.max(options.timeout, MIN_TIMEOUT_MS);
   // Startup timeout: cap at idle timeout so short timeouts (e.g., tests) aren't overridden
   const rawStartup =
-    options.startupTimeout !== undefined
-      ? options.startupTimeout
-      : DEFAULT_STARTUP_TIMEOUT;
+    options.startupTimeout !== undefined ? options.startupTimeout : DEFAULT_STARTUP_TIMEOUT;
   const startupTimeout = rawStartup > 0 ? Math.min(rawStartup, timeout) : 0;
 
   let idleTimedOut = false;

--- a/packages/agent-worker/test/e2e/backends.test.ts
+++ b/packages/agent-worker/test/e2e/backends.test.ts
@@ -249,7 +249,7 @@ describe.skipIf(!hasCodex || !hasCodexAuth)(
 
 // ─── Cursor Agent ────────────────────────────────────────────
 
-const hasCursor = cliAvailable("cursor");
+const hasCursor = cliAvailable("cursor") || cliAvailable("agent");
 const hasCursorKey = !!process.env.CURSOR_API_KEY;
 
 describe.skipIf(!hasCursor || !hasCursorKey)(


### PR DESCRIPTION
Two issues found when debugging workflow with CLI backends:

1. Startup timeout for unresponsive backends:
   - `claude -p` hangs silently inside nested Claude Code sessions
   - Previously waited full idle timeout (10 min) before failing
   - Now fails fast (30s) if process produces zero output
   - Clear error message suggests using SDK backend instead

2. CursorBackend now supports standalone `agent` binary:
   - `curl -fsS https://cursor.com/install | bash` installs as `agent`
   - Previously only checked for `cursor agent` subcommand style
   - Now tries both: `cursor agent --version` then `agent --version`

https://claude.ai/code/session_014ZqJqKRzuAMxNyxZ9tJkac