### PR TITLE
feat(agent-worker): add --wakeup flag to CLI and schedule support in workflow YAML

### DIFF
--- a/packages/agent-worker/src/agent/config.ts
+++ b/packages/agent-worker/src/agent/config.ts
@@ -7,6 +7,7 @@
 
 import type { BackendType } from "../backends/types.ts";
 import type { ProviderConfig } from "../workflow/types.ts";
+import type { ScheduleConfig } from "../daemon/registry.ts";
 
 export interface AgentConfig {
   /** Agent name (unique within daemon) */
@@ -25,4 +26,6 @@ export interface AgentConfig {
   tag: string;
   /** When this agent was created */
   createdAt: string;
+  /** Periodic wakeup schedule */
+  schedule?: ScheduleConfig;
 }

--- a/packages/agent-worker/src/cli/client.ts
+++ b/packages/agent-worker/src/cli/client.ts
@@ -117,6 +117,7 @@ export function createAgent(body: {
   provider?: string | { name: string; base_url?: string; api_key?: string };
   workflow?: string;
   tag?: string;
+  schedule?: { wakeup: string | number; prompt?: string };
 }): Promise<ApiResponse> {
   return request("POST", "/agents", body);
 }

--- a/packages/agent-worker/src/daemon/daemon.ts
+++ b/packages/agent-worker/src/daemon/daemon.ts
@@ -280,6 +280,7 @@ export function createDaemonApp(
       provider,
       workflow = "global",
       tag = "main",
+      schedule,
     } = body as {
       name: string;
       model: string;
@@ -288,6 +289,7 @@ export function createDaemonApp(
       provider?: string | { name: string; base_url?: string; api_key?: string };
       workflow?: string;
       tag?: string;
+      schedule?: { wakeup: string | number; prompt?: string };
     };
 
     if (!name || !model || !system) {
@@ -307,6 +309,7 @@ export function createDaemonApp(
       workflow,
       tag,
       createdAt: new Date().toISOString(),
+      schedule,
     };
 
     // Worker — execution handle (restore from store if available)
@@ -316,7 +319,7 @@ export function createDaemonApp(
     s.configs.set(name, agentConfig);
     s.workers.set(name, handle);
 
-    return c.json({ name, model, backend, workflow, tag }, 201);
+    return c.json({ name, model, backend, workflow, tag, schedule }, 201);
   });
 
   // ── GET /agents/:name ────────────────────────────────────────
@@ -334,6 +337,7 @@ export function createDaemonApp(
       workflow: cfg.workflow,
       tag: cfg.tag,
       createdAt: cfg.createdAt,
+      schedule: cfg.schedule,
     });
   });
 

--- a/packages/agent-worker/src/workflow/parser.ts
+++ b/packages/agent-worker/src/workflow/parser.ts
@@ -338,6 +338,28 @@ function validateAgent(name: string, agent: unknown, errors: ValidationError[]):
     errors.push({ path: `${path}.tools`, message: 'Optional field "tools" must be an array' });
   }
 
+  // Validate wakeup field
+  if (a.wakeup !== undefined) {
+    if (typeof a.wakeup !== "string" && typeof a.wakeup !== "number") {
+      errors.push({
+        path: `${path}.wakeup`,
+        message: 'Field "wakeup" must be a string (duration or cron) or number (ms)',
+      });
+    } else if (typeof a.wakeup === "number" && a.wakeup <= 0) {
+      errors.push({
+        path: `${path}.wakeup`,
+        message: 'Field "wakeup" must be a positive number when specified as ms',
+      });
+    }
+  }
+
+  if (a.wakeup_prompt !== undefined && typeof a.wakeup_prompt !== "string") {
+    errors.push({
+      path: `${path}.wakeup_prompt`,
+      message: 'Field "wakeup_prompt" must be a string',
+    });
+  }
+
   // Validate provider field
   if (a.provider !== undefined) {
     if (typeof a.provider === "string") {

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -93,6 +93,12 @@ export interface AgentDefinition {
 
   /** Backend timeout in milliseconds (overrides backend default) */
   timeout?: number;
+
+  /** Periodic wakeup schedule: number (ms), duration string ("30s"/"5m"/"2h"), or cron expression */
+  wakeup?: string | number;
+
+  /** Custom prompt for wakeup events */
+  wakeup_prompt?: string;
 }
 
 // ==================== Setup Task ====================


### PR DESCRIPTION
Expose existing ScheduleConfig through two new user-facing interfaces:

CLI: `agent-worker new monitor --wakeup 30s --wakeup-prompt "Check status"`
Workflow YAML: `wakeup` and `wakeup_prompt` fields on agent definitions

Changes:
- Add wakeup/wakeup_prompt fields to AgentDefinition (workflow types)
- Add schedule field to AgentConfig
- Add --wakeup and --wakeup-prompt options to CLI `new` command
- Add schedule to createAgent client API body type
- Handle schedule in daemon POST /agents and GET /agents/:name
- Add validation for wakeup/wakeup_prompt in workflow parser

Closes #85

https://claude.ai/code/session_014mdrBc7iFQqr73vKejr5Rr