### PR TITLE
fix(agent-worker): validate wakeup_prompt requires wakeup in CLI and workflow parser

### DIFF
--- a/packages/agent-worker/src/cli/commands/agent.ts
+++ b/packages/agent-worker/src/cli/commands/agent.ts
@@ -123,6 +123,10 @@ Examples:
       }
 
       // Build schedule config from CLI options
+      if (options.wakeupPrompt && !options.wakeup) {
+        console.error("Error: --wakeup-prompt can only be used with --wakeup.");
+        process.exit(1);
+      }
       let schedule: { wakeup: string; prompt?: string } | undefined;
       if (options.wakeup) {
         schedule = { wakeup: options.wakeup };

--- a/packages/agent-worker/src/workflow/parser.ts
+++ b/packages/agent-worker/src/workflow/parser.ts
@@ -353,11 +353,19 @@ function validateAgent(name: string, agent: unknown, errors: ValidationError[]):
     }
   }
 
-  if (a.wakeup_prompt !== undefined && typeof a.wakeup_prompt !== "string") {
-    errors.push({
-      path: `${path}.wakeup_prompt`,
-      message: 'Field "wakeup_prompt" must be a string',
-    });
+  if (a.wakeup_prompt !== undefined) {
+    if (typeof a.wakeup_prompt !== "string") {
+      errors.push({
+        path: `${path}.wakeup_prompt`,
+        message: 'Field "wakeup_prompt" must be a string',
+      });
+    }
+    if (a.wakeup === undefined) {
+      errors.push({
+        path: `${path}.wakeup_prompt`,
+        message: 'Field "wakeup_prompt" can only be used when "wakeup" is also specified',
+      });
+    }
   }
 
   // Validate provider field


### PR DESCRIPTION
Address Gemini Code Assist review feedback on PR #86:
- CLI: error early when --wakeup-prompt is used without --wakeup
- Workflow parser: reject wakeup_prompt when wakeup is not specified

https://claude.ai/code/session_01JWbWL3ubNUc5sTTzE4b5MV