### PR TITLE
chore: add changesets for recent undocumented changes (0.14→0.16)

### DIFF
--- a/.changeset/architecture-refactoring.md
+++ b/.changeset/architecture-refactoring.md
@@ -1,0 +1,10 @@
+---
+"agent-worker": patch
+---
+
+Refactor architecture: context store decomposition, AgentLoop rename, deprecated API cleanup
+
+- Decompose monolithic `ContextProviderImpl` into domain-specific stores (`ChannelStore`, `InboxStore`, `DocumentStore`, `ResourceStore`, `StatusStore`)
+- Rename `AgentController` → `AgentLoop` with `controller/` → `loop/` directory move
+- Remove deprecated `AgentSession`/`AgentSessionConfig` aliases from public exports
+- Clean technical debt: remove unused imports, dead code, and deprecated instance fields

--- a/.changeset/provider-auto-discovery.md
+++ b/.changeset/provider-auto-discovery.md
@@ -1,0 +1,10 @@
+---
+"agent-worker": minor
+---
+
+Add provider auto-discovery and model fallback chains
+
+- Auto-detect available AI providers by scanning environment variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.)
+- Support `AGENT_DEFAULT_MODELS` env var with comma-separated fallback chain (e.g. `deepseek-chat, anthropic/claude-sonnet-4-5`)
+- Fall back to direct provider SDK when `AI_GATEWAY_API_KEY` is unavailable, fixing CI environments with only provider-specific keys
+- Lazy-load and cache provider SDKs for reuse

--- a/.changeset/security-and-infra.md
+++ b/.changeset/security-and-infra.md
@@ -1,0 +1,10 @@
+---
+"agent-worker": patch
+---
+
+Security hardening, zod v4 upgrade, and CLI improvements
+
+- Prevent command injection in git ref handling: validate refs with allowlist, use `execFileSync` instead of `execSync`, replace shell `rm -rf` with `rmSync`
+- Upgrade zod from v3 to v4 (`^4.3.6`), update `z.record()` calls to explicit key/value types
+- Use standard `--` separator for passing workflow params in CLI, replacing fragile `allowUnknownOption` hack
+- Fix typecheck in CI without `@types/bun` by adding `preserveSymlinks` config

--- a/.changeset/workflow-remote-sources.md
+++ b/.changeset/workflow-remote-sources.md
@@ -1,0 +1,11 @@
+---
+"agent-worker": minor
+---
+
+Add remote GitHub workflow sources and workflow params support
+
+- Support `github:owner/repo@ref/path/file.yml` and shorthand `github:owner/repo@ref#name` syntax for remote workflows
+- Clone remote repos to `~/.cache/agent-worker/sources/` with shallow fetch and cache invalidation
+- Expose `${{ source.dir }}` for referencing files relative to the workflow source
+- Add `params` block in workflow YAML with type validation and default values
+- Extract reusable workflow definitions (`workflows/review.yml`, `workflows/changeset.yml`)


### PR DESCRIPTION
Four changeset files covering significant changes that were released
in 0.15.0 and 0.16.0 with inadequate changelog descriptions:

- workflow-remote-sources: remote GitHub workflow sources, params support
- provider-auto-discovery: env var scanning, model fallback chains
- architecture-refactoring: context store decomposition, AgentLoop rename
- security-and-infra: command injection fix, zod v4, CLI -- separator

https://claude.ai/code/session_01UJbUPT9cRenih6DcD4DDmV