### PR TITLE
Add schedule-based wakeup support for agents

### DIFF
--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ContextConfig } from "./context/types.ts";
+import type { ScheduleConfig } from "../daemon/registry.ts";
 
 // Re-export context types for convenience
 export type { ContextConfig, FileContextConfig, MemoryContextConfig } from "./context/types.ts";
@@ -131,6 +132,9 @@ export interface ParsedWorkflow {
 export interface ResolvedAgent extends AgentDefinition {
   /** Resolved system prompt content */
   resolvedSystemPrompt?: string;
+
+  /** Schedule config derived from wakeup/wakeup_prompt fields */
+  schedule?: ScheduleConfig;
 }
 
 /** Resolved context configuration */


### PR DESCRIPTION
## Summary
This PR adds support for schedule-based agent wakeups, allowing agents to be triggered periodically based on either time intervals or cron expressions. The feature integrates scheduling configuration throughout the workflow parsing and agent controller layers.

## Key Changes

- **Agent Controller**: Added schedule resolution and wakeup logic that:
  - Resolves `ScheduleConfig` from agent configuration
  - Tracks `lastActivityTime` to measure idle periods
  - Checks for schedule-based wakeups when inbox is empty
  - Supports both interval-based (elapsed time) and cron-based wakeups
  - Injects a system message to trigger agent processing on scheduled wakeup
  - Resets the activity timer on successful message processing

- **Workflow Parser**: Enhanced `resolveAgent()` to:
  - Transform `wakeup` and `wakeup_prompt` fields from agent definitions into a typed `ScheduleConfig` object
  - Pass the resolved schedule to the controller layer

- **Type Definitions**: Updated `ResolvedAgent` interface to include the new `schedule` field derived from wakeup configuration

## Implementation Details

- Schedule wakeup is only checked when the agent's inbox is empty, avoiding unnecessary processing
- The wakeup prompt is customizable via `wakeup_prompt` field, with a sensible default
- Activity tracking ensures the schedule timer resets after agent processes messages
- Startup logging includes schedule information for debugging and monitoring
- Both interval and cron schedule types are supported with appropriate time calculations

https://claude.ai/code/session_01T5G6NYXEm9EvPKHUQJiRn1