### PR TITLE
fix(agent-worker): allow excess arguments in run/start commands

### DIFF
--- a/.github/workflows/changeset-agent.yml
+++ b/.github/workflows/changeset-agent.yml
@@ -69,7 +69,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           bun packages/agent-worker/src/cli/index.ts run workflows/changeset.yml \
-            --guidelines "This project is in 0.x development (pre-1.0). During 0.x: ALWAYS use minor for breaking changes (NOT major). This keeps versions in 0.x range."
+            -- --guidelines "This project is in 0.x development (pre-1.0). During 0.x: ALWAYS use minor for breaking changes (NOT major). This keeps versions in 0.x range."
 
       - name: Check result
         id: result

--- a/packages/agent-worker/src/cli/commands/workflow.ts
+++ b/packages/agent-worker/src/cli/commands/workflow.ts
@@ -12,6 +12,7 @@ export function registerWorkflowCommands(program: Command) {
     .option("--feedback", "Enable feedback tool (agents can report tool/workflow observations)")
     .option("--json", "Output results as JSON")
     .allowUnknownOption() // Workflow params are parsed separately
+    .allowExcessArguments() // Unknown option values appear as excess args
     .addHelpText(
       "after",
       `
@@ -164,6 +165,7 @@ Note: Workflow name is inferred from YAML 'name' field or filename.
     .option("--feedback", "Enable feedback tool (agents can report tool/workflow observations)")
     .option("--json", "Output as JSON")
     .allowUnknownOption() // Workflow params are parsed separately
+    .allowExcessArguments() // Unknown option values appear as excess args
     .addHelpText(
       "after",
       `


### PR DESCRIPTION
Commander v14 rejects excess positional arguments by default. When
workflow params like --guidelines are passed, Commander treats the
option value as an excess positional argument (since it doesn't know
the unknown option takes a value), causing "too many arguments" error.

Adding .allowExcessArguments() lets the existing collectUnknownArgs()
handle workflow param extraction from process.argv as designed.

https://claude.ai/code/session_01NBd4h7iquLyd4Qi36QRudr