### PR TITLE
design: drop global workspace, simplify to personal + workspace model

### DIFF
--- a/.memory/decisions/2026-02-24-agent-top-level-architecture.md
+++ b/.memory/decisions/2026-02-24-agent-top-level-architecture.md
@@ -1,7 +1,7 @@
 # ADR: Agent as Top-Level Entity
 
 **Date**: 2026-02-24
-**Status**: Proposed
+**Status**: Accepted (amended by 2026-02-26-drop-global-workspace.md)
 **Context**: User wants to replace openclaw with agent-worker; needs agents as first-class entities with persistent context
 
 ---
@@ -34,7 +34,7 @@ Key changes:
 ### Positive
 - Agents accumulate knowledge over time (memory, notes persist)
 - Single agent definition reused across multiple workflows
-- Agents work standalone in global workspace without workflow
+- Agents work standalone via DM without workflow (amended: no global workspace, see 2026-02-26)
 - Clear separation: who (agent) vs where (workspace) vs how (workflow)
 
 ### Risks

--- a/.memory/decisions/2026-02-26-drop-global-workspace.md
+++ b/.memory/decisions/2026-02-26-drop-global-workspace.md
@@ -1,0 +1,124 @@
+# ADR: Drop Global Workspace, Simplify to Personal + Workspace
+
+**Date**: 2026-02-26
+**Status**: Accepted
+**Amends**: 2026-02-24-agent-top-level-architecture.md
+
+---
+
+## Problem
+
+The AGENT-TOP-LEVEL proposal (2026-02-24) introduced three layers of context:
+1. Agent personal context (memory, soul, notes, todo)
+2. Global workspace (shared channel/documents for standalone agents)
+3. Workflow workspace (per-workflow channel/documents)
+
+The "global workspace" was an awkward concept — a shared container pretending to be a workspace, trying to answer "where do standalone agents live?" But standalone agents don't need a shared space; they need their own personal context and DM capability.
+
+In the current implementation, standalone agents already expose the contradiction:
+- Each gets its own workflow key (`standalone:{name}`) — runtime isolation
+- But all share the same directory (`.workflow/global/main/`) — accidental storage sharing
+- Worst of both: neither truly shared nor truly isolated
+
+## Decision
+
+**Drop the global workspace. Two data types only: Agent personal context + Workspace.**
+
+### The model
+
+```
+Agent (defined in .agents/)
+├── Personal context (memory, notes, conversations, config)
+│   └── Always available, travels with the agent
+│
+├── State: idle
+│   └── No workspace, DM only, uses personal context
+│
+└── State: active (in one or more workspaces)
+    └── Personal context + workspace context (channel, documents, inbox)
+```
+
+### Key design points
+
+1. **"Standalone" is a state, not a type.** All agents in `.agents/` are the same kind of entity. An agent with no active workspace is "idle" — it accepts DMs and works from personal context. No fake `standalone:{name}` workflow needed.
+
+2. **DM is DM, not a workspace message.** `send alice "hi"` goes directly to alice's personal context. It does not post to any channel or workspace.
+
+3. **Collaboration requires explicit workspace.** Two idle agents cannot communicate without a workflow/workspace. This is a correct constraint — want collaboration? Create a workspace. No implicit global fallback.
+
+4. **Borrowing model (借调).** When alice is referenced in a workflow, she's "seconded" to that workspace. She has personal (home) + workspace (local) data. Default read/write targets workspace; accessing personal data is explicit.
+
+5. **Inline agents unchanged.** Workflows can still define agents inline. Inline agents have no personal context — they're temporary, workflow-local.
+
+### Send semantics
+
+```
+send alice "hi"              → DM to alice (personal context, no workspace)
+send @review @alice "task"   → post to review workspace channel, @mention alice
+send alice@review "task"     → wake alice in review workspace context
+```
+
+### Data structure (updated)
+
+```
+.agents/
+├── alice.yaml              # Agent definition
+└── alice/                  # Agent personal context
+    ├── memory/             # Persistent structured knowledge
+    ├── notes/              # Freeform reflections
+    ├── conversations/      # DM history
+    └── todo/               # Cross-session tasks
+
+.workflows/
+├── review.yaml             # Workflow definition
+
+.workspace/                 # Runtime workspaces (no global/)
+├── review/main/
+│   ├── channel.md
+│   ├── documents/
+│   └── inbox/
+└── review/pr-123/
+    ├── channel.md
+    ├── documents/
+    └── inbox/
+```
+
+Note: `.workspace/global/` is gone. No global workspace directory.
+
+### Context layers when borrowed
+
+```
+alice in review/pr-123:
+  Layer 1: .agents/alice/                 ← personal (identity + memory) — always
+  Layer 2: .workspace/review/pr-123/      ← workspace (collaboration) — current mission
+
+  Read/write defaults to Layer 2 (workspace)
+  Layer 1 accessible via explicit scope (scope: "personal" / scope: "home")
+```
+
+## Consequences
+
+### Positive
+- Simpler mental model: personal + workspace, no third layer
+- DM is a natural concept, no channel pretending to be DM
+- Eliminates the `standalone:{name}` hack in daemon
+- Explicit workspace creation for collaboration (no hidden shared state)
+- Agent idle state needs no runtime infrastructure (no MCP server until workspace)
+
+### Trade-offs
+- Multi-standalone-agent coordination requires creating a workflow (intentional friction)
+- Daemon needs new code path for DM (not workspace-based, just agent personal context)
+
+## Implementation Impact
+
+Phase 3 of AGENT-TOP-LEVEL ("Workspace Separation") changes:
+- Remove global workspace from WorkspaceRegistry
+- Add DM code path in daemon (agent personal context only, no workspace)
+- `ensureAgentLoop` for idle agents creates loop with personal context only (no MCP workspace tools)
+- When agent joins workflow, add workspace context to existing loop or create new loop with both
+
+## References
+
+- Full design: `packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md`
+- Superseded concept: "Global Workspace" from the 2026-02-24 proposal
+- CLI terminology: `.memory/decisions/2026-02-08-cli-design-unified-terminology.md`

--- a/.memory/decisions/2026-02-27-unified-logger.md
+++ b/.memory/decisions/2026-02-27-unified-logger.md
@@ -15,18 +15,23 @@ Logger → ContextProvider.appendChannel() → ChannelStore → channel.jsonl
 
 `Message` 结构 + `EventKind` 已覆盖所有事件类型。`ChannelStore` 支持 append-only JSONL、增量 sync、visibility 过滤。
 
-**但 channel 是 per-workspace 的**——它是 agent 间通信的共享空间，绑在 workflow context 目录下。daemon 级别的事件（启动、registry 操作）不属于任何 workspace。
+**但 channel 是 per-workspace 的**——它是 agent 间通信的共享空间，绑在 workflow context 目录下。两类事件无处安放：
+
+1. **Daemon 级别**：启动/关闭、registry 操作——不属于任何 workspace，也不属于任何 agent
+2. **Agent 级别**：malformed YAML、maxSteps、state 变迁、worker 错误——属于 agent 自身的操作历史，不是 agent 间通信，也不是基础设施
 
 以下事件没有持久化：
 
-| 来源 | 事件 | 现状 |
-|------|------|------|
-| daemon | 启动/关闭/端口分配 | `console.log` → 消失 |
-| agent-handle | malformed YAML 跳过 | `console.warn` → 消失 |
-| agent-registry | agent 加载/创建/删除 | callback / 无 |
-| worker | maxSteps 到达 | `console.warn` → 消失 |
-| idle-timeout | callback 执行错误 | `console.error` → 消失 |
-| skills/importer | 导入进度/失败 | `console.log/error` → 消失 |
+| 来源 | 事件 | 归属层级 | 现状 |
+|------|------|----------|------|
+| daemon | 启动/关闭/端口分配 | daemon | `console.log` → 消失 |
+| agent-registry | agent 加载/创建/删除 | daemon | callback / 无 |
+| skills/importer | 导入进度/失败 | daemon | `console.log/error` → 消失 |
+| agent-handle | malformed YAML 跳过 | **agent** | `console.warn` → 消失 |
+| worker | maxSteps 到达 | **agent** | `console.warn` → 消失 |
+| worker | state 变迁 idle→running→stopped | **agent** | 无 |
+| idle-timeout | callback 执行错误 | **agent** | `console.error` → 消失 |
+| worker | backend 调用/重试 | **agent** | 无 |
 
 ### 目标
 
@@ -34,21 +39,36 @@ Logger → ContextProvider.appendChannel() → ChannelStore → channel.jsonl
 
 ## Decision
 
-### 两层存储，共享格式
+### 三层存储，共享格式
 
 ```
 ~/.agent-worker/
-├── events.jsonl                          ← daemon event log（新的）
+├── events.jsonl                              ← daemon event log（新的）
 └── workflows/<name>/<tag>/
-    └── channel.jsonl                     ← workspace channel（已有）
+    └── channel.jsonl                         ← workspace channel（已有）
+
+.agents/<name>/
+└── timeline.jsonl                            ← agent timeline（新的）
 ```
 
 | 层级 | 文件 | 内容 | 谁写 |
 |------|------|------|------|
-| **Daemon event log** | `events.jsonl` | 启动/关闭、registry CRUD、跨 workspace 事件 | daemon、registry、agent-handle |
-| **Workspace channel** | `channel.jsonl` | agent 通信、tool call、workflow 内部事件 | ContextProvider（已有，不变） |
+| **Daemon** | `~/.agent-worker/events.jsonl` | 启动/关闭、registry CRUD、importer 进度 | daemon、registry |
+| **Agent** | `.agents/<name>/timeline.jsonl` | state 变迁、maxSteps、malformed YAML、worker 错误/重试 | agent-handle、worker、loop |
+| **Workspace** | `channel.jsonl` | agent 间通信、tool call、workflow 内部事件 | ContextProvider（已有，不变） |
 
-两者共享 `Message` 格式和 `EventKind` 类型。统一时间线通过**读取时合并**实现（类似 `git log --all`），不是写入时混在一起。
+三者共享 `Message` 格式和 `EventKind` 类型。统一时间线通过**读取时合并**实现（类似 `git log --all`），不是写入时混在一起。
+
+**为什么三层而不是两层？**
+
+Agent timeline 和 workspace channel 职责不同：
+
+- **channel** 是 agent 间通信——"我跟你说了什么"
+- **timeline** 是 agent 自身操作记录——"我做了什么"
+
+把 agent 操作事件放进 workspace channel 会污染通信流。放进 daemon event log 则丧失了 agent 归属（daemon 级别不知道是哪个 agent 的 maxSteps 到了）。每个 agent 拥有自己的 timeline 是最自然的归属。
+
+**Agent timeline 跟随 agent 而非 workspace。** Agent 可以参与多个 workspace，但 timeline 始终在 `.agents/<name>/timeline.jsonl`。这与 agent-top-level 设计一致：personal context travels with the agent。
 
 ### 1. `EventSink` — 最小写入接口
 
@@ -59,11 +79,43 @@ export interface EventSink {
 }
 ```
 
-两个实现都满足：
+三个实现都满足：
 - `ChannelStore.append()` → workspace channel（已有，Promise 返回值兼容）
 - 新的 `DaemonEventLog` → daemon events.jsonl
+- 新的 `TimelineStore` → agent timeline.jsonl
 
-### 2. `createEventLogger(sink, from)` — Logger → EventSink
+### 2. `TimelineStore` — Agent 级别事件存储
+
+```typescript
+export class DefaultTimelineStore implements EventSink {
+  constructor(private storage: StorageBackend) {}
+
+  append(from: string, content: string, options?: { kind?: EventKind }): void {
+    const event: Message = {
+      id: nanoid(),
+      timestamp: new Date().toISOString(),
+      from,
+      content,
+      mentions: [],
+      kind: options?.kind ?? "system",
+    };
+    const line = JSON.stringify(event) + "\n";
+    // fire-and-forget, same pattern as DaemonEventLog
+    void this.storage.append("timeline.jsonl", line);
+  }
+
+  async read(offset?: number): Promise<{ events: Message[]; offset: number }> {
+    // Same incremental sync pattern as ChannelStore
+    const { content, offset: newOffset } = await this.storage.readFrom("timeline.jsonl", offset ?? 0);
+    const events = content.split("\n").filter(Boolean).map((l) => JSON.parse(l));
+    return { events, offset: newOffset };
+  }
+}
+```
+
+`TimelineStore` 用同样的 `StorageBackend` 接口。`FileStorage` → 文件，`MemoryStorage` → 测试。换存储后端不影响任何逻辑。
+
+### 3. `createEventLogger(sink, from)` — Logger → EventSink
 
 ```typescript
 export function createEventLogger(sink: EventSink, from?: string): Logger {
@@ -79,19 +131,23 @@ export function createEventLogger(sink: EventSink, from?: string): Logger {
 }
 ```
 
-### 3. Daemon 拥有 event log
+### 4. 各层拥有各自的 event log
 
 ```typescript
-// daemon.ts startup
-const eventLog = new DaemonEventLog(daemonDir); // → events.jsonl
-const logger = createEventLogger(eventLog, "daemon");
+// Daemon level
+const daemonLog = new DaemonEventLog(daemonDir);           // → events.jsonl
+const daemonLogger = createEventLogger(daemonLog, "daemon");
+const registry = new AgentRegistry(projectDir, daemonLogger.child("registry"));
 
-const registry = new AgentRegistry(projectDir, logger.child("registry"));
+// Agent level — per agent
+const agentStorage = new FileStorage(agentContextDir);      // → .agents/<name>/
+const timeline = new DefaultTimelineStore(agentStorage);
+const agentLogger = createEventLogger(timeline, agentName);
+// worker、loop、agent-handle 使用 agentLogger
+
+// Workspace level — unchanged
+// createChannelLogger({ provider }) 保持原样
 ```
-
-### 4. Workspace channel 不变
-
-`createChannelLogger({ provider })` 保持原样。Workflow 内部仍写入 workspace-scoped channel.jsonl。
 
 ### 5. CLI 无 daemon 时降级
 
@@ -110,29 +166,36 @@ export function createConsoleSink(): EventSink {
 ### 6. 统一时间线 = 合并读取
 
 ```bash
-agent-worker logs                          # tail daemon events.jsonl
-agent-worker logs --workspace <name>       # tail workspace channel.jsonl
-agent-worker logs --all                    # 合并两者，按 timestamp 排序
-agent-worker logs --debug                  # 含 debug kind
-agent-worker logs --from=registry          # 按 from 过滤
+agent-worker logs                              # tail daemon events.jsonl
+agent-worker logs --agent alice                # tail alice's timeline.jsonl
+agent-worker logs --workspace review           # tail workspace channel.jsonl
+agent-worker logs --all                        # 合并三层，按 timestamp 排序
+agent-worker logs --debug                      # 含 debug kind
+agent-worker logs --from=worker                # 按 from 过滤
 ```
 
 ## Migration Order
 
 1. 定义 `EventSink` 接口
 2. 实现 `DaemonEventLog`（append-only JSONL，复用 `Message` 格式）
-3. 实现 `createEventLogger(sink, from)` + `createConsoleSink()`
-4. Daemon 启动时创建 event log + logger
-5. 库代码（AgentHandle / Registry / worker / idle-timeout / importer）接收 Logger
-6. 清除所有库代码 `console.*`
-7. CLI 入口注入 logger（daemon → EventSink，直接 → ConsoleSink）
-8. 可选：`agent-worker logs` 命令
+3. 实现 `DefaultTimelineStore`（同样的 append-only JSONL，用 `StorageBackend`）
+4. 实现 `createEventLogger(sink, from)` + `createConsoleSink()`
+5. Daemon 启动时创建 daemon event log + logger
+6. Agent 创建时创建 timeline store + logger
+7. 库代码接收 Logger：
+   - daemon 级别（Registry / importer）→ daemon logger
+   - agent 级别（AgentHandle / worker / loop / idle-timeout）→ agent logger
+8. 清除所有库代码 `console.*`
+9. CLI 入口注入 logger（daemon → EventSink，agent → TimelineStore，直接 → ConsoleSink）
+10. 可选：`agent-worker logs` 命令
 
 ## Consequences
 
-- **两层分离**：workspace channel 是 agent 通信，daemon event log 是运维事件，职责清晰
-- **统一格式**：共享 Message + EventKind，合并读取时无需转换
+- **三层分离**：daemon event log 是基础设施，agent timeline 是个人操作历史，workspace channel 是 agent 间通信——各归各位
+- **统一格式**：三层共享 `Message` + `EventKind`，合并读取时无需转换
+- **provider 可替换**：`TimelineStore` 通过 `StorageBackend` 注入，`FileStorage`/`MemoryStorage`/任何自定义实现均可
 - **显示与存储分离**：存全部，显示按需过滤
-- **零外部依赖**：EventSink ~5 行，DaemonEventLog ~30 行
+- **零外部依赖**：`EventSink` ~5 行，`DaemonEventLog` ~30 行，`TimelineStore` ~30 行
 - **向后兼容**：workspace channel 完全不变
 - **降级优雅**：无 daemon 时 ConsoleSink → stderr
+- **与 agent-top-level 一致**：timeline 跟随 agent personal context，跨 workspace 携带

--- a/.memory/decisions/2026-02-27-unified-logger.md
+++ b/.memory/decisions/2026-02-27-unified-logger.md
@@ -1,0 +1,140 @@
+# ADR: Unified Logger
+
+**Date**: 2026-02-27
+**Status**: Proposed
+
+## Context
+
+项目有两条日志路径：
+
+1. **CLI/daemon** — 直接 `console.*`，用户界面输出，合理
+2. **Workflow** — `Logger` → `ContextProvider.appendChannel()`，已有抽象
+
+问题出在**库代码**（非 CLI、非 workflow）散落的 `console.*`：
+
+| 文件 | 调用 | 问题 |
+|------|------|------|
+| `agent-handle.ts:76` | `console.warn(malformed yaml)` | daemon 模式下污染输出 |
+| `worker.ts:313` | `console.warn(maxSteps limit)` | 同上 |
+| `idle-timeout.ts:100` | `console.error(callback error)` | 同上 |
+| `skills/importer.ts:37,45,61` | `console.log/error(import status)` | CLI 上下文合理，但被 daemon 调用时不合理 |
+
+还有一种散落的 callback 模式：
+
+| 文件 | 签名 |
+|------|------|
+| `yaml-parser.ts` | `log?: (msg: string) => void` |
+| `agent-registry.ts` | `log?: (msg: string) => void` |
+| `loop/types.ts` | `log / infoLog / errorLog` 三个 callback |
+
+## Decision
+
+### 1. 复用现有 `Logger` 接口
+
+`workflow/logger.ts` 的 `Logger` 接口已经够用（debug/info/warn/error + child）。不引入新抽象。
+
+### 2. 新增 `createConsoleLogger(options?)`
+
+给非 workflow 上下文用。写到 stderr，尊重 debug flag：
+
+```typescript
+export interface ConsoleLoggerConfig {
+  /** Show debug messages (default: false) */
+  debug?: boolean;
+  /** Prefix for all messages */
+  from?: string;
+}
+
+export function createConsoleLogger(config?: ConsoleLoggerConfig): Logger {
+  const { debug: showDebug = false, from } = config ?? {};
+  const prefix = from ? `[${from}] ` : "";
+
+  return {
+    debug: (msg, ...args) => {
+      if (showDebug) console.error(`${prefix}${msg}`, ...args);
+    },
+    info: (msg, ...args) => console.error(`${prefix}${msg}`, ...args),
+    warn: (msg, ...args) => console.error(`${prefix}[WARN] ${msg}`, ...args),
+    error: (msg, ...args) => console.error(`${prefix}[ERROR] ${msg}`, ...args),
+    isDebug: () => showDebug,
+    child: (childPrefix) => createConsoleLogger({
+      debug: showDebug,
+      from: from ? `${from}:${childPrefix}` : childPrefix,
+    }),
+  };
+}
+```
+
+关键设计：
+- **全部 stderr**：永不污染 stdout（JSON 输出、pipe 安全）
+- **debug 默认关**：生产环境安静
+- **child() 支持**：与 ChannelLogger 行为一致
+
+### 3. 库代码接收 `Logger` 参数
+
+替换散落的 `console.*` 和 `log?: (msg) => void` callback：
+
+```typescript
+// Before
+class AgentHandle {
+  async readMemory() {
+    // ...
+    catch { console.warn(`Skipping malformed...`) }
+  }
+}
+
+// After
+class AgentHandle {
+  private readonly logger: Logger;
+  constructor(def, contextDir, logger?: Logger) {
+    this.logger = logger ?? createSilentLogger();
+  }
+  async readMemory() {
+    // ...
+    catch (err) { this.logger.warn(`Skipping malformed memory file ${file}:`, err) }
+  }
+}
+```
+
+同理：
+- `AgentRegistry` 构造时传 logger，替换 `loadFromDisk(log?)` callback
+- `worker.ts` 的 `console.warn(maxSteps)` → `this.logger.warn(...)`
+- `idle-timeout.ts` → 接收 logger 参数
+- `skills/importer.ts` → 接收 logger 参数
+
+### 4. 统一 callback → Logger
+
+loop 的三个 callback (`log/infoLog/errorLog`) 已通过 `factory.ts` 从 Logger 映射。保持现状，但新代码不再新增 callback 模式，直接传 Logger。
+
+### 5. CLI 入口负责创建 Logger
+
+```
+CLI command
+  └─ createConsoleLogger({ debug: options.debug })
+       └─ 传给 AgentRegistry / AgentHandle / worker ...
+
+Daemon
+  └─ createConsoleLogger({ debug, from: "daemon" })
+       └─ 传给内部组件
+
+Workflow
+  └─ createChannelLogger({ provider })  ← 已有，不变
+```
+
+## Migration Order
+
+1. 在 `workflow/logger.ts` 中添加 `createConsoleLogger`
+2. `AgentHandle` 构造函数加 `logger?: Logger`，替换 `console.warn`
+3. `AgentRegistry` 构造函数加 `logger?: Logger`，替换 `loadFromDisk(log?)`
+4. `worker.ts` 接收 logger，替换 `console.warn`
+5. `idle-timeout.ts` 接收 logger，替换 `console.error`
+6. `skills/importer.ts` 接收 logger，替换 `console.log/error`
+7. CLI 入口 (`agent.ts`, `daemon.ts`) 创建并传递 logger
+
+## Consequences
+
+- **库代码零 `console.*`**：所有日志通过 Logger 接口，调用方决定输出方式
+- **向后兼容**：logger 参数都是 optional，默认 silent
+- **daemon 安静**：不传 logger 就没有输出
+- **CLI 可控**：`--debug` 控制 debug 级别
+- **不引入外部依赖**：复用已有接口 + 一个 ~20 行的 console 实现

--- a/.memory/notes/2026-02-27-phase0-prep-complete.md
+++ b/.memory/notes/2026-02-27-phase0-prep-complete.md
@@ -1,0 +1,43 @@
+# Phase 0 Pre-Implementation Cleanup
+
+**Date**: 2026-02-27
+**Agent**: Session 018 (Phase 0 implementer)
+**Status**: Complete — all 6 tasks done, 880 tests pass
+
+## What Was Done
+
+Structural preparation for AGENT-TOP-LEVEL architecture:
+
+1. **Renamed types**: `AgentDefinition` → `WorkflowAgentDef`, `ResolvedAgent` → `ResolvedWorkflowAgent` across 14 files. Frees the names for Phase 1.
+
+2. **Decoupled AgentConfig**: `workflow` and `tag` are now optional. Standalone agents no longer pretend to belong to a workflow at creation. CLI handles the undefined case.
+
+3. **Added lifecycle tests**: 8 new tests covering create → findLoop → execute → delete → cleanup paths. Safety net for the structural changes in tasks 4-5.
+
+4. **Extracted loop ownership**: `DaemonState.loops: Map<string, AgentLoop>` now exists alongside `workflows`. `findLoop()` checks daemon loops first, then workflow-scoped loops. `ensureAgentLoop()` stores in both. This is the key structural inversion for Phase 3.
+
+5. **Formalized standalone convention**: `standaloneKey()` helper, `STANDALONE_PREFIX` constant, `WorkflowHandle.standalone` flag. GET /health and GET /workflows filter out standalone handles. The magic string `standalone:` is now centralized and typed.
+
+6. **Made buildAgentPrompt composable**: `PromptSection` type, each section is an independent function, `DEFAULT_SECTIONS` list, `assemblePrompt()` combinator. Phase 5 can inject soul/memory/todo as new sections without touching existing code.
+
+## Design Decisions
+
+- **Did NOT build FileStateStore**: Phase 3 replaces SessionState entirely with JSONL ConversationLog + ThinThread. Building FileStateStore for the current shape would be wasted work.
+
+- **Did NOT refactor ContextProvider**: Current interface maps cleanly to Workspace. Personal context is a new module, not a split of the existing one.
+
+- **Kept standalone WorkflowHandle**: It still manages runtime resources (MCP server, context provider). Removing it entirely requires a new structure for per-agent resource management, which is Phase 3 scope.
+
+## What's Next
+
+Phase 1: Agent Definition + Context
+- New `AgentDefinition` type (prompt, soul, context fields)
+- Agent YAML parser (`.agents/*.yaml`)
+- `AgentHandle` with context operations
+- `AgentRegistry` — loads and manages definitions
+- CLI: `agent create`, `agent list`, `agent info`
+- Agent context directory auto-creation
+
+## Lesson
+
+The rename was the easiest task but had the highest value — it removed naming ambiguity before it could compound across new code. Type names are architectural signals. Getting them right early saves confusion for every agent that follows.

--- a/.memory/todos/index.md
+++ b/.memory/todos/index.md
@@ -14,7 +14,7 @@ todos/
 
 | 优先级 | 任务 | 状态 | 链接 |
 |--------|------|------|------|
-| low | agent-handle.ts console.warn 需替换为可配置 logger，避免污染 CLI/daemon 输出 | open | - |
+| medium | 统一 logger：库代码零 console.*，通过 Logger 接口输出 | open | [ADR](../decisions/2026-02-27-unified-logger.md) |
 
 ## 使用场景
 

--- a/.memory/todos/index.md
+++ b/.memory/todos/index.md
@@ -14,7 +14,7 @@ todos/
 
 | 优先级 | 任务 | 状态 | 链接 |
 |--------|------|------|------|
-| - | 暂无活跃任务 | - | - |
+| low | agent-handle.ts console.warn 需替换为可配置 logger，避免污染 CLI/daemon 输出 | open | - |
 
 ## 使用场景
 

--- a/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
+++ b/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
@@ -1170,7 +1170,7 @@ participation.
 - [x] CLI: `agent create`, `agent list`, `agent info`, `agent delete`
 - [x] Agent context directory auto-creation (memory/, notes/, conversations/, todo/)
 
-### Phase 2: Workflow Agent References
+### Phase 2: Workflow Agent References ✅
 
 **Goal**: Workflows reference global agents instead of defining them inline.
 
@@ -1193,6 +1193,7 @@ participation.
 - [ ] Agent timeline: `.agents/<name>/timeline.jsonl` (state changes, errors, maxSteps)
 - [ ] `createEventLogger(sink, from)` + `createConsoleSink()` (graceful degradation)
 - [ ] Replace library `console.*` with injected Logger
+- [ ] (Optional) `agent-worker logs` CLI command (tail/filter event logs)
 
 ### Phase 3b: Daemon Agent Registry + Workspace
 
@@ -1203,6 +1204,7 @@ participation.
 - [ ] `WorkspaceRegistry` for managing active workspaces
 - [ ] Workspace attach/detach when workflows start/stop
 - [ ] Remove `standalone:{name}` workflow key hack (Workspace takes over resource management)
+- [ ] `send` CLI command with target parsing (DM / @workspace / agent@workspace)
 
 ### Phase 3c: Conversation Model
 
@@ -1224,6 +1226,7 @@ participation.
 - [ ] `AgentInstruction` type with workspace context (null = DM) and priority
 - [ ] Cooperative preemption: yield between steps, re-queue with progress marker
 - [ ] `InstructionProgress` for yielded instruction resume
+- [ ] Scheduled wakeup: `schedule.wakeup` interval → enqueue instruction at background priority
 
 ### Phase 4: Recall Tools + Auto-Memory + Failure Handling
 

--- a/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
+++ b/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
@@ -121,6 +121,8 @@ context:                # Agent's own persistent context directory
   #   notes/          — freeform reflection/learning
   #   conversations/  — DM history
   #   todo/           — cross-session task tracking
+  # Auto-created files:
+  #   timeline.jsonl  — agent operation history (state changes, errors, maxSteps)
 
 # Optional runtime config
 max_tokens: 8000
@@ -146,8 +148,9 @@ schedule:
 │   └── 2026-02-25-learned-about-auth.md
 ├── conversations/    # DM history (append-only JSONL logs)
 │   └── 2026-02-26.jsonl
-└── todo/             # Cross-session task tracking
-    └── index.md
+├── todo/             # Cross-session task tracking
+│   └── index.md
+└── timeline.jsonl    # Agent operation history (append-only JSONL)
 ```
 
 ### Soul

--- a/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
+++ b/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
@@ -4,6 +4,9 @@
 **Status**: Proposed
 **Supersedes**: Inline agent definitions in workflow YAML
 
+> **实施原则：不考虑向后兼容。** 不写兼容遗留代码，不保留 deprecated 接口，不加 shim 或 fallback。
+> 每个 phase 直接用新结构替换旧结构。旧接口该删就删，旧路径该断就断。
+
 ---
 
 ## Problem

--- a/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
+++ b/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
@@ -391,13 +391,15 @@ project/
 │   │   ├── memory/
 │   │   ├── notes/
 │   │   ├── conversations/      # DM history
-│   │   └── todo/
+│   │   ├── todo/
+│   │   └── timeline.jsonl      # Operation history (state, errors, maxSteps)
 │   ├── bob.yaml
 │   └── bob/
 │       ├── memory/
 │       ├── notes/
 │       ├── conversations/
-│       └── todo/
+│       ├── todo/
+│       └── timeline.jsonl
 │
 ├── .workflows/                 # Workflow definitions
 │   ├── review.yaml
@@ -1197,6 +1199,10 @@ participation.
 - [ ] Log persistence (personal → `.agents/<name>/conversations/`, workspace → `.workspace/`)
 - [ ] `thin_thread` config in agent definition (default: 10 messages)
 - [ ] Thin thread integration in prompt assembly
+- [ ] Unified event log: `EventSink` interface + `DaemonEventLog` + `DefaultTimelineStore`
+- [ ] Agent timeline: `.agents/<name>/timeline.jsonl` (state changes, errors, maxSteps)
+- [ ] `createEventLogger(sink, from)` + `createConsoleSink()` (graceful degradation)
+- [ ] Replace library `console.*` with injected Logger
 
 ### Phase 3b: Priority Queue + Preemption
 
@@ -1317,7 +1323,8 @@ project/
 │       ├── memory/             # 结构化知识（YAML key-value）
 │       ├── notes/              # 自由格式笔记（markdown）
 │       ├── conversations/      # DM 历史（Phase 3 启用）
-│       └── todo/               # 跨 session 任务追踪
+│       ├── todo/               # 跨 session 任务追踪
+│       └── timeline.jsonl      # 操作历史（Phase 3 启用）
 │
 ├── review.yaml                 # 现有 workflow（格式不变）
 └── ...

--- a/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
+++ b/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
@@ -829,17 +829,19 @@ This is intentional: workflows are isolated collaboration spaces.
 Cross-pollination happens through the agent's persistent identity, not through
 direct messaging.
 
-### DMs: User → Agent Only (V1)
+### DMs: User → Agent Only
 
-Direct messages are **user-to-agent** only in V1:
+Direct messages are **user-to-agent** only. Agent-to-agent DMs are not supported:
 
 - `send alice "review this"` → user to alice (immediate priority)
-- Agent-to-agent DMs → deferred to V2
+- Agent-to-agent → must go through a workspace channel
 
-**Rationale**: Agent-to-agent DMs outside a workspace would need a routing
-mechanism with no natural scope boundary. Within a workspace, the channel
-provides that scope. For V1, personal context transfer is sufficient for
-cross-workflow knowledge sharing.
+**Rationale**: Agent-to-agent DMs would be an unobservable side channel — hard
+to debug, hard to audit, and prone to message loops. If two agents need to
+communicate, they belong in the same workflow. The workspace channel provides
+scope, observability, and natural coordination. Cross-workflow knowledge sharing
+happens through agent personal context (memory/notes that travel with the agent),
+not through direct messaging.
 
 ---
 
@@ -1269,14 +1271,14 @@ agent-worker agent notes architect  # See what architect has learned
 
 3. ~~**DM conversation management**~~ → **Conversation Model § Thread Lifecycle**: DM conversations are continuous personal threads, persisted to `.agents/<name>/conversations/`. Summarized into memory when context window exceeded.
 
+4. ~~**Agent-to-agent DMs**~~ → **Agent-to-Agent Communication § DMs**: Not supported. Agent communication must go through workspace channels (observable, scoped, debuggable). Cross-workflow knowledge sharing uses personal context.
+
 ### Open
 
-4. **Agent context format** — Should memory be YAML, JSON, or freeform markdown? Different formats suit different use cases. Proposal: memory/ is YAML (structured, searchable), notes/ is markdown (freeform).
+5. **Agent context format** — Should memory be YAML, JSON, or freeform markdown? Different formats suit different use cases. Proposal: memory/ is YAML (structured, searchable), notes/ is markdown (freeform).
 
-5. **Soul mutability** — Can a soul evolve over time (agent learns and updates its own soul), or is it fixed by the definition? Proposal: soul in YAML is the baseline; agents can propose soul updates that the user approves.
+6. **Soul mutability** — Can a soul evolve over time (agent learns and updates its own soul), or is it fixed by the definition? Proposal: soul in YAML is the baseline; agents can propose soul updates that the user approves.
 
-6. **Cross-project agents** — Should agents be portable across projects? (e.g., `~/.agents/alice.yaml` shared globally). Proposal: start project-scoped, add global scope later.
+7. **Cross-project agents** — Should agents be portable across projects? (e.g., `~/.agents/alice.yaml` shared globally). Proposal: start project-scoped, add global scope later.
 
-7. **Thread summarization model** — What model/strategy to use for compressing old thread messages into summaries? Options: (a) same model as the agent (expensive but high quality), (b) fast model like haiku (cheap, might lose nuance), (c) hybrid (fast model + agent review). Proposal: fast model by default, configurable.
-
-8. **Agent-to-agent DMs (V2)** — Should agents be able to DM each other outside of a workspace? Use case: alice asks bob a question without a shared workflow. Requires: routing, permission model, preventing message loops. Deferred to V2.
+8. **Thread summarization model** — What model/strategy to use for compressing old thread messages into summaries? Options: (a) same model as the agent (expensive but high quality), (b) fast model like haiku (cheap, might lose nuance), (c) hybrid (fast model + agent review). Proposal: fast model by default, configurable.

--- a/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
+++ b/packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md
@@ -1169,12 +1169,12 @@ participation.
 
 **Goal**: Workflows reference global agents instead of defining them inline.
 
-- [ ] `AgentEntry` discriminated union: `RefAgentEntry | InlineAgentEntry`
-- [ ] Agent resolution: ref → load from registry + apply overrides
-- [ ] Prompt assembly: base system prompt + workflow append (soul/memory/todo injection deferred to Phase 5)
-- [ ] Updated workflow parser (handle both ref and inline)
-- [ ] Updated `WorkflowFile` type
-- [ ] Inline definitions are a formal type (`InlineAgentEntry`), not a compat shim
+- [x] `AgentEntry` discriminated union: `RefAgentEntry | InlineAgentEntry`
+- [x] Agent resolution: ref → load from registry + apply overrides
+- [x] Prompt assembly: base system prompt + workflow append (soul/memory/todo injection deferred to Phase 5)
+- [x] Updated workflow parser (handle both ref and inline)
+- [x] Updated `WorkflowFile` type
+- [x] Inline definitions are a formal type (`InlineAgentEntry`), not a compat shim
 
 ### Phase 3: Daemon Agent Registry + Workspace
 

--- a/packages/agent-worker/docs/architecture/PHASE0-PREP.md
+++ b/packages/agent-worker/docs/architecture/PHASE0-PREP.md
@@ -1,0 +1,119 @@
+# Phase 0: Pre-Implementation Cleanup
+
+**Date**: 2026-02-27
+**Status**: In Progress
+**Prerequisite for**: AGENT-TOP-LEVEL Phases 1-3
+
+---
+
+## Why
+
+AGENT-TOP-LEVEL 定义了 6 个实施阶段。但当前代码有几个结构性问题会阻碍实施：
+
+1. **命名冲突** — 当前 `AgentDefinition` 是 workflow 层的类型（`system_prompt`, `wakeup`），新架构需要一个同名但完全不同的顶层类型（`prompt`, `soul`, `context`）。两者同时存在会造成混乱。
+2. **Agent-Workflow 耦合** — `AgentConfig` 有必填的 `workflow` 和 `tag` 字段，每个 agent 创建时就绑定到一个 workflow。新架构要求 agent 独立于 workflow 存在。
+3. **Loop 归属权倒置** — `WorkflowHandle.loops` 拥有 agent loops。新架构要求 daemon 拥有 loops，workflow 只引用它们。
+4. **`standalone:` hack** — 独立 agent 通过假的 `WorkflowHandle`（key 为 `standalone:{name}`）运行。这是 #3 的症状，消除 #3 后自然消失。
+5. **Prompt 建构不可组合** — `buildAgentPrompt` 是单一函数，硬编码 workflow 上下文。新架构需要注入 soul/memory/todo 段落。
+
+这些不是"nice to have"的重构 — 它们是实施 Phase 1-3 的前置条件。
+
+---
+
+## Tasks
+
+### 0.1 Rename `AgentDefinition` → `WorkflowAgentDef`
+
+**Blocks**: Phase 1（需要定义新的 `AgentDefinition`）
+**Risk**: Zero — 纯重命名
+**Scope**: ~15 files
+
+当前 `AgentDefinition`（workflow/types.ts:76）描述 workflow 内的 agent 配置。重命名为 `WorkflowAgentDef`，释放 `AgentDefinition` 给新的顶层 agent 定义。
+
+同步重命名：
+- `ResolvedAgent` → `ResolvedWorkflowAgent`（已有命名冲突：AGENT-TOP-LEVEL.md 也用了这个名字）
+
+### 0.2 Decouple `AgentConfig` from workflow
+
+**Blocks**: Phase 1（agent 需要独立于 workflow 注册）
+**Risk**: Low — 向后兼容（保留默认值）
+**Scope**: agent/config.ts, daemon.ts, CLI commands
+
+改动：
+- `workflow` 和 `tag` 变为 optional（`workflow?: string`, `tag?: string`）
+- `POST /agents` 不再要求 workflow，默认 undefined
+- `findLoop()` 和 `ensureAgentLoop()` 适配无 workflow 的 agent
+- `configToResolvedAgent()` 不依赖 workflow 字段
+
+### 0.3 Add daemon agent lifecycle tests
+
+**Blocks**: 0.4, 0.5（安全网）
+**Risk**: Zero — 只加测试
+**Scope**: test/unit/
+
+为即将改动的路径增加集成测试：
+- Standalone agent lifecycle: create → run → delete
+- `ensureAgentLoop` lazy creation
+- `findLoop` across workflows
+- Agent cleanup on delete（包括 standalone workflow handle）
+
+### 0.4 Extract loop ownership from `WorkflowHandle`
+
+**Blocks**: Phase 3（daemon 需要拥有 agent loops）
+**Risk**: Medium — 触及执行路径
+**Scope**: daemon.ts, factory.ts
+
+改动：
+- `DaemonState` 增加 `loops: Map<string, AgentLoop>`
+- `WorkflowHandle.loops` 变为引用（ref）而非拥有（own）
+- `ensureAgentLoop()` 在 daemon loops map 中创建
+- `findLoop()` 从 daemon loops map 查找
+- Workflow shutdown 不再负责 stop agent loops（standalone loops 由 daemon 管理）
+- Workflow loops 仍然需要 stop workflow-local 的 inline agents
+
+### 0.5 Remove `standalone:` hack
+
+**Depends**: 0.4
+**Blocks**: Phase 3 cleanup
+**Risk**: Low（0.4 完成后很自然）
+**Scope**: daemon.ts
+
+改动：
+- Standalone agent 不再创建假的 `WorkflowHandle`
+- `ensureAgentLoop()` 只在 daemon loops map 中创建 loop + runtime
+- `DELETE /agents/:name` 直接从 daemon loops map 清理
+- `GET /health` 和 `GET /agents` 从 daemon loops map 获取状态
+
+### 0.6 Make `buildAgentPrompt` composable
+
+**Blocks**: Phase 2/5（需要注入新的 prompt 段落）
+**Risk**: Low — 纯函数重构
+**Scope**: workflow/loop/prompt.ts
+
+改动：
+- 提取 `PromptSection` 接口：`(ctx) => string | null`
+- 每个当前段落变成独立 section（project, inbox, activity, document, retry, instructions）
+- `buildAgentPrompt` 变成组合器：接收 sections 数组，拼接非 null 结果
+- 默认 sections 列表保持当前行为
+- Phase 5 新增 sections：soul, memory, todo
+
+---
+
+## Skip List
+
+以下不在 Phase 0 范围内（原因见 AGENT-TOP-LEVEL.md）：
+
+| Item | Reason |
+|------|--------|
+| `FileStateStore` | Phase 3 直接替换为 JSONL ConversationLog + ThinThread，不走中间状态 |
+| `ContextProvider` 拆分 | 当前接口映射到 Workspace，不需要改。Personal context 是新模块 |
+| Legacy workers 清理 | 第 18 任已统一到 controller 路径。剩余 workers map 是测试桩，不阻塞 |
+
+---
+
+## Verification
+
+每个 task 完成后：
+1. `bun test` 全部通过
+2. `bun run build` clean
+3. 无行为变更（纯结构重构）

--- a/packages/agent-worker/docs/architecture/PHASE0-PREP.md
+++ b/packages/agent-worker/docs/architecture/PHASE0-PREP.md
@@ -1,8 +1,10 @@
 # Phase 0: Pre-Implementation Cleanup
 
 **Date**: 2026-02-27
-**Status**: In Progress
+**Status**: Complete (all 6 tasks done, 880 tests pass)
 **Prerequisite for**: AGENT-TOP-LEVEL Phases 1-3
+
+> **实施原则：不考虑向后兼容。** Phase 1+ 不写兼容遗留代码，不保留 deprecated 接口，直接替换。
 
 ---
 

--- a/packages/agent-worker/docs/architecture/PHASE0-PREP.md
+++ b/packages/agent-worker/docs/architecture/PHASE0-PREP.md
@@ -73,18 +73,21 @@ AGENT-TOP-LEVEL 定义了 6 个实施阶段。但当前代码有几个结构性�
 - Workflow shutdown 不再负责 stop agent loops（standalone loops 由 daemon 管理）
 - Workflow loops 仍然需要 stop workflow-local 的 inline agents
 
-### 0.5 Remove `standalone:` hack
+### 0.5 Formalize `standalone:` convention
 
 **Depends**: 0.4
 **Blocks**: Phase 3 cleanup
-**Risk**: Low（0.4 完成后很自然）
+**Risk**: Low
 **Scope**: daemon.ts
 
-改动：
-- Standalone agent 不再创建假的 `WorkflowHandle`
-- `ensureAgentLoop()` 只在 daemon loops map 中创建 loop + runtime
-- `DELETE /agents/:name` 直接从 daemon loops map 清理
-- `GET /health` 和 `GET /agents` 从 daemon loops map 获取状态
+原计划完全移除 WorkflowHandle，实际保留用于运行时资源管理（MCP server、context provider）。
+完全移除需要新的 Workspace 类型接管资源——这是 Phase 3 范围。
+
+实际改动：
+- `standaloneKey()` helper + `STANDALONE_PREFIX` 常量集中管理
+- `WorkflowHandle.standalone` 布尔标记（用于 GET /health、GET /workflows 过滤）
+- Loop 存在 `s.loops`（daemon 拥有），WorkflowHandle 仅管理 MCP/context 生命周期
+- Phase 3 用 Workspace 替换后可以彻底去掉
 
 ### 0.6 Make `buildAgentPrompt` composable
 

--- a/packages/agent-worker/docs/workflow/SCHEMA.md
+++ b/packages/agent-worker/docs/workflow/SCHEMA.md
@@ -1,0 +1,308 @@
+<!-- Auto-generated from src/workflow/schema.ts — DO NOT EDIT -->
+<!-- Regenerate: bun scripts/gen-workflow-ref.ts > docs/workflow/SCHEMA.md -->
+
+# Workflow YAML Schema Reference
+
+Source of truth: [`src/workflow/schema.ts`](../../src/workflow/schema.ts)
+
+---
+
+## Workflow File
+
+Workflow file — defines agents, context, and orchestration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | no | Workflow name (defaults to filename without extension) |
+| `agents` | Record<string, [AgentEntry](#agent-entry)> | **yes** | Agent definitions — keyed by agent name |
+| `context` | [ContextConfig](#context-configuration) | no | Shared context — `undefined`/`null` = default file provider, `false` = disabled |
+| `params` | [ParamDefinition](#parameter-definitions)[] | no | CLI-style parameter definitions |
+| `setup` | [SetupTask](#setup-tasks)[] | no | Setup commands — run sequentially before kickoff |
+| `kickoff` | string | no | Kickoff message — initiates the workflow via `@mention`. Supports variable interpolation |
+
+### Example
+
+```yaml
+name: review
+
+agents:
+  alice: { ref: alice }
+  bob:
+    ref: bob
+    prompt:
+      append: Focus on performance issues.
+  helper:
+    model: anthropic/claude-haiku-4-5
+    system_prompt: You help with quick lookups.
+
+context: null    # default file provider
+
+params:
+  - name: target
+    description: Branch to review
+    required: true
+
+setup:
+  - shell: git diff main...${{ params.target }}
+    as: changes
+
+kickoff: |
+  @alice Review these changes:
+  ${{ changes }}
+```
+
+---
+
+## Agent Entry
+
+Agent entry — either a `ref` to a global agent or an inline definition. Discriminated by presence of `ref`
+
+Workflows support two agent entry types:
+
+| Type | Discriminator | Use Case |
+|------|--------------|----------|
+| **Ref agent** | Has `ref` field | Reference a global agent from `.agents/*.yaml` |
+| **Inline agent** | No `ref` field | Define a workflow-local temporary agent |
+
+### Ref Agent Entry
+
+Reference to a global agent definition — carries persistent context (memory, notes, todo)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ref` | string | **yes** | Name of the global agent to reference (from `.agents/*.yaml`) |
+| `prompt` | object | no | Prompt extension for this workflow |
+| `max_tokens` | number | no | Override maximum tokens for response |
+| `max_steps` | number | no | Override maximum tool call steps per turn |
+
+**Disallowed fields**: `model`, `backend`, `provider`, `tools`, `system_prompt`, `wakeup`, `wakeup_prompt`, `timeout` — these come from the agent definition.
+
+#### Examples
+
+```yaml
+# Shorthand — use agent as-is
+alice: { ref: alice }
+
+# With prompt extension
+bob:
+  ref: bob
+  prompt:
+    append: |
+      In this workflow, focus on security issues.
+
+# With runtime overrides
+charlie:
+  ref: charlie
+  max_tokens: 16000
+  max_steps: 50
+```
+
+### Inline Agent Entry
+
+Inline agent definition — workflow-local, no persistent identity
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `backend` | `"default"` \| `"claude"` \| `"cursor"` \| `"codex"` \| `"opencode"` \| `"mock"` | no | Backend to use. `default` = Vercel AI SDK, others = CLI wrappers. CLI backends (`claude`, `cursor`, `codex`, `opencode`) don't require `model` |
+| `model` | string | no | Model identifier. Required for `default` backend. Formats: `provider/model`, `provider:model`, or `auto` for env-based detection |
+| `provider` | string \| [ProviderConfig](#provider-configuration) | no | Provider configuration — string (built-in name) or object (custom endpoint) |
+| `system_prompt` | string | no | System prompt — inline string or file path ending in `.txt`/`.md` (auto-loaded) |
+| `tools` | string[] | no | Tool names to enable for this agent |
+| `max_tokens` | number | no | Maximum tokens for response |
+| `max_steps` | number | no | Maximum tool call steps per turn (default: 200) |
+| `timeout` | number | no | Backend timeout in milliseconds (overrides backend default) |
+| `wakeup` | string \| number | no | Periodic wakeup schedule: number (ms), duration string (`"30s"`/`"5m"`/`"2h"`), or cron expression |
+| `wakeup_prompt` | string | no | Custom prompt for wakeup events (requires `wakeup` to be set) |
+
+#### Backend model requirements
+
+| Backend | `model` required? | Notes |
+|---------|-------------------|-------|
+| `default` | **yes** | Vercel AI SDK — needs model identifier |
+| `claude` | no | Uses Claude Code CLI defaults |
+| `cursor` | no | Uses Cursor Agent defaults |
+| `codex` | no | Uses Codex CLI defaults |
+| `opencode` | no | Uses OpenCode CLI defaults |
+| `mock` | no | Testing backend — echoes input |
+
+#### Examples
+
+```yaml
+# Minimal inline agent
+helper:
+  model: anthropic/claude-haiku-4-5
+  system_prompt: You help with quick lookups.
+
+# CLI backend (no model needed)
+coder:
+  backend: claude
+  system_prompt: You write code.
+
+# Full configuration
+reviewer:
+  model: anthropic/claude-sonnet-4-5
+  provider:
+    name: anthropic
+    base_url: https://custom.api.com
+    api_key: $CUSTOM_API_KEY
+  system_prompt: prompts/reviewer.md
+  tools: [read_file, write_file]
+  max_tokens: 8000
+  max_steps: 100
+  timeout: 120000
+
+# With periodic wakeup
+monitor:
+  model: anthropic/claude-haiku-4-5
+  system_prompt: Check system health.
+  wakeup: 5m
+  wakeup_prompt: Run your health check now.
+```
+
+---
+
+## Provider Configuration
+
+Custom provider configuration for API endpoint overrides
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | **yes** | Provider SDK name (e.g., `anthropic`, `openai`) |
+| `base_url` | string | no | Override base URL for the provider |
+| `api_key` | string | no | API key — env var reference with `$` prefix (e.g., `$MINIMAX_API_KEY`) or literal value |
+
+#### Examples
+
+```yaml
+# String shorthand
+provider: anthropic
+
+# Custom endpoint
+provider:
+  name: anthropic
+  base_url: https://api.minimax.io/anthropic/v1
+  api_key: $MINIMAX_API_KEY
+```
+
+---
+
+## Context Configuration
+
+Shared context for agent collaboration (channel, inbox, documents).
+
+| Value | Behavior |
+|-------|----------|
+| *(not set)* / `null` | Default file provider enabled |
+| `false` | Context explicitly disabled |
+| `{ provider: "file", ... }` | File-based context (ephemeral or persistent) |
+| `{ provider: "memory" }` | In-memory context (for testing) |
+
+### File Context Config
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `dir` | string | no | Ephemeral context directory path (template variables supported) |
+| `bind` | string | no | Persistent context directory path — state survives across runs |
+
+> `dir` and `bind` are mutually exclusive. `bind` enables persistent mode.
+
+#### Examples
+
+```yaml
+# Default (auto-generated ephemeral dir)
+context: null
+
+# Disabled
+context: false
+
+# Persistent context
+context:
+  provider: file
+  config:
+    bind: ./data/review
+
+# In-memory (testing)
+context:
+  provider: memory
+```
+
+---
+
+## Parameter Definitions
+
+CLI-style workflow parameter definition
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | **yes** | Parameter name (used as `--name` on CLI) |
+| `description` | string | no | Human-readable description |
+| `type` | `"string"` \| `"number"` \| `"boolean"` | no | Value type (default: `"string"`) |
+| `short` | string | no | Short flag — single character (used as `-x` on CLI) |
+| `required` | boolean | no | Whether the parameter is required |
+| `default` | string \| number \| boolean | no | Default value when not provided |
+
+Parameters are passed on the CLI after the workflow file and accessible via `${{ params.name }}` interpolation.
+
+#### Example
+
+```yaml
+params:
+  - name: target
+    description: Branch to review
+    type: string
+    short: t
+    required: true
+  - name: depth
+    description: Analysis depth
+    type: number
+    default: 3
+  - name: verbose
+    description: Enable verbose output
+    type: boolean
+    short: v
+```
+
+CLI usage:
+
+```sh
+moniro run review.yml --target main -v --depth 5
+```
+
+---
+
+## Setup Tasks
+
+Setup command — runs before kickoff to prepare variables
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `shell` | string | **yes** | Shell command to execute before kickoff |
+| `as` | string | no | Variable name to store command output (accessible via `${{ name }}` interpolation) |
+
+Setup tasks run sequentially before kickoff. Output captured via `as` is available in `${{ name }}` interpolation.
+
+Reserved variable names: `env`, `workflow`, `params`, `source`
+
+#### Example
+
+```yaml
+setup:
+  - shell: git diff main...HEAD
+    as: changes
+  - shell: date -u +%Y-%m-%d
+    as: today
+```
+
+---
+
+## Variable Interpolation
+
+Variables use `${{ name }}` syntax throughout the workflow YAML (kickoff, system_prompt, etc.).
+
+| Namespace | Example | Source |
+|-----------|---------|--------|
+| *(top-level)* | `${{ changes }}` | Setup task output (`as: changes`) |
+| `env.*` | `${{ env.API_KEY }}` | Environment variables |
+| `params.*` | `${{ params.target }}` | CLI parameters |
+| `workflow.*` | `${{ workflow.name }}` | Workflow metadata |
+| `source.*` | `${{ source.dir }}` | Source directory path |

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -29,6 +29,7 @@
     "format": "oxfmt src",
     "format:check": "oxfmt src --check",
     "typecheck": "tsgo",
+    "gen:schema": "bun scripts/gen-workflow-ref.ts > docs/workflow/SCHEMA.md",
     "prepublishOnly": "bun run build"
   },
   "dependencies": {

--- a/packages/agent-worker/scripts/gen-workflow-ref.ts
+++ b/packages/agent-worker/scripts/gen-workflow-ref.ts
@@ -1,0 +1,444 @@
+#!/usr/bin/env bun
+/**
+ * Generate Workflow YAML Reference from Zod schema.
+ *
+ * Usage:
+ *   bun scripts/gen-workflow-ref.ts                    # stdout
+ *   bun scripts/gen-workflow-ref.ts > docs/workflow/SCHEMA.md
+ *
+ * Source of truth: src/workflow/schema.ts
+ */
+
+import {
+  WorkflowFileSchema,
+  AgentEntrySchema,
+  RefAgentEntrySchema,
+  InlineAgentEntrySchema,
+  ContextConfigSchema,
+  ParamDefinitionSchema,
+  SetupTaskSchema,
+  ProviderConfigSchema,
+} from "../src/workflow/schema.ts";
+
+// ── Zod 4 Introspection Helpers ──────────────────────────────────
+
+interface FieldInfo {
+  name: string;
+  type: string;
+  required: boolean;
+  description: string;
+}
+
+/**
+ * Named type references — map schema instances to markdown links.
+ * Used to render "[AgentEntry](#agent-entry)" instead of "object | object".
+ */
+const NAMED_TYPES = new Map<any, string>();
+
+function registerNamedType(schema: any, label: string, anchor: string): void {
+  NAMED_TYPES.set(schema, `[${label}](#${anchor})`);
+}
+
+/** Get the Zod def type string */
+function defType(schema: any): string {
+  return schema?._zod?.def?.type ?? "unknown";
+}
+
+/** Get human-readable type string from a Zod schema */
+function typeString(schema: any): string {
+  // Check named type map first
+  if (NAMED_TYPES.has(schema)) return NAMED_TYPES.get(schema)!;
+
+  const dt = defType(schema);
+
+  switch (dt) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "literal": {
+      const val = schema._zod.def.value;
+      return typeof val === "string" ? `\`"${val}"\`` : `\`${val}\``;
+    }
+    case "enum": {
+      const values = [...schema._zod.values];
+      return values.map((v: string) => `\`"${v}"\``).join(" \\| ");
+    }
+    case "array": {
+      const el = schema._zod.def.element;
+      return `${typeString(el)}[]`;
+    }
+    case "optional": {
+      const inner = schema._zod.def.innerType;
+      // Check named types for the inner schema too
+      if (NAMED_TYPES.has(inner)) return NAMED_TYPES.get(inner)!;
+      return typeString(inner);
+    }
+    case "union": {
+      const opts = schema._zod.def.options;
+      // Check if the whole union is named
+      return opts.map((o: any) => typeString(o)).join(" \\| ");
+    }
+    case "object":
+      return "object";
+    case "record": {
+      const val = schema._zod.def.valueType;
+      return `Record<string, ${typeString(val)}>`;
+    }
+    default:
+      return dt;
+  }
+}
+
+/** Check if a schema is optional */
+function isOptional(schema: any): boolean {
+  return defType(schema) === "optional";
+}
+
+/** Unwrap optional to get inner schema */
+function unwrap(schema: any): any {
+  if (defType(schema) === "optional") {
+    return schema._zod.def.innerType;
+  }
+  return schema;
+}
+
+/** Get description from a schema (checks inner for optionals) */
+function getDesc(schema: any): string {
+  return schema.description ?? unwrap(schema)?.description ?? "";
+}
+
+/** Extract field info from an object schema */
+function extractFields(schema: any): FieldInfo[] {
+  const shape = schema._zod?.def?.shape;
+  if (!shape) return [];
+
+  const fields: FieldInfo[] = [];
+  for (const [name, fieldSchema] of Object.entries(shape) as [string, any][]) {
+    fields.push({
+      name,
+      type: typeString(fieldSchema),
+      required: !isOptional(fieldSchema),
+      description: getDesc(fieldSchema),
+    });
+  }
+  return fields;
+}
+
+/** Render a fields table */
+function fieldsTable(fields: FieldInfo[]): string {
+  if (fields.length === 0) return "";
+  const lines = [
+    "| Field | Type | Required | Description |",
+    "|-------|------|----------|-------------|",
+  ];
+  for (const f of fields) {
+    const req = f.required ? "**yes**" : "no";
+    lines.push(`| \`${f.name}\` | ${f.type} | ${req} | ${f.description} |`);
+  }
+  return lines.join("\n");
+}
+
+// ── Document Generation ──────────────────────────────────────────
+
+function generate(): string {
+  // Register named types for cross-referencing
+  registerNamedType(AgentEntrySchema, "AgentEntry", "agent-entry");
+  registerNamedType(RefAgentEntrySchema, "RefAgentEntry", "ref-agent-entry");
+  registerNamedType(InlineAgentEntrySchema, "InlineAgentEntry", "inline-agent-entry");
+  registerNamedType(ContextConfigSchema, "ContextConfig", "context-configuration");
+  registerNamedType(ParamDefinitionSchema, "ParamDefinition", "parameter-definitions");
+  registerNamedType(SetupTaskSchema, "SetupTask", "setup-tasks");
+  registerNamedType(ProviderConfigSchema, "ProviderConfig", "provider-configuration");
+
+  const sections: string[] = [];
+
+  sections.push(`<!-- Auto-generated from src/workflow/schema.ts — DO NOT EDIT -->
+<!-- Regenerate: bun scripts/gen-workflow-ref.ts > docs/workflow/SCHEMA.md -->
+
+# Workflow YAML Schema Reference
+
+Source of truth: [\`src/workflow/schema.ts\`](../../src/workflow/schema.ts)
+
+---`);
+
+  // ── Top-level
+  sections.push(`## Workflow File
+
+${WorkflowFileSchema.description}
+
+${fieldsTable(extractFields(WorkflowFileSchema))}
+
+### Example
+
+\`\`\`yaml
+name: review
+
+agents:
+  alice: { ref: alice }
+  bob:
+    ref: bob
+    prompt:
+      append: Focus on performance issues.
+  helper:
+    model: anthropic/claude-haiku-4-5
+    system_prompt: You help with quick lookups.
+
+context: null    # default file provider
+
+params:
+  - name: target
+    description: Branch to review
+    required: true
+
+setup:
+  - shell: git diff main...\${{ params.target }}
+    as: changes
+
+kickoff: |
+  @alice Review these changes:
+  \${{ changes }}
+\`\`\``);
+
+  // ── Agent Entry
+  sections.push(`---
+
+## Agent Entry
+
+${AgentEntrySchema.description ?? ""}
+
+Workflows support two agent entry types:
+
+| Type | Discriminator | Use Case |
+|------|--------------|----------|
+| **Ref agent** | Has \`ref\` field | Reference a global agent from \`.agents/*.yaml\` |
+| **Inline agent** | No \`ref\` field | Define a workflow-local temporary agent |`);
+
+  // ── Ref Agent
+  sections.push(`### Ref Agent Entry
+
+${RefAgentEntrySchema.description}
+
+${fieldsTable(extractFields(RefAgentEntrySchema))}
+
+**Disallowed fields**: \`model\`, \`backend\`, \`provider\`, \`tools\`, \`system_prompt\`, \`wakeup\`, \`wakeup_prompt\`, \`timeout\` — these come from the agent definition.
+
+#### Examples
+
+\`\`\`yaml
+# Shorthand — use agent as-is
+alice: { ref: alice }
+
+# With prompt extension
+bob:
+  ref: bob
+  prompt:
+    append: |
+      In this workflow, focus on security issues.
+
+# With runtime overrides
+charlie:
+  ref: charlie
+  max_tokens: 16000
+  max_steps: 50
+\`\`\``);
+
+  // ── Inline Agent
+  sections.push(`### Inline Agent Entry
+
+${InlineAgentEntrySchema.description}
+
+${fieldsTable(extractFields(InlineAgentEntrySchema))}
+
+#### Backend model requirements
+
+| Backend | \`model\` required? | Notes |
+|---------|-------------------|-------|
+| \`default\` | **yes** | Vercel AI SDK — needs model identifier |
+| \`claude\` | no | Uses Claude Code CLI defaults |
+| \`cursor\` | no | Uses Cursor Agent defaults |
+| \`codex\` | no | Uses Codex CLI defaults |
+| \`opencode\` | no | Uses OpenCode CLI defaults |
+| \`mock\` | no | Testing backend — echoes input |
+
+#### Examples
+
+\`\`\`yaml
+# Minimal inline agent
+helper:
+  model: anthropic/claude-haiku-4-5
+  system_prompt: You help with quick lookups.
+
+# CLI backend (no model needed)
+coder:
+  backend: claude
+  system_prompt: You write code.
+
+# Full configuration
+reviewer:
+  model: anthropic/claude-sonnet-4-5
+  provider:
+    name: anthropic
+    base_url: https://custom.api.com
+    api_key: \$CUSTOM_API_KEY
+  system_prompt: prompts/reviewer.md
+  tools: [read_file, write_file]
+  max_tokens: 8000
+  max_steps: 100
+  timeout: 120000
+
+# With periodic wakeup
+monitor:
+  model: anthropic/claude-haiku-4-5
+  system_prompt: Check system health.
+  wakeup: 5m
+  wakeup_prompt: Run your health check now.
+\`\`\``);
+
+  // ── Provider Config
+  sections.push(`---
+
+## Provider Configuration
+
+${ProviderConfigSchema.description}
+
+${fieldsTable(extractFields(ProviderConfigSchema))}
+
+#### Examples
+
+\`\`\`yaml
+# String shorthand
+provider: anthropic
+
+# Custom endpoint
+provider:
+  name: anthropic
+  base_url: https://api.minimax.io/anthropic/v1
+  api_key: \$MINIMAX_API_KEY
+\`\`\``);
+
+  // ── Context
+  sections.push(`---
+
+## Context Configuration
+
+Shared context for agent collaboration (channel, inbox, documents).
+
+| Value | Behavior |
+|-------|----------|
+| *(not set)* / \`null\` | Default file provider enabled |
+| \`false\` | Context explicitly disabled |
+| \`{ provider: "file", ... }\` | File-based context (ephemeral or persistent) |
+| \`{ provider: "memory" }\` | In-memory context (for testing) |
+
+### File Context Config
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| \`dir\` | string | no | Ephemeral context directory path (template variables supported) |
+| \`bind\` | string | no | Persistent context directory path — state survives across runs |
+
+> \`dir\` and \`bind\` are mutually exclusive. \`bind\` enables persistent mode.
+
+#### Examples
+
+\`\`\`yaml
+# Default (auto-generated ephemeral dir)
+context: null
+
+# Disabled
+context: false
+
+# Persistent context
+context:
+  provider: file
+  config:
+    bind: ./data/review
+
+# In-memory (testing)
+context:
+  provider: memory
+\`\`\``);
+
+  // ── Params
+  sections.push(`---
+
+## Parameter Definitions
+
+${ParamDefinitionSchema.description}
+
+${fieldsTable(extractFields(ParamDefinitionSchema))}
+
+Parameters are passed on the CLI after the workflow file and accessible via \`\${{ params.name }}\` interpolation.
+
+#### Example
+
+\`\`\`yaml
+params:
+  - name: target
+    description: Branch to review
+    type: string
+    short: t
+    required: true
+  - name: depth
+    description: Analysis depth
+    type: number
+    default: 3
+  - name: verbose
+    description: Enable verbose output
+    type: boolean
+    short: v
+\`\`\`
+
+CLI usage:
+
+\`\`\`sh
+moniro run review.yml --target main -v --depth 5
+\`\`\``);
+
+  // ── Setup
+  sections.push(`---
+
+## Setup Tasks
+
+${SetupTaskSchema.description}
+
+${fieldsTable(extractFields(SetupTaskSchema))}
+
+Setup tasks run sequentially before kickoff. Output captured via \`as\` is available in \`\${{ name }}\` interpolation.
+
+Reserved variable names: \`env\`, \`workflow\`, \`params\`, \`source\`
+
+#### Example
+
+\`\`\`yaml
+setup:
+  - shell: git diff main...HEAD
+    as: changes
+  - shell: date -u +%Y-%m-%d
+    as: today
+\`\`\``);
+
+  // ── Interpolation
+  sections.push(`---
+
+## Variable Interpolation
+
+Variables use \`\${{ name }}\` syntax throughout the workflow YAML (kickoff, system_prompt, etc.).
+
+| Namespace | Example | Source |
+|-----------|---------|--------|
+| *(top-level)* | \`\${{ changes }}\` | Setup task output (\`as: changes\`) |
+| \`env.*\` | \`\${{ env.API_KEY }}\` | Environment variables |
+| \`params.*\` | \`\${{ params.target }}\` | CLI parameters |
+| \`workflow.*\` | \`\${{ workflow.name }}\` | Workflow metadata |
+| \`source.*\` | \`\${{ source.dir }}\` | Source directory path |`);
+
+  return sections.join("\n\n");
+}
+
+// ── Main ─────────────────────────────────────────────────────────
+
+console.log(generate());

--- a/packages/agent-worker/src/agent/agent-handle.ts
+++ b/packages/agent-worker/src/agent/agent-handle.ts
@@ -1,0 +1,152 @@
+/**
+ * AgentHandle — Runtime wrapper for an agent definition + persistent context.
+ *
+ * Created by AgentRegistry when an agent is loaded. Provides:
+ *   - Context directory management (memory/, notes/, conversations/, todo/)
+ *   - Read/write operations for personal context
+ *   - State tracking (idle, running, stopped, error)
+ *
+ * Phase 1 scope: context directory + read/write ops.
+ * Phase 3 adds: loop, workspaces, threads.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { join, basename } from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import type { AgentDefinition } from "./definition.ts";
+import { CONTEXT_SUBDIRS } from "./definition.ts";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export type AgentHandleState = "idle" | "running" | "stopped" | "error";
+
+// ── AgentHandle ───────────────────────────────────────────────────
+
+export class AgentHandle {
+  /** Agent definition (from YAML) */
+  readonly definition: AgentDefinition;
+
+  /** Absolute path to agent's persistent context directory */
+  readonly contextDir: string;
+
+  /** Current agent state */
+  state: AgentHandleState = "idle";
+
+  constructor(definition: AgentDefinition, contextDir: string) {
+    this.definition = definition;
+    this.contextDir = contextDir;
+  }
+
+  /** Agent name (convenience accessor) */
+  get name(): string {
+    return this.definition.name;
+  }
+
+  // ── Context Directory ───────────────────────────────────────────
+
+  /**
+   * Ensure the context directory and all subdirectories exist.
+   * Called on agent load/creation. Idempotent.
+   */
+  ensureContextDir(): void {
+    for (const sub of CONTEXT_SUBDIRS) {
+      mkdirSync(join(this.contextDir, sub), { recursive: true });
+    }
+  }
+
+  // ── Memory (structured key-value) ───────────────────────────────
+
+  /**
+   * Read all memory entries as key-value records.
+   * Memory files are YAML in memory/<key>.yaml.
+   */
+  async readMemory(): Promise<Record<string, unknown>> {
+    const memDir = join(this.contextDir, "memory");
+    if (!existsSync(memDir)) return {};
+
+    const result: Record<string, unknown> = {};
+    for (const file of readdirSync(memDir)) {
+      if (!file.endsWith(".yaml") && !file.endsWith(".yml")) continue;
+      const key = basename(file).replace(/\.ya?ml$/i, "");
+      try {
+        const content = readFileSync(join(memDir, file), "utf-8");
+        result[key] = parseYaml(content);
+      } catch {
+        // Skip malformed files
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Write a memory entry. Creates/overwrites memory/<key>.yaml.
+   */
+  async writeMemory(key: string, value: unknown): Promise<void> {
+    const memDir = join(this.contextDir, "memory");
+    mkdirSync(memDir, { recursive: true });
+    writeFileSync(join(memDir, `${key}.yaml`), stringifyYaml(value));
+  }
+
+  // ── Notes (freeform reflections) ────────────────────────────────
+
+  /**
+   * Read agent's notes, most recent first.
+   * Notes are markdown files in notes/.
+   */
+  async readNotes(limit?: number): Promise<string[]> {
+    const notesDir = join(this.contextDir, "notes");
+    if (!existsSync(notesDir)) return [];
+
+    const files = readdirSync(notesDir)
+      .filter((f) => f.endsWith(".md"))
+      .sort()
+      .reverse();
+
+    const selected = limit ? files.slice(0, limit) : files;
+    return selected.map((f) => readFileSync(join(notesDir, f), "utf-8"));
+  }
+
+  /**
+   * Append a note. Creates notes/<date>-<slug>.md.
+   */
+  async appendNote(content: string, slug?: string): Promise<string> {
+    const notesDir = join(this.contextDir, "notes");
+    mkdirSync(notesDir, { recursive: true });
+
+    const date = new Date().toISOString().slice(0, 10);
+    const suffix = slug ?? `note-${Date.now().toString(36)}`;
+    const filename = `${date}-${suffix}.md`;
+    const filePath = join(notesDir, filename);
+
+    writeFileSync(filePath, content);
+    return filename;
+  }
+
+  // ── Todos (cross-session task tracking) ─────────────────────────
+
+  /**
+   * Read active todos from todo/index.md.
+   * Returns lines that look like incomplete tasks: "- [ ] ..."
+   */
+  async readTodos(): Promise<string[]> {
+    const todoFile = join(this.contextDir, "todo", "index.md");
+    if (!existsSync(todoFile)) return [];
+
+    const content = readFileSync(todoFile, "utf-8");
+    return content
+      .split("\n")
+      .filter((line) => line.match(/^\s*-\s*\[\s*\]/))
+      .map((line) => line.replace(/^\s*-\s*\[\s*\]\s*/, "").trim());
+  }
+
+  /**
+   * Write the full todo list. Replaces todo/index.md.
+   */
+  async writeTodos(todos: string[]): Promise<void> {
+    const todoDir = join(this.contextDir, "todo");
+    mkdirSync(todoDir, { recursive: true });
+
+    const content = todos.map((t) => `- [ ] ${t}`).join("\n") + "\n";
+    writeFileSync(join(todoDir, "index.md"), content);
+  }
+}

--- a/packages/agent-worker/src/agent/agent-registry.ts
+++ b/packages/agent-worker/src/agent/agent-registry.ts
@@ -1,0 +1,155 @@
+/**
+ * AgentRegistry — Loads and manages top-level agent definitions.
+ *
+ * Responsibilities:
+ *   - Discover agents from .agents/*.yaml
+ *   - Load definitions → create AgentHandles
+ *   - Register/unregister agents at runtime
+ *   - Ensure context directories exist
+ *   - Provide agent lookup by name
+ *
+ * Owned by the daemon. One registry per daemon process.
+ */
+
+import { mkdirSync, writeFileSync, unlinkSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { AgentHandle } from "./agent-handle.ts";
+import type { AgentDefinition } from "./definition.ts";
+import { discoverAgents, serializeAgent, AGENTS_DIR } from "./yaml-parser.ts";
+
+// ── AgentRegistry ─────────────────────────────────────────────────
+
+export class AgentRegistry {
+  /** Loaded agent handles, keyed by name */
+  private agents = new Map<string, AgentHandle>();
+
+  /** Project root directory */
+  readonly projectDir: string;
+
+  /** Agents directory (.agents/) */
+  readonly agentsDir: string;
+
+  constructor(projectDir: string) {
+    this.projectDir = projectDir;
+    this.agentsDir = join(projectDir, AGENTS_DIR);
+  }
+
+  // ── Discovery & Loading ─────────────────────────────────────────
+
+  /**
+   * Load all agents from .agents/*.yaml.
+   * Skips invalid files (logs warnings).
+   * Creates context directories for each loaded agent.
+   */
+  loadFromDisk(log?: (msg: string) => void): void {
+    const defs = discoverAgents(this.projectDir, log);
+    for (const def of defs) {
+      this.registerDefinition(def);
+    }
+  }
+
+  // ── Registration ────────────────────────────────────────────────
+
+  /**
+   * Register an agent definition. Creates AgentHandle + ensures context dir.
+   * Overwrites existing agent with same name (reload semantics).
+   */
+  registerDefinition(def: AgentDefinition): AgentHandle {
+    const contextDir = this.resolveContextDir(def);
+    const handle = new AgentHandle(def, contextDir);
+    handle.ensureContextDir();
+    this.agents.set(def.name, handle);
+    return handle;
+  }
+
+  /**
+   * Create a new agent: write YAML file + register.
+   * @throws Error if agent already exists on disk.
+   */
+  create(def: AgentDefinition): AgentHandle {
+    const yamlPath = this.agentYamlPath(def.name);
+    if (existsSync(yamlPath)) {
+      throw new Error(`Agent file already exists: ${yamlPath}`);
+    }
+
+    // Ensure .agents/ directory exists
+    mkdirSync(this.agentsDir, { recursive: true });
+
+    // Write YAML file
+    writeFileSync(yamlPath, serializeAgent(def));
+
+    // Register in memory
+    return this.registerDefinition(def);
+  }
+
+  /**
+   * Delete an agent: remove YAML file + context directory + unregister.
+   * @returns true if agent existed and was deleted.
+   */
+  delete(name: string): boolean {
+    const handle = this.agents.get(name);
+    if (!handle) return false;
+
+    this.agents.delete(name);
+
+    // Remove YAML file
+    const yamlPath = this.agentYamlPath(name);
+    if (existsSync(yamlPath)) {
+      try {
+        unlinkSync(yamlPath);
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    // Remove context directory
+    if (existsSync(handle.contextDir)) {
+      try {
+        rmSync(handle.contextDir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+
+    return true;
+  }
+
+  // ── Lookup ──────────────────────────────────────────────────────
+
+  /** Get agent handle by name */
+  get(name: string): AgentHandle | undefined {
+    return this.agents.get(name);
+  }
+
+  /** Check if agent exists */
+  has(name: string): boolean {
+    return this.agents.has(name);
+  }
+
+  /** List all registered agent handles */
+  list(): AgentHandle[] {
+    return [...this.agents.values()];
+  }
+
+  /** Number of registered agents */
+  get size(): number {
+    return this.agents.size;
+  }
+
+  // ── Path Helpers ────────────────────────────────────────────────
+
+  /** Resolve agent's context directory (absolute path) */
+  private resolveContextDir(def: AgentDefinition): string {
+    if (def.context?.dir) {
+      // Treat as relative to project root
+      return join(this.projectDir, def.context.dir);
+    }
+    // Default: .agents/<name>/
+    return join(this.agentsDir, def.name);
+  }
+
+  /** Path to agent's YAML file */
+  private agentYamlPath(name: string): string {
+    return join(this.agentsDir, `${name}.yaml`);
+  }
+}

--- a/packages/agent-worker/src/agent/config.ts
+++ b/packages/agent-worker/src/agent/config.ts
@@ -20,10 +20,10 @@ export interface AgentConfig {
   backend: BackendType;
   /** Provider configuration — string (built-in) or object (custom endpoint) */
   provider?: string | ProviderConfig;
-  /** Workflow this agent belongs to */
-  workflow: string;
-  /** Workflow instance tag */
-  tag: string;
+  /** Workflow this agent belongs to (optional — standalone agents have no workflow) */
+  workflow?: string;
+  /** Workflow instance tag (optional — standalone agents have no tag) */
+  tag?: string;
   /** When this agent was created */
   createdAt: string;
   /** Periodic wakeup schedule */

--- a/packages/agent-worker/src/agent/definition.ts
+++ b/packages/agent-worker/src/agent/definition.ts
@@ -106,13 +106,13 @@ export const AgentSoulSchema = z.object({
   expertise: z.array(z.string()).optional(),
   style: z.string().optional(),
   principles: z.array(z.string()).optional(),
-});
+}).passthrough();  // Extensible — custom soul fields preserved
 
 const ProviderConfigSchema = z.object({
   name: z.string(),
   base_url: z.string().optional(),
   api_key: z.string().optional(),
-});
+}).passthrough();  // Allow extra provider fields
 
 export const AgentPromptConfigSchema = z.union([
   z.object({ system: z.string(), system_file: z.undefined().optional() }),

--- a/packages/agent-worker/src/agent/definition.ts
+++ b/packages/agent-worker/src/agent/definition.ts
@@ -101,18 +101,22 @@ export const CONTEXT_SUBDIRS = ["memory", "notes", "conversations", "todo"] as c
 
 // ── Zod Schemas ───────────────────────────────────────────────────
 
-export const AgentSoulSchema = z.object({
-  role: z.string().optional(),
-  expertise: z.array(z.string()).optional(),
-  style: z.string().optional(),
-  principles: z.array(z.string()).optional(),
-}).passthrough();  // Extensible — custom soul fields preserved
+export const AgentSoulSchema = z
+  .object({
+    role: z.string().optional(),
+    expertise: z.array(z.string()).optional(),
+    style: z.string().optional(),
+    principles: z.array(z.string()).optional(),
+  })
+  .passthrough(); // Extensible — custom soul fields preserved
 
-const ProviderConfigSchema = z.object({
-  name: z.string(),
-  base_url: z.string().optional(),
-  api_key: z.string().optional(),
-}).passthrough();  // Allow extra provider fields
+const ProviderConfigSchema = z
+  .object({
+    name: z.string(),
+    base_url: z.string().optional(),
+    api_key: z.string().optional(),
+  })
+  .passthrough(); // Allow extra provider fields
 
 export const AgentPromptConfigSchema = z.union([
   z.object({ system: z.string(), system_file: z.undefined().optional() }),
@@ -132,9 +136,7 @@ const ScheduleConfigSchema = z.object({
 export const AgentDefinitionSchema = z.object({
   name: z.string().min(1),
   model: z.string().min(1),
-  backend: z
-    .enum(["sdk", "claude", "cursor", "codex", "opencode", "mock"])
-    .optional(),
+  backend: z.enum(["sdk", "claude", "cursor", "codex", "opencode", "mock"]).optional(),
   provider: z.union([z.string(), ProviderConfigSchema]).optional(),
   prompt: AgentPromptConfigSchema,
   soul: AgentSoulSchema.optional(),

--- a/packages/agent-worker/src/agent/definition.ts
+++ b/packages/agent-worker/src/agent/definition.ts
@@ -1,0 +1,145 @@
+/**
+ * AgentDefinition — Top-level persistent agent identity.
+ *
+ * This is the NEW AgentDefinition from AGENT-TOP-LEVEL architecture.
+ * It describes WHO an agent is (prompt, soul, context) — not how it runs in a workflow.
+ *
+ * Loaded from .agents/*.yaml files. Workflows reference agents by name.
+ *
+ * Distinct from:
+ *   - WorkflowAgentDef (workflow/types.ts) — inline agent config within a workflow
+ *   - AgentConfig (agent/config.ts)        — runtime config for daemon-created agents
+ */
+
+import { z } from "zod/v4";
+import type { ScheduleConfig } from "../daemon/registry.ts";
+
+// ── Soul ──────────────────────────────────────────────────────────
+
+/**
+ * Agent soul — persistent identity traits injected into prompt context.
+ * Captures WHO the agent is beyond the system prompt.
+ *
+ * The system prompt says "what to do now"; the soul says "who you are always."
+ */
+export interface AgentSoul {
+  /** What this agent does */
+  role?: string;
+  /** Domain knowledge areas */
+  expertise?: string[];
+  /** Communication and work style */
+  style?: string;
+  /** Core values/guidelines */
+  principles?: string[];
+  /** Extensible — additional fields preserved */
+  [key: string]: unknown;
+}
+
+// ── Prompt Config ─────────────────────────────────────────────────
+
+/**
+ * Agent prompt configuration.
+ * Exactly one of `system` or `system_file` must be provided.
+ */
+export interface AgentPromptConfig {
+  /** Inline system prompt */
+  system?: string;
+  /** Path to system prompt file (relative to agent YAML location) */
+  system_file?: string;
+}
+
+// ── Context Config ────────────────────────────────────────────────
+
+/**
+ * Agent context directory configuration.
+ */
+export interface AgentContextConfig {
+  /** Path to agent's persistent context directory. Default: .agents/<name>/ */
+  dir?: string;
+  /** Number of recent messages to keep in prompt thin thread. Default: 10 */
+  thin_thread?: number;
+}
+
+// ── Agent Definition ──────────────────────────────────────────────
+
+/**
+ * Top-level agent definition — loaded from .agents/<name>.yaml.
+ *
+ * This is the single source of truth for "who this agent is".
+ * Workflows reference agents by name; the definition travels with the agent.
+ */
+export interface AgentDefinition {
+  /** Agent name (unique within project, matches filename) */
+  name: string;
+  /** Model identifier (e.g., 'anthropic/claude-sonnet-4-5') */
+  model: string;
+  /** Backend type */
+  backend?: "sdk" | "claude" | "cursor" | "codex" | "opencode" | "mock";
+  /** Provider configuration */
+  provider?: string | { name: string; base_url?: string; api_key?: string };
+  /** System prompt configuration */
+  prompt: AgentPromptConfig;
+  /** Persistent identity traits */
+  soul?: AgentSoul;
+  /** Context directory configuration */
+  context?: AgentContextConfig;
+  /** Maximum tokens for response */
+  max_tokens?: number;
+  /** Maximum tool call steps per turn */
+  max_steps?: number;
+  /** Periodic wakeup schedule */
+  schedule?: ScheduleConfig;
+}
+
+// ── Context Subdirectories ────────────────────────────────────────
+
+/**
+ * Standard subdirectories within an agent's context directory.
+ * Created automatically when the agent is loaded.
+ */
+export const CONTEXT_SUBDIRS = ["memory", "notes", "conversations", "todo"] as const;
+
+// ── Zod Schemas ───────────────────────────────────────────────────
+
+export const AgentSoulSchema = z.object({
+  role: z.string().optional(),
+  expertise: z.array(z.string()).optional(),
+  style: z.string().optional(),
+  principles: z.array(z.string()).optional(),
+});
+
+const ProviderConfigSchema = z.object({
+  name: z.string(),
+  base_url: z.string().optional(),
+  api_key: z.string().optional(),
+});
+
+export const AgentPromptConfigSchema = z.union([
+  z.object({ system: z.string(), system_file: z.undefined().optional() }),
+  z.object({ system_file: z.string(), system: z.undefined().optional() }),
+]);
+
+export const AgentContextConfigSchema = z.object({
+  dir: z.string().optional(),
+  thin_thread: z.number().int().min(1).optional(),
+});
+
+const ScheduleConfigSchema = z.object({
+  wakeup: z.union([z.string(), z.number()]),
+  prompt: z.string().optional(),
+});
+
+export const AgentDefinitionSchema = z.object({
+  name: z.string().min(1),
+  model: z.string().min(1),
+  backend: z
+    .enum(["sdk", "claude", "cursor", "codex", "opencode", "mock"])
+    .optional(),
+  provider: z.union([z.string(), ProviderConfigSchema]).optional(),
+  prompt: AgentPromptConfigSchema,
+  soul: AgentSoulSchema.optional(),
+  context: AgentContextConfigSchema.optional(),
+  max_tokens: z.number().int().positive().optional(),
+  max_steps: z.number().int().positive().optional(),
+  schedule: ScheduleConfigSchema.optional(),
+});

--- a/packages/agent-worker/src/agent/index.ts
+++ b/packages/agent-worker/src/agent/index.ts
@@ -22,3 +22,28 @@ export type {
   TokenUsage,
   Transcript,
 } from "./types.ts";
+
+// Top-level agent definition (AGENT-TOP-LEVEL architecture)
+export type {
+  AgentDefinition,
+  AgentSoul,
+  AgentPromptConfig,
+  AgentContextConfig,
+} from "./definition.ts";
+export {
+  AgentDefinitionSchema,
+  AgentSoulSchema,
+  AgentPromptConfigSchema,
+  AgentContextConfigSchema,
+  CONTEXT_SUBDIRS,
+} from "./definition.ts";
+export { AgentHandle } from "./agent-handle.ts";
+export type { AgentHandleState } from "./agent-handle.ts";
+export { AgentRegistry } from "./agent-registry.ts";
+export {
+  parseAgentFile,
+  parseAgentObject,
+  discoverAgents,
+  serializeAgent,
+  AGENTS_DIR,
+} from "./yaml-parser.ts";

--- a/packages/agent-worker/src/agent/yaml-parser.ts
+++ b/packages/agent-worker/src/agent/yaml-parser.ts
@@ -1,0 +1,170 @@
+/**
+ * Agent YAML Parser — Load agent definitions from .agents/*.yaml files.
+ *
+ * Handles:
+ *   - Single file: parseAgentFile("path/to/alice.yaml")
+ *   - Directory:   discoverAgents("path/to/project") → scans .agents/*.yaml
+ *   - Validation:  Zod schema + semantic checks (system XOR system_file)
+ *   - Resolution:  system_file → reads content into system (relative to YAML dir)
+ *
+ * The name field is optional in YAML — defaults to filename (without .yaml).
+ */
+
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+import { AgentDefinitionSchema, type AgentDefinition } from "./definition.ts";
+
+// ── Constants ─────────────────────────────────────────────────────
+
+/** Default directory for agent definitions (relative to project root) */
+export const AGENTS_DIR = ".agents";
+
+// ── Parse Single File ─────────────────────────────────────────────
+
+/**
+ * Parse an agent definition from a YAML file.
+ *
+ * Validates the schema, resolves system_file to inline content,
+ * and infers name from filename if not specified.
+ *
+ * @throws Error if file doesn't exist, YAML is malformed, or validation fails.
+ */
+export function parseAgentFile(filePath: string): AgentDefinition {
+  if (!existsSync(filePath)) {
+    throw new Error(`Agent file not found: ${filePath}`);
+  }
+
+  const raw = readFileSync(filePath, "utf-8");
+  const data = parseYaml(raw);
+
+  if (!data || typeof data !== "object") {
+    throw new Error(`Invalid YAML in ${filePath}: expected an object`);
+  }
+
+  // Infer name from filename if not specified
+  const obj = data as Record<string, unknown>;
+  if (!obj.name) {
+    const filename = basename(filePath);
+    obj.name = filename.replace(/\.ya?ml$/i, "");
+  }
+
+  // Validate with Zod
+  const result = AgentDefinitionSchema.safeParse(obj);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Invalid agent definition in ${filePath}:\n${issues}`);
+  }
+
+  const def = result.data as AgentDefinition;
+
+  // Resolve system_file → system (read file content)
+  if (def.prompt.system_file) {
+    const promptPath = join(dirname(filePath), def.prompt.system_file);
+    if (!existsSync(promptPath)) {
+      throw new Error(
+        `system_file not found: ${def.prompt.system_file} (resolved: ${promptPath})`,
+      );
+    }
+    const content = readFileSync(promptPath, "utf-8");
+    // Replace system_file with resolved system content
+    return {
+      ...def,
+      prompt: { system: content },
+    };
+  }
+
+  return def;
+}
+
+// ── Parse from Raw Object ─────────────────────────────────────────
+
+/**
+ * Parse an agent definition from a plain object (e.g., from CLI input).
+ * No system_file resolution — expects inline system prompt.
+ *
+ * @throws Error if validation fails.
+ */
+export function parseAgentObject(data: Record<string, unknown>): AgentDefinition {
+  const result = AgentDefinitionSchema.safeParse(data);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Invalid agent definition:\n${issues}`);
+  }
+  return result.data as AgentDefinition;
+}
+
+// ── Discover Agents in Directory ──────────────────────────────────
+
+/**
+ * Discover all agent YAML files in a project's .agents/ directory.
+ * Returns parsed and validated definitions.
+ *
+ * Non-fatal: logs warnings for invalid files, skips them.
+ *
+ * @param projectDir - Project root directory
+ * @param log - Optional warning logger (default: console.warn)
+ * @returns Array of valid agent definitions
+ */
+export function discoverAgents(
+  projectDir: string,
+  log?: (msg: string) => void,
+): AgentDefinition[] {
+  const agentsDir = join(projectDir, AGENTS_DIR);
+  if (!existsSync(agentsDir)) return [];
+
+  const warn = log ?? console.warn;
+  const agents: AgentDefinition[] = [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(agentsDir);
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".yaml") && !entry.endsWith(".yml")) continue;
+
+    const filePath = join(agentsDir, entry);
+    try {
+      agents.push(parseAgentFile(filePath));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      warn(`Skipping ${entry}: ${msg}`);
+    }
+  }
+
+  return agents;
+}
+
+// ── Serialize to YAML ─────────────────────────────────────────────
+
+/**
+ * Serialize an agent definition to YAML string.
+ * Used by CLI `agent create` to write .agents/<name>.yaml.
+ */
+export function serializeAgent(def: AgentDefinition): string {
+  // Build a clean object (omit undefined fields)
+  const obj: Record<string, unknown> = {
+    name: def.name,
+    model: def.model,
+  };
+
+  if (def.backend) obj.backend = def.backend;
+  if (def.provider) obj.provider = def.provider;
+
+  obj.prompt = def.prompt;
+
+  if (def.soul) obj.soul = def.soul;
+  if (def.context) obj.context = def.context;
+  if (def.max_tokens) obj.max_tokens = def.max_tokens;
+  if (def.max_steps) obj.max_steps = def.max_steps;
+  if (def.schedule) obj.schedule = def.schedule;
+
+  return stringifyYaml(obj, { lineWidth: 120 });
+}

--- a/packages/agent-worker/src/agent/yaml-parser.ts
+++ b/packages/agent-worker/src/agent/yaml-parser.ts
@@ -52,9 +52,7 @@ export function parseAgentFile(filePath: string): AgentDefinition {
   // Validate with Zod
   const result = AgentDefinitionSchema.safeParse(obj);
   if (!result.success) {
-    const issues = result.error.issues
-      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
-      .join("\n");
+    const issues = result.error.issues.map((i) => `  ${i.path.join(".")}: ${i.message}`).join("\n");
     throw new Error(`Invalid agent definition in ${filePath}:\n${issues}`);
   }
 
@@ -64,9 +62,7 @@ export function parseAgentFile(filePath: string): AgentDefinition {
   if (def.prompt.system_file) {
     const promptPath = join(dirname(filePath), def.prompt.system_file);
     if (!existsSync(promptPath)) {
-      throw new Error(
-        `system_file not found: ${def.prompt.system_file} (resolved: ${promptPath})`,
-      );
+      throw new Error(`system_file not found: ${def.prompt.system_file} (resolved: ${promptPath})`);
     }
     const content = readFileSync(promptPath, "utf-8");
     // Replace system_file with resolved system content
@@ -90,9 +86,7 @@ export function parseAgentFile(filePath: string): AgentDefinition {
 export function parseAgentObject(data: Record<string, unknown>): AgentDefinition {
   const result = AgentDefinitionSchema.safeParse(data);
   if (!result.success) {
-    const issues = result.error.issues
-      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
-      .join("\n");
+    const issues = result.error.issues.map((i) => `  ${i.path.join(".")}: ${i.message}`).join("\n");
     throw new Error(`Invalid agent definition:\n${issues}`);
   }
   return result.data as AgentDefinition;
@@ -110,10 +104,7 @@ export function parseAgentObject(data: Record<string, unknown>): AgentDefinition
  * @param log - Optional warning logger (default: console.warn)
  * @returns Array of valid agent definitions
  */
-export function discoverAgents(
-  projectDir: string,
-  log?: (msg: string) => void,
-): AgentDefinition[] {
+export function discoverAgents(projectDir: string, log?: (msg: string) => void): AgentDefinition[] {
   const agentsDir = join(projectDir, AGENTS_DIR);
   if (!existsSync(agentsDir)) return [];
 

--- a/packages/agent-worker/src/cli/commands/agent.ts
+++ b/packages/agent-worker/src/cli/commands/agent.ts
@@ -216,7 +216,11 @@ Examples:
       }
 
       for (const a of agents) {
-        const wf = a.workflow ? (a.tag === "main" ? `@${a.workflow}` : `@${a.workflow}:${a.tag}`) : "";
+        const wf = a.workflow
+          ? a.tag === "main"
+            ? `@${a.workflow}`
+            : `@${a.workflow}:${a.tag}`
+          : "";
         const info = a.model || a.state || "";
         console.log(`${a.name.padEnd(12)} ${info.padEnd(30)} ${wf}`);
       }
@@ -433,7 +437,8 @@ Examples:
       if (options.role || options.expertise || options.style) {
         def.soul = {};
         if (options.role) def.soul.role = options.role;
-        if (options.expertise) def.soul.expertise = options.expertise.split(",").map((s: string) => s.trim());
+        if (options.expertise)
+          def.soul.expertise = options.expertise.split(",").map((s: string) => s.trim());
         if (options.style) def.soul.style = options.style;
       }
 
@@ -516,9 +521,10 @@ Examples:
       console.log(`Model:   ${def.model}`);
       if (def.backend) console.log(`Backend: ${def.backend}`);
       if (def.prompt.system) {
-        const preview = def.prompt.system.length > 80
-          ? def.prompt.system.slice(0, 77) + "..."
-          : def.prompt.system;
+        const preview =
+          def.prompt.system.length > 80
+            ? def.prompt.system.slice(0, 77) + "..."
+            : def.prompt.system;
         console.log(`Prompt:  ${preview}`);
       }
       if (def.soul) {

--- a/packages/agent-worker/src/cli/commands/agent.ts
+++ b/packages/agent-worker/src/cli/commands/agent.ts
@@ -213,7 +213,7 @@ Examples:
       }
 
       for (const a of agents) {
-        const wf = a.tag === "main" ? `@${a.workflow}` : `@${a.workflow}:${a.tag}`;
+        const wf = a.workflow ? (a.tag === "main" ? `@${a.workflow}` : `@${a.workflow}:${a.tag}`) : "";
         const info = a.model || a.state || "";
         console.log(`${a.name.padEnd(12)} ${info.padEnd(30)} ${wf}`);
       }

--- a/packages/agent-worker/src/daemon/daemon.ts
+++ b/packages/agent-worker/src/daemon/daemon.ts
@@ -789,21 +789,23 @@ export function createDaemonApp(options: DaemonAppOptions): Hono {
     const s = getState();
     if (!s) return c.json({ error: "Not ready" }, 503);
 
-    const workflows = [...s.workflows.values()].filter((wf) => !wf.standalone).map((wf) => {
-      const agentStates: Record<string, string> = {};
-      for (const [name, loop] of wf.loops) {
-        agentStates[name] = loop.state;
-      }
-      return {
-        name: wf.name,
-        tag: wf.tag,
-        key: wf.key,
-        agents: wf.agents,
-        agentStates,
-        workflowPath: wf.workflowPath,
-        startedAt: wf.startedAt,
-      };
-    });
+    const workflows = [...s.workflows.values()]
+      .filter((wf) => !wf.standalone)
+      .map((wf) => {
+        const agentStates: Record<string, string> = {};
+        for (const [name, loop] of wf.loops) {
+          agentStates[name] = loop.state;
+        }
+        return {
+          name: wf.name,
+          tag: wf.tag,
+          key: wf.key,
+          agents: wf.agents,
+          agentStates,
+          workflowPath: wf.workflowPath,
+          startedAt: wf.startedAt,
+        };
+      });
 
     return c.json({ workflows });
   });

--- a/packages/agent-worker/src/workflow/factory.ts
+++ b/packages/agent-worker/src/workflow/factory.ts
@@ -26,7 +26,7 @@ import { createContextMCPServer } from "./context/mcp/server.ts";
 import { runWithHttp, type HttpMCPServer } from "./context/http-transport.ts";
 import { EventLog } from "./context/event-log.ts";
 import type { Message } from "./context/types.ts";
-import type { ResolvedAgent } from "./types.ts";
+import type { ResolvedWorkflowAgent } from "./types.ts";
 import type { Backend } from "../backends/types.ts";
 import type { StreamParserCallbacks } from "../backends/stream-json.ts";
 import { createAgentLoop } from "./loop/loop.ts";
@@ -211,7 +211,7 @@ export interface WiredLoopConfig {
   /** Agent name */
   name: string;
   /** Resolved agent definition */
-  agent: ResolvedAgent;
+  agent: ResolvedWorkflowAgent;
   /** The workflow runtime this agent belongs to */
   runtime: RuntimeContext;
   /** Poll interval in ms (default: 5000) */
@@ -219,7 +219,7 @@ export interface WiredLoopConfig {
   /** Enable feedback tool */
   feedback?: boolean;
   /** Custom backend factory (overrides default resolution) */
-  createBackend?: (agentName: string, agent: ResolvedAgent) => Backend;
+  createBackend?: (agentName: string, agent: ResolvedWorkflowAgent) => Backend;
   /** Logger for this agent's output */
   logger?: Logger;
 }
@@ -306,7 +306,7 @@ export function createWiredLoop(config: WiredLoopConfig): WiredLoopResult {
 
   // Pass resolved model/provider to the loop so SDK runner uses the concrete
   // model instead of the raw "auto" value from the workflow YAML.
-  const resolvedAgent: ResolvedAgent =
+  const resolvedAgent: ResolvedWorkflowAgent =
     effectiveModel !== agent.model || effectiveProvider !== agent.provider
       ? { ...agent, model: effectiveModel, provider: effectiveProvider }
       : agent;

--- a/packages/agent-worker/src/workflow/loop/prompt.ts
+++ b/packages/agent-worker/src/workflow/loop/prompt.ts
@@ -1,10 +1,25 @@
 /**
  * Agent Prompt Building
- * Helpers for building agent prompts from context
+ *
+ * Composable prompt assembly: each section is an independent function
+ * that returns content or null. The assembler joins non-null sections.
+ *
+ * This design supports Phase 2/5 where new sections (soul, memory, todo)
+ * will be added without touching existing ones.
  */
 
 import type { Message, InboxMessage } from "../context/types.ts";
 import type { AgentRunContext } from "./types.ts";
+
+// ── Section Type ──────────────────────────────────────────────────
+
+/**
+ * A prompt section: receives context, returns content or null (skip).
+ * Each section is independent and can be added/removed/reordered.
+ */
+export type PromptSection = (ctx: AgentRunContext) => string | null;
+
+// ── Format Helpers ────────────────────────────────────────────────
 
 /**
  * Format inbox messages for display
@@ -36,128 +51,167 @@ export function formatChannel(entries: Message[]): string {
     .join("\n");
 }
 
-/**
- * Build the complete agent prompt from run context
- */
-export function buildAgentPrompt(ctx: AgentRunContext): string {
-  const sections: string[] = [];
+// ── Built-in Sections ─────────────────────────────────────────────
 
-  // Project context (what codebase to work on)
-  sections.push("## Project");
-  sections.push(`Working on: ${ctx.projectDir}`);
+/** Project context (what codebase to work on) */
+export const projectSection: PromptSection = (ctx) =>
+  `## Project\nWorking on: ${ctx.projectDir}`;
 
-  // Inbox section (most important)
-  sections.push("");
-  sections.push(
-    `## Inbox (${ctx.inbox.length} message${ctx.inbox.length === 1 ? "" : "s"} for you)`,
-  );
-  sections.push(formatInbox(ctx.inbox));
+/** Inbox (unread messages for this agent) */
+export const inboxSection: PromptSection = (ctx) => {
+  const count = ctx.inbox.length;
+  const label = count === 1 ? "message" : "messages";
+  return `## Inbox (${count} ${label} for you)\n${formatInbox(ctx.inbox)}`;
+};
 
-  // Recent activity hint (use tool instead of injecting messages)
-  sections.push("");
-  sections.push("## Recent Activity");
-  sections.push(
-    "Use channel_read tool to view recent channel messages and conversation context if needed.",
-  );
+/** Recent activity hint (use tool instead of injecting messages) */
+export const activitySection: PromptSection = () =>
+  "## Recent Activity\nUse channel_read tool to view recent channel messages and conversation context if needed.";
 
-  // Shared document section
-  if (ctx.documentContent) {
-    sections.push("");
-    sections.push("## Shared Document");
-    sections.push(ctx.documentContent);
-  }
+/** Shared document section */
+export const documentSection: PromptSection = (ctx) =>
+  ctx.documentContent ? `## Shared Document\n${ctx.documentContent}` : null;
 
-  // Retry notice
-  if (ctx.retryAttempt > 1) {
-    sections.push("");
-    sections.push(`## Note`);
-    sections.push(`This is retry attempt ${ctx.retryAttempt}. Previous attempt failed.`);
-  }
+/** Retry notice */
+export const retrySection: PromptSection = (ctx) =>
+  ctx.retryAttempt > 1
+    ? `## Note\nThis is retry attempt ${ctx.retryAttempt}. Previous attempt failed.`
+    : null;
 
-  // Instructions section
-  sections.push("");
-  sections.push("## Instructions");
-  sections.push(
+/** MCP tool instructions */
+export const instructionsSection: PromptSection = (ctx) => {
+  const lines: string[] = [];
+  lines.push("## Instructions");
+  lines.push(
     "You are an agent in a multi-agent workflow. Communicate ONLY through the MCP tools below.",
   );
-  sections.push(
+  lines.push(
     "Your text output is NOT seen by other agents — you MUST use channel_send to communicate.",
   );
-  sections.push("");
-  sections.push("### Channel Tools");
-  sections.push(
+  lines.push("");
+  lines.push("### Channel Tools");
+  lines.push(
     "- **channel_send**: Send a message to the shared channel. Use @agentname to mention/notify.",
   );
-  sections.push(
+  lines.push(
     '  Use the "to" parameter for private DMs: channel_send({ message: "...", to: "bob" })',
   );
-  sections.push(
+  lines.push(
     "- **channel_read**: Read recent channel messages (DMs and logs are auto-filtered).",
   );
-  sections.push("");
-  sections.push("### Team Tools");
-  sections.push(
+  lines.push("");
+  lines.push("### Team Tools");
+  lines.push(
     "- **team_members**: List all agents you can @mention. Pass includeStatus=true to see their current state and tasks.",
   );
-  sections.push("- **team_doc_read/write/append/list/create**: Shared team documents.");
-  sections.push("");
-  sections.push("### Personal Tools");
-  sections.push("- **my_inbox**: Check your unread messages.");
-  sections.push(
+  lines.push("- **team_doc_read/write/append/list/create**: Shared team documents.");
+  lines.push("");
+  lines.push("### Personal Tools");
+  lines.push("- **my_inbox**: Check your unread messages.");
+  lines.push(
     "- **my_inbox_ack**: Acknowledge messages after processing (pass the latest message ID).",
   );
-  sections.push(
+  lines.push(
     "- **my_status_set**: Update your status. Call when starting work (state='running', task='...') or when done (state='idle').",
   );
-  sections.push("");
-  sections.push("### Proposal & Voting Tools");
-  sections.push(
+  lines.push("");
+  lines.push("### Proposal & Voting Tools");
+  lines.push(
     "- **team_proposal_create**: Create a proposal for team voting (types: election, decision, approval, assignment).",
   );
-  sections.push(
+  lines.push(
     "- **team_vote**: Cast your vote on an active proposal. You can change your vote by voting again.",
   );
-  sections.push(
+  lines.push(
     "- **team_proposal_status**: Check status of a proposal, or list all active proposals.",
   );
-  sections.push("- **team_proposal_cancel**: Cancel a proposal you created.");
-  sections.push("");
-  sections.push("### Resource Tools");
-  sections.push(
+  lines.push("- **team_proposal_cancel**: Cancel a proposal you created.");
+  lines.push("");
+  lines.push("### Resource Tools");
+  lines.push(
     "- **resource_create**: Store large content, get a reference (resource:id) for use anywhere.",
   );
-  sections.push("- **resource_read**: Read resource content by ID.");
+  lines.push("- **resource_read**: Read resource content by ID.");
 
   // Feedback tool (opt-in)
   if (ctx.feedback) {
-    sections.push("");
-    sections.push("### Feedback Tool");
-    sections.push(
+    lines.push("");
+    lines.push("### Feedback Tool");
+    lines.push(
       "- **feedback_submit**: Report workflow improvement needs — a missing tool, an awkward step, or a capability gap.",
     );
-    sections.push("  Only use when you genuinely hit a pain point during your work.");
+    lines.push("  Only use when you genuinely hit a pain point during your work.");
   }
 
-  sections.push("");
-  sections.push("### Workflow");
-  sections.push("1. Read your inbox messages above");
-  sections.push("2. Do your assigned work using channel_send with @mentions");
-  sections.push("3. Acknowledge your inbox with my_inbox_ack");
-  sections.push("4. Exit when your task is complete");
-  sections.push("");
-  sections.push("### IMPORTANT: When to stop");
-  sections.push(
+  return lines.join("\n");
+};
+
+/** Workflow instructions (read → work → ack → exit) */
+export const workflowSection: PromptSection = () => {
+  const lines: string[] = [];
+  lines.push("### Workflow");
+  lines.push("1. Read your inbox messages above");
+  lines.push("2. Do your assigned work using channel_send with @mentions");
+  lines.push("3. Acknowledge your inbox with my_inbox_ack");
+  lines.push("4. Exit when your task is complete");
+  return lines.join("\n");
+};
+
+/** Exit guidance (when to stop) */
+export const exitSection: PromptSection = () => {
+  const lines: string[] = [];
+  lines.push("### IMPORTANT: When to stop");
+  lines.push(
     "- Once your assigned task is complete, acknowledge your inbox and exit. Do NOT keep chatting.",
   );
-  sections.push(
+  lines.push(
     '- Do NOT send pleasantries ("you\'re welcome", "glad to help", "thanks again") — they trigger unnecessary cycles.',
   );
-  sections.push(
+  lines.push(
     "- Do NOT @mention another agent in your final message unless you need them to do more work.",
   );
-  sections.push(
+  lines.push(
     "- If you receive a thank-you or acknowledgment, just call my_inbox_ack and exit. Do not reply.",
   );
+  return lines.join("\n");
+};
 
-  return sections.join("\n");
+// ── Default Section List ──────────────────────────────────────────
+
+/**
+ * Default prompt sections — produces the same output as the original
+ * monolithic buildAgentPrompt. New sections (soul, memory, todo) can
+ * be inserted at specific positions without touching these.
+ */
+export const DEFAULT_SECTIONS: PromptSection[] = [
+  projectSection,
+  inboxSection,
+  activitySection,
+  documentSection,
+  retrySection,
+  instructionsSection,
+  workflowSection,
+  exitSection,
+];
+
+// ── Assembler ─────────────────────────────────────────────────────
+
+/**
+ * Assemble prompt from sections. Joins non-null sections with blank lines.
+ */
+export function assemblePrompt(sections: PromptSection[], ctx: AgentRunContext): string {
+  return sections
+    .map((section) => section(ctx))
+    .filter((content): content is string => content !== null)
+    .join("\n\n");
+}
+
+/**
+ * Build the complete agent prompt from run context.
+ *
+ * Uses the default section list. For custom section lists,
+ * use assemblePrompt() directly.
+ */
+export function buildAgentPrompt(ctx: AgentRunContext): string {
+  return assemblePrompt(DEFAULT_SECTIONS, ctx);
 }

--- a/packages/agent-worker/src/workflow/loop/prompt.ts
+++ b/packages/agent-worker/src/workflow/loop/prompt.ts
@@ -54,8 +54,7 @@ export function formatChannel(entries: Message[]): string {
 // ── Built-in Sections ─────────────────────────────────────────────
 
 /** Project context (what codebase to work on) */
-export const projectSection: PromptSection = (ctx) =>
-  `## Project\nWorking on: ${ctx.projectDir}`;
+export const projectSection: PromptSection = (ctx) => `## Project\nWorking on: ${ctx.projectDir}`;
 
 /** Inbox (unread messages for this agent) */
 export const inboxSection: PromptSection = (ctx) => {
@@ -96,9 +95,7 @@ export const instructionsSection: PromptSection = (ctx) => {
   lines.push(
     '  Use the "to" parameter for private DMs: channel_send({ message: "...", to: "bob" })',
   );
-  lines.push(
-    "- **channel_read**: Read recent channel messages (DMs and logs are auto-filtered).",
-  );
+  lines.push("- **channel_read**: Read recent channel messages (DMs and logs are auto-filtered).");
   lines.push("");
   lines.push("### Team Tools");
   lines.push(

--- a/packages/agent-worker/src/workflow/loop/types.ts
+++ b/packages/agent-worker/src/workflow/loop/types.ts
@@ -3,7 +3,7 @@
  * Types for agent lifecycle management and backend abstraction
  */
 
-import type { ResolvedAgent } from "../types.ts";
+import type { ResolvedWorkflowAgent } from "../types.ts";
 import type { ContextProvider } from "../context/provider.ts";
 import type { Message, InboxMessage } from "../context/types.ts";
 import type { Backend } from "@/backends/types.ts";
@@ -68,7 +68,7 @@ export interface AgentLoopConfig {
   /** Agent name */
   name: string;
   /** Resolved agent definition */
-  agent: ResolvedAgent;
+  agent: ResolvedWorkflowAgent;
   /** Context provider for channel/document access */
   contextProvider: ContextProvider;
   /** Unified event log */
@@ -104,7 +104,7 @@ export interface AgentRunContext {
   /** Agent name */
   name: string;
   /** Agent config */
-  agent: ResolvedAgent;
+  agent: ResolvedWorkflowAgent;
   /** Unread inbox messages */
   inbox: InboxMessage[];
   /** Recent channel messages (for context) */

--- a/packages/agent-worker/src/workflow/parser.ts
+++ b/packages/agent-worker/src/workflow/parser.ts
@@ -20,7 +20,6 @@ import type {
 import { isRefAgentEntry } from "./types.ts";
 import type { ScheduleConfig } from "../daemon/registry.ts";
 import type { AgentRegistry } from "../agent/agent-registry.ts";
-import type { AgentDefinition } from "../agent/definition.ts";
 import { CONTEXT_DEFAULTS } from "./context/types.ts";
 import { resolveContextDir } from "./context/file-provider.ts";
 import { resolveSource, isRemoteSource } from "./source.ts";
@@ -526,8 +525,9 @@ function validateRefAgent(
     });
   }
 
-  // model/backend/provider/tools are not allowed with ref (they come from the definition)
-  for (const field of ["model", "backend", "provider", "tools"] as const) {
+  // model/backend/provider/tools/wakeup/timeout are not allowed with ref
+  // (they come from the agent definition or are not applicable)
+  for (const field of ["model", "backend", "provider", "tools", "wakeup", "wakeup_prompt", "timeout"] as const) {
     if (a[field] !== undefined) {
       errors.push({
         path: `${path}.${field}`,

--- a/packages/agent-worker/src/workflow/parser.ts
+++ b/packages/agent-worker/src/workflow/parser.ts
@@ -13,7 +13,6 @@ import type {
   ValidationResult,
   ValidationError,
   WorkflowAgentDef,
-  AgentEntry,
   RefAgentEntry,
   ParamDefinition,
 } from "./types.ts";
@@ -208,14 +207,11 @@ async function resolveInlineAgent(
  * Resolve a ref agent entry — load from AgentRegistry, map to WorkflowAgentDef,
  * apply workflow overrides (prompt.append, max_tokens, max_steps).
  */
-function resolveRefAgent(
-  entry: RefAgentEntry,
-  registry?: AgentRegistry,
-): ResolvedWorkflowAgent {
+function resolveRefAgent(entry: RefAgentEntry, registry?: AgentRegistry): ResolvedWorkflowAgent {
   if (!registry) {
     throw new Error(
       `Agent ref "${entry.ref}" requires an AgentRegistry. ` +
-      `Pass agentRegistry in ParseOptions.`,
+        `Pass agentRegistry in ParseOptions.`,
     );
   }
 
@@ -223,7 +219,12 @@ function resolveRefAgent(
   if (!handle) {
     throw new Error(
       `Agent ref "${entry.ref}" not found in registry. ` +
-      `Available agents: ${registry.list().map((h) => h.definition.name).join(", ") || "(none)"}`,
+        `Available agents: ${
+          registry
+            .list()
+            .map((h) => h.definition.name)
+            .join(", ") || "(none)"
+        }`,
     );
   }
 
@@ -527,7 +528,15 @@ function validateRefAgent(
 
   // model/backend/provider/tools/wakeup/timeout are not allowed with ref
   // (they come from the agent definition or are not applicable)
-  for (const field of ["model", "backend", "provider", "tools", "wakeup", "wakeup_prompt", "timeout"] as const) {
+  for (const field of [
+    "model",
+    "backend",
+    "provider",
+    "tools",
+    "wakeup",
+    "wakeup_prompt",
+    "timeout",
+  ] as const) {
     if (a[field] !== undefined) {
       errors.push({
         path: `${path}.${field}`,

--- a/packages/agent-worker/src/workflow/parser.ts
+++ b/packages/agent-worker/src/workflow/parser.ts
@@ -8,11 +8,11 @@ import { parseArgs } from "node:util";
 import type {
   WorkflowFile,
   ParsedWorkflow,
-  ResolvedAgent,
+  ResolvedWorkflowAgent,
   ResolvedContext,
   ValidationResult,
   ValidationError,
-  AgentDefinition,
+  WorkflowAgentDef,
   ParamDefinition,
 } from "./types.ts";
 import type { ScheduleConfig } from "../daemon/registry.ts";
@@ -71,7 +71,7 @@ export async function parseWorkflowFile(
   const name = raw.name || source.inferredName;
 
   // Resolve agents (using source's file reader for system_prompt resolution)
-  const agents: Record<string, ResolvedAgent> = {};
+  const agents: Record<string, ResolvedWorkflowAgent> = {};
   for (const [agentName, agentDef] of Object.entries(raw.agents)) {
     agents[agentName] = await resolveAgent(agentDef, source.readRelativeFile);
   }
@@ -163,9 +163,9 @@ function resolveContext(
  * for setting up periodic wakeup timers.
  */
 async function resolveAgent(
-  agent: AgentDefinition,
+  agent: WorkflowAgentDef,
   readRelativeFile: (path: string) => Promise<string | null>,
-): Promise<ResolvedAgent> {
+): Promise<ResolvedWorkflowAgent> {
   let resolvedSystemPrompt = agent.system_prompt;
 
   // Check if system_prompt is a file path

--- a/packages/agent-worker/src/workflow/runner.ts
+++ b/packages/agent-worker/src/workflow/runner.ts
@@ -19,7 +19,7 @@ import { join } from "node:path";
 import type {
   ParsedWorkflow,
   SetupTask,
-  ResolvedAgent,
+  ResolvedWorkflowAgent,
   ResolvedContext,
   ResolvedFileContext,
 } from "./types.ts";
@@ -49,7 +49,7 @@ export interface RunConfig {
   /** Workflow tag (defaults to "main") */
   tag?: string;
   /** Agent startup function */
-  startAgent: (agentName: string, config: ResolvedAgent, mcpUrl: string) => Promise<void>;
+  startAgent: (agentName: string, config: ResolvedWorkflowAgent, mcpUrl: string) => Promise<void>;
   /** Callback when an agent @mentions another agent */
   onMention?: (from: string, target: string, msg: import("./context/types.ts").Message) => void;
   /** Debug log function for MCP tool calls */
@@ -451,7 +451,7 @@ export interface LoopRunConfig {
   /** Poll interval for loops (ms) */
   pollInterval?: number;
   /** Custom backend factory (optional, defaults to getBackendForModel) */
-  createBackend?: (agentName: string, agent: ResolvedAgent) => Backend;
+  createBackend?: (agentName: string, agent: ResolvedWorkflowAgent) => Backend;
   /** Enable feedback tool for all workflow agents */
   feedback?: boolean;
   /** Use pretty display mode (with @clack/prompts) */

--- a/packages/agent-worker/src/workflow/schema.ts
+++ b/packages/agent-worker/src/workflow/schema.ts
@@ -1,0 +1,172 @@
+/**
+ * Workflow YAML Schema — Single source of truth.
+ *
+ * Used for:
+ *   1. Reference documentation generation (scripts/gen-workflow-ref.ts)
+ *   2. Future: replace hand-written validateWorkflow() in parser.ts
+ *
+ * Every field has a .describe() — the generator reads these to produce docs.
+ */
+
+import { z } from "zod";
+
+// ── Reusable Components ──────────────────────────────────────────
+
+export const ProviderConfigSchema = z
+  .object({
+    name: z.string().describe("Provider SDK name (e.g., `anthropic`, `openai`)"),
+    base_url: z.string().optional().describe("Override base URL for the provider"),
+    api_key: z
+      .string()
+      .optional()
+      .describe("API key — env var reference with `$` prefix (e.g., `$MINIMAX_API_KEY`) or literal value"),
+  })
+  .describe("Custom provider configuration for API endpoint overrides");
+
+// ── Agent Entries ────────────────────────────────────────────────
+
+export const RefAgentEntrySchema = z
+  .object({
+    ref: z.string().min(1).describe("Name of the global agent to reference (from `.agents/*.yaml`)"),
+    prompt: z
+      .object({
+        append: z.string().describe("Additional instructions appended to the agent's base system prompt"),
+      })
+      .optional()
+      .describe("Prompt extension for this workflow"),
+    max_tokens: z.number().int().positive().optional().describe("Override maximum tokens for response"),
+    max_steps: z.number().int().positive().optional().describe("Override maximum tool call steps per turn"),
+  })
+  .describe("Reference to a global agent definition — carries persistent context (memory, notes, todo)");
+
+export const InlineAgentEntrySchema = z
+  .object({
+    backend: z
+      .enum(["default", "claude", "cursor", "codex", "opencode", "mock"])
+      .optional()
+      .describe(
+        "Backend to use. `default` = Vercel AI SDK, others = CLI wrappers. " +
+          "CLI backends (`claude`, `cursor`, `codex`, `opencode`) don't require `model`",
+      ),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        "Model identifier. Required for `default` backend. " +
+          "Formats: `provider/model`, `provider:model`, or `auto` for env-based detection",
+      ),
+    provider: z
+      .union([z.string(), ProviderConfigSchema])
+      .optional()
+      .describe("Provider configuration — string (built-in name) or object (custom endpoint)"),
+    system_prompt: z
+      .string()
+      .optional()
+      .describe("System prompt — inline string or file path ending in `.txt`/`.md` (auto-loaded)"),
+    tools: z.array(z.string()).optional().describe("Tool names to enable for this agent"),
+    max_tokens: z.number().int().positive().optional().describe("Maximum tokens for response"),
+    max_steps: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Maximum tool call steps per turn (default: 200)"),
+    timeout: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Backend timeout in milliseconds (overrides backend default)"),
+    wakeup: z
+      .union([z.string(), z.number()])
+      .optional()
+      .describe('Periodic wakeup schedule: number (ms), duration string (`"30s"`/`"5m"`/`"2h"`), or cron expression'),
+    wakeup_prompt: z
+      .string()
+      .optional()
+      .describe("Custom prompt for wakeup events (requires `wakeup` to be set)"),
+  })
+  .describe("Inline agent definition — workflow-local, no persistent identity");
+
+export const AgentEntrySchema = z
+  .union([RefAgentEntrySchema, InlineAgentEntrySchema])
+  .describe("Agent entry — either a `ref` to a global agent or an inline definition. Discriminated by presence of `ref`");
+
+// ── Context ──────────────────────────────────────────────────────
+
+const FileContextConfigSchema = z
+  .object({
+    dir: z.string().optional().describe("Ephemeral context directory path (template variables supported)"),
+    bind: z.string().optional().describe("Persistent context directory path — state survives across runs"),
+  })
+  .describe("File context configuration (`dir` and `bind` are mutually exclusive)");
+
+export const ContextConfigSchema = z
+  .union([
+    z.literal(false).describe("Explicitly disable shared context"),
+    z
+      .object({
+        provider: z
+          .enum(["file", "memory"])
+          .describe('Context provider type. `file` for disk-based, `memory` for testing'),
+        config: FileContextConfigSchema.optional().describe("Provider-specific configuration"),
+        documentOwner: z
+          .string()
+          .optional()
+          .describe("Document owner for single-writer model"),
+      })
+      .describe("Shared context configuration"),
+  ])
+  .optional()
+  .describe("Shared context — `undefined`/`null` = default file provider, `false` = disabled");
+
+// ── Params ───────────────────────────────────────────────────────
+
+export const ParamDefinitionSchema = z
+  .object({
+    name: z.string().min(1).describe("Parameter name (used as `--name` on CLI)"),
+    description: z.string().optional().describe("Human-readable description"),
+    type: z
+      .enum(["string", "number", "boolean"])
+      .optional()
+      .describe('Value type (default: `"string"`)'),
+    short: z
+      .string()
+      .max(1)
+      .optional()
+      .describe("Short flag — single character (used as `-x` on CLI)"),
+    required: z.boolean().optional().describe("Whether the parameter is required"),
+    default: z
+      .union([z.string(), z.number(), z.boolean()])
+      .optional()
+      .describe("Default value when not provided"),
+  })
+  .describe("CLI-style workflow parameter definition");
+
+// ── Setup ────────────────────────────────────────────────────────
+
+export const SetupTaskSchema = z
+  .object({
+    shell: z.string().min(1).describe("Shell command to execute before kickoff"),
+    as: z
+      .string()
+      .optional()
+      .describe("Variable name to store command output (accessible via `${{ name }}` interpolation)"),
+  })
+  .describe("Setup command — runs before kickoff to prepare variables");
+
+// ── Workflow File ────────────────────────────────────────────────
+
+export const WorkflowFileSchema = z
+  .object({
+    name: z.string().optional().describe("Workflow name (defaults to filename without extension)"),
+    agents: z.record(z.string(), AgentEntrySchema).describe("Agent definitions — keyed by agent name"),
+    context: ContextConfigSchema,
+    params: z.array(ParamDefinitionSchema).optional().describe("CLI-style parameter definitions"),
+    setup: z.array(SetupTaskSchema).optional().describe("Setup commands — run sequentially before kickoff"),
+    kickoff: z
+      .string()
+      .optional()
+      .describe("Kickoff message — initiates the workflow via `@mention`. Supports variable interpolation"),
+  })
+  .describe("Workflow file — defines agents, context, and orchestration");

--- a/packages/agent-worker/src/workflow/schema.ts
+++ b/packages/agent-worker/src/workflow/schema.ts
@@ -19,7 +19,9 @@ export const ProviderConfigSchema = z
     api_key: z
       .string()
       .optional()
-      .describe("API key — env var reference with `$` prefix (e.g., `$MINIMAX_API_KEY`) or literal value"),
+      .describe(
+        "API key — env var reference with `$` prefix (e.g., `$MINIMAX_API_KEY`) or literal value",
+      ),
   })
   .describe("Custom provider configuration for API endpoint overrides");
 
@@ -27,17 +29,34 @@ export const ProviderConfigSchema = z
 
 export const RefAgentEntrySchema = z
   .object({
-    ref: z.string().min(1).describe("Name of the global agent to reference (from `.agents/*.yaml`)"),
+    ref: z
+      .string()
+      .min(1)
+      .describe("Name of the global agent to reference (from `.agents/*.yaml`)"),
     prompt: z
       .object({
-        append: z.string().describe("Additional instructions appended to the agent's base system prompt"),
+        append: z
+          .string()
+          .describe("Additional instructions appended to the agent's base system prompt"),
       })
       .optional()
       .describe("Prompt extension for this workflow"),
-    max_tokens: z.number().int().positive().optional().describe("Override maximum tokens for response"),
-    max_steps: z.number().int().positive().optional().describe("Override maximum tool call steps per turn"),
+    max_tokens: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Override maximum tokens for response"),
+    max_steps: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Override maximum tool call steps per turn"),
   })
-  .describe("Reference to a global agent definition — carries persistent context (memory, notes, todo)");
+  .describe(
+    "Reference to a global agent definition — carries persistent context (memory, notes, todo)",
+  );
 
 export const InlineAgentEntrySchema = z
   .object({
@@ -80,7 +99,9 @@ export const InlineAgentEntrySchema = z
     wakeup: z
       .union([z.string(), z.number()])
       .optional()
-      .describe('Periodic wakeup schedule: number (ms), duration string (`"30s"`/`"5m"`/`"2h"`), or cron expression'),
+      .describe(
+        'Periodic wakeup schedule: number (ms), duration string (`"30s"`/`"5m"`/`"2h"`), or cron expression',
+      ),
     wakeup_prompt: z
       .string()
       .optional()
@@ -90,14 +111,22 @@ export const InlineAgentEntrySchema = z
 
 export const AgentEntrySchema = z
   .union([RefAgentEntrySchema, InlineAgentEntrySchema])
-  .describe("Agent entry — either a `ref` to a global agent or an inline definition. Discriminated by presence of `ref`");
+  .describe(
+    "Agent entry — either a `ref` to a global agent or an inline definition. Discriminated by presence of `ref`",
+  );
 
 // ── Context ──────────────────────────────────────────────────────
 
 const FileContextConfigSchema = z
   .object({
-    dir: z.string().optional().describe("Ephemeral context directory path (template variables supported)"),
-    bind: z.string().optional().describe("Persistent context directory path — state survives across runs"),
+    dir: z
+      .string()
+      .optional()
+      .describe("Ephemeral context directory path (template variables supported)"),
+    bind: z
+      .string()
+      .optional()
+      .describe("Persistent context directory path — state survives across runs"),
   })
   .describe("File context configuration (`dir` and `bind` are mutually exclusive)");
 
@@ -108,12 +137,9 @@ export const ContextConfigSchema = z
       .object({
         provider: z
           .enum(["file", "memory"])
-          .describe('Context provider type. `file` for disk-based, `memory` for testing'),
+          .describe("Context provider type. `file` for disk-based, `memory` for testing"),
         config: FileContextConfigSchema.optional().describe("Provider-specific configuration"),
-        documentOwner: z
-          .string()
-          .optional()
-          .describe("Document owner for single-writer model"),
+        documentOwner: z.string().optional().describe("Document owner for single-writer model"),
       })
       .describe("Shared context configuration"),
   ])
@@ -151,7 +177,9 @@ export const SetupTaskSchema = z
     as: z
       .string()
       .optional()
-      .describe("Variable name to store command output (accessible via `${{ name }}` interpolation)"),
+      .describe(
+        "Variable name to store command output (accessible via `${{ name }}` interpolation)",
+      ),
   })
   .describe("Setup command — runs before kickoff to prepare variables");
 
@@ -160,13 +188,20 @@ export const SetupTaskSchema = z
 export const WorkflowFileSchema = z
   .object({
     name: z.string().optional().describe("Workflow name (defaults to filename without extension)"),
-    agents: z.record(z.string(), AgentEntrySchema).describe("Agent definitions — keyed by agent name"),
+    agents: z
+      .record(z.string(), AgentEntrySchema)
+      .describe("Agent definitions — keyed by agent name"),
     context: ContextConfigSchema,
     params: z.array(ParamDefinitionSchema).optional().describe("CLI-style parameter definitions"),
-    setup: z.array(SetupTaskSchema).optional().describe("Setup commands — run sequentially before kickoff"),
+    setup: z
+      .array(SetupTaskSchema)
+      .optional()
+      .describe("Setup commands — run sequentially before kickoff"),
     kickoff: z
       .string()
       .optional()
-      .describe("Kickoff message — initiates the workflow via `@mention`. Supports variable interpolation"),
+      .describe(
+        "Kickoff message — initiates the workflow via `@mention`. Supports variable interpolation",
+      ),
   })
   .describe("Workflow file — defines agents, context, and orchestration");

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -5,7 +5,6 @@
 import type { ContextConfig } from "./context/types.ts";
 import type { ScheduleConfig } from "../daemon/registry.ts";
 import type { AgentHandle } from "../agent/agent-handle.ts";
-import type { AgentSoul } from "../agent/definition.ts";
 
 // Re-export context types for convenience
 export type { ContextConfig, FileContextConfig, MemoryContextConfig } from "./context/types.ts";

--- a/packages/agent-worker/src/workflow/types.ts
+++ b/packages/agent-worker/src/workflow/types.ts
@@ -18,7 +18,7 @@ export interface WorkflowFile {
   name?: string;
 
   /** Agent definitions */
-  agents: Record<string, AgentDefinition>;
+  agents: Record<string, WorkflowAgentDef>;
 
   /**
    * Shared context configuration
@@ -73,7 +73,7 @@ export interface ProviderConfig {
 
 // ==================== Agent Definition ====================
 
-export interface AgentDefinition {
+export interface WorkflowAgentDef {
   /** Backend to use: 'default' (Vercel AI SDK), 'claude', 'cursor', 'codex', 'opencode', 'mock' (testing) */
   backend?: "default" | "claude" | "cursor" | "codex" | "opencode" | "mock";
 
@@ -154,7 +154,7 @@ export interface ParsedWorkflow {
    * Exposed as ${{ source.dir }} in workflow interpolation.
    */
   sourceDir: string;
-  agents: Record<string, ResolvedAgent>;
+  agents: Record<string, ResolvedWorkflowAgent>;
 
   /** Resolved context configuration */
   context?: ResolvedContext;
@@ -169,7 +169,7 @@ export interface ParsedWorkflow {
   kickoff?: string;
 }
 
-export interface ResolvedAgent extends AgentDefinition {
+export interface ResolvedWorkflowAgent extends WorkflowAgentDef {
   /** Resolved system prompt content */
   resolvedSystemPrompt?: string;
 

--- a/packages/agent-worker/test/controller.test.ts
+++ b/packages/agent-worker/test/controller.test.ts
@@ -18,7 +18,7 @@ import { parseSendTarget, sendToWorkflowChannel, formatUserSender } from '../src
 import type { WorkflowIdleState } from '../src/workflow/loop/types.ts'
 import { createMemoryContextProvider } from '../src/workflow/context/memory-provider.ts'
 import type { InboxMessage, Message } from '../src/workflow/context/types.ts'
-import type { ResolvedAgent } from '../src/workflow/types.ts'
+import type { ResolvedWorkflowAgent } from '../src/workflow/types.ts'
 
 // ==================== Model Parsing Tests ====================
 
@@ -145,7 +145,7 @@ describe('formatChannel', () => {
 })
 
 describe('buildAgentPrompt', () => {
-  const mockAgent: ResolvedAgent = {
+  const mockAgent: ResolvedWorkflowAgent = {
     model: 'claude-sonnet-4-5',
     system_prompt: 'You are a helpful assistant',
     resolvedSystemPrompt: 'You are a helpful assistant',
@@ -282,7 +282,7 @@ describe('generateWorkflowMCPConfig', () => {
 // ==================== Loop Tests ====================
 
 describe('createAgentLoop', () => {
-  const mockAgent: ResolvedAgent = {
+  const mockAgent: ResolvedWorkflowAgent = {
     model: 'claude-sonnet-4-5',
     system_prompt: 'Test agent',
     resolvedSystemPrompt: 'Test agent',
@@ -523,7 +523,7 @@ describe('createAgentLoop', () => {
 })
 
 describe('checkWorkflowIdle', () => {
-  const mockAgent: ResolvedAgent = {
+  const mockAgent: ResolvedWorkflowAgent = {
     model: 'claude-sonnet-4-5',
     system_prompt: 'Test agent',
     resolvedSystemPrompt: 'Test agent',
@@ -677,7 +677,7 @@ describe('isWorkflowComplete', () => {
 })
 
 describe('buildWorkflowIdleState', () => {
-  const mockAgent: ResolvedAgent = {
+  const mockAgent: ResolvedWorkflowAgent = {
     model: 'claude-sonnet-4-5',
     system_prompt: 'Test agent',
     resolvedSystemPrompt: 'Test agent',

--- a/packages/agent-worker/test/unit/agent-definition.test.ts
+++ b/packages/agent-worker/test/unit/agent-definition.test.ts
@@ -129,6 +129,26 @@ describe("AgentDefinitionSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  test("preserves custom soul fields (passthrough)", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Hello" },
+      soul: {
+        role: "reviewer",
+        custom_trait: "value",
+        nested: { deep: true },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const soul = (result.data as AgentDefinition).soul!;
+      expect(soul.role).toBe("reviewer");
+      expect(soul.custom_trait).toBe("value");
+      expect(soul.nested).toEqual({ deep: true });
+    }
+  });
+
   test("rejects negative thin_thread", () => {
     const result = AgentDefinitionSchema.safeParse({
       name: "alice",

--- a/packages/agent-worker/test/unit/agent-definition.test.ts
+++ b/packages/agent-worker/test/unit/agent-definition.test.ts
@@ -1,0 +1,667 @@
+/**
+ * Tests for Phase 1: Agent Definition + Context
+ *
+ * Covers:
+ *   - AgentDefinition type + Zod schema validation
+ *   - YAML parsing (single file, discovery, serialization)
+ *   - AgentHandle context operations (memory, notes, todos)
+ *   - AgentRegistry (load, create, delete, lookup)
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { AgentDefinitionSchema, CONTEXT_SUBDIRS } from "@/agent/definition.ts";
+import type { AgentDefinition } from "@/agent/definition.ts";
+import { parseAgentFile, parseAgentObject, discoverAgents, serializeAgent } from "@/agent/yaml-parser.ts";
+import { AgentHandle } from "@/agent/agent-handle.ts";
+import { AgentRegistry } from "@/agent/agent-registry.ts";
+
+// ── Test Helpers ──────────────────────────────────────────────────
+
+function tmpDir(): string {
+  const dir = join(tmpdir(), `agent-test-${randomUUID().slice(0, 8)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeYaml(dir: string, filename: string, content: string): string {
+  const path = join(dir, filename);
+  writeFileSync(path, content);
+  return path;
+}
+
+// ── AgentDefinitionSchema ─────────────────────────────────────────
+
+describe("AgentDefinitionSchema", () => {
+  test("validates a minimal definition", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "You are Alice." },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("validates a full definition", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+      backend: "sdk",
+      provider: "anthropic",
+      prompt: { system: "You are Alice." },
+      soul: {
+        role: "code-reviewer",
+        expertise: ["typescript", "testing"],
+        style: "thorough",
+        principles: ["Be precise", "Be kind"],
+      },
+      context: { dir: ".agents/alice/", thin_thread: 15 },
+      max_tokens: 8000,
+      max_steps: 20,
+      schedule: { wakeup: "5m", prompt: "Check inbox" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("validates system_file prompt variant", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "bob",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system_file: "./prompts/bob.md" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing name", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Hello" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing model", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "alice",
+      prompt: { system: "Hello" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing prompt", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty name", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Hello" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid backend", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Hello" },
+      backend: "invalid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("validates provider as object", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "alice",
+      model: "MiniMax-M2.5",
+      prompt: { system: "Hello" },
+      provider: { name: "anthropic", base_url: "https://api.example.com" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects negative thin_thread", () => {
+    const result = AgentDefinitionSchema.safeParse({
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Hello" },
+      context: { thin_thread: -1 },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── YAML Parser ───────────────────────────────────────────────────
+
+describe("parseAgentFile", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("parses a valid YAML file", () => {
+    const path = writeYaml(
+      dir,
+      "alice.yaml",
+      `
+name: alice
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system: You are Alice, a code reviewer.
+soul:
+  role: code-reviewer
+  expertise:
+    - typescript
+    - testing
+`,
+    );
+
+    const def = parseAgentFile(path);
+    expect(def.name).toBe("alice");
+    expect(def.model).toBe("anthropic/claude-sonnet-4-5");
+    expect(def.prompt.system).toBe("You are Alice, a code reviewer.");
+    expect(def.soul?.role).toBe("code-reviewer");
+    expect(def.soul?.expertise).toEqual(["typescript", "testing"]);
+  });
+
+  test("infers name from filename", () => {
+    const path = writeYaml(
+      dir,
+      "bob.yaml",
+      `
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system: You are Bob.
+`,
+    );
+
+    const def = parseAgentFile(path);
+    expect(def.name).toBe("bob");
+  });
+
+  test("resolves system_file", () => {
+    writeFileSync(join(dir, "prompt.md"), "You are a helpful assistant.");
+    const path = writeYaml(
+      dir,
+      "helper.yaml",
+      `
+name: helper
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system_file: ./prompt.md
+`,
+    );
+
+    const def = parseAgentFile(path);
+    expect(def.prompt.system).toBe("You are a helpful assistant.");
+    expect(def.prompt.system_file).toBeUndefined();
+  });
+
+  test("throws on missing file", () => {
+    expect(() => parseAgentFile(join(dir, "nonexistent.yaml"))).toThrow(
+      "Agent file not found",
+    );
+  });
+
+  test("throws on missing system_file reference", () => {
+    const path = writeYaml(
+      dir,
+      "bad.yaml",
+      `
+name: bad
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system_file: ./nonexistent.md
+`,
+    );
+
+    expect(() => parseAgentFile(path)).toThrow("system_file not found");
+  });
+
+  test("throws on invalid YAML content", () => {
+    const path = writeYaml(dir, "invalid.yaml", "model: x\nprompt: just-a-string\n");
+    expect(() => parseAgentFile(path)).toThrow();
+  });
+});
+
+describe("parseAgentObject", () => {
+  test("validates a valid object", () => {
+    const def = parseAgentObject({
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Hello" },
+    });
+    expect(def.name).toBe("alice");
+  });
+
+  test("throws on invalid object", () => {
+    expect(() => parseAgentObject({ name: "alice" })).toThrow(
+      "Invalid agent definition",
+    );
+  });
+});
+
+describe("discoverAgents", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("discovers agents from .agents/ directory", () => {
+    const agentsDir = join(dir, ".agents");
+    mkdirSync(agentsDir, { recursive: true });
+
+    writeYaml(
+      agentsDir,
+      "alice.yaml",
+      `
+name: alice
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system: Alice prompt
+`,
+    );
+    writeYaml(
+      agentsDir,
+      "bob.yaml",
+      `
+name: bob
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system: Bob prompt
+`,
+    );
+
+    const agents = discoverAgents(dir);
+    expect(agents.length).toBe(2);
+    const names = agents.map((a) => a.name).sort();
+    expect(names).toEqual(["alice", "bob"]);
+  });
+
+  test("returns empty array if .agents/ doesn't exist", () => {
+    const agents = discoverAgents(dir);
+    expect(agents).toEqual([]);
+  });
+
+  test("skips invalid files", () => {
+    const agentsDir = join(dir, ".agents");
+    mkdirSync(agentsDir, { recursive: true });
+
+    writeYaml(
+      agentsDir,
+      "good.yaml",
+      `
+name: good
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system: Good agent
+`,
+    );
+    writeYaml(agentsDir, "bad.yaml", "not: valid: agent\n");
+
+    const warnings: string[] = [];
+    const agents = discoverAgents(dir, (msg) => warnings.push(msg));
+    expect(agents.length).toBe(1);
+    expect(agents[0]!.name).toBe("good");
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  test("skips non-yaml files", () => {
+    const agentsDir = join(dir, ".agents");
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(join(agentsDir, "readme.md"), "not an agent");
+
+    const agents = discoverAgents(dir);
+    expect(agents).toEqual([]);
+  });
+});
+
+describe("serializeAgent", () => {
+  test("serializes a definition to YAML", () => {
+    const def: AgentDefinition = {
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "You are Alice." },
+      soul: { role: "reviewer" },
+    };
+
+    const yaml = serializeAgent(def);
+    expect(yaml).toContain("name: alice");
+    expect(yaml).toContain("model: anthropic/claude-sonnet-4-5");
+    expect(yaml).toContain("system: You are Alice.");
+    expect(yaml).toContain("role: reviewer");
+  });
+
+  test("round-trips through parse", () => {
+    const dir = tmpDir();
+    const def: AgentDefinition = {
+      name: "roundtrip",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Test agent." },
+      backend: "sdk",
+      soul: { role: "tester", expertise: ["ts"] },
+    };
+
+    const yaml = serializeAgent(def);
+    const path = writeYaml(dir, "roundtrip.yaml", yaml);
+    const parsed = parseAgentFile(path);
+
+    expect(parsed.name).toBe(def.name);
+    expect(parsed.model).toBe(def.model);
+    expect(parsed.prompt.system).toBe(def.prompt.system);
+    expect(parsed.backend).toBe(def.backend);
+    expect(parsed.soul?.role).toBe(def.soul?.role);
+    expect(parsed.soul?.expertise).toEqual(def.soul?.expertise);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ── AgentHandle ───────────────────────────────────────────────────
+
+describe("AgentHandle", () => {
+  let dir: string;
+  let handle: AgentHandle;
+
+  beforeEach(() => {
+    dir = tmpDir();
+    const contextDir = join(dir, "alice");
+    handle = new AgentHandle(
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        prompt: { system: "You are Alice." },
+        soul: { role: "reviewer" },
+      },
+      contextDir,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("name accessor returns definition name", () => {
+    expect(handle.name).toBe("alice");
+  });
+
+  test("initial state is idle", () => {
+    expect(handle.state).toBe("idle");
+  });
+
+  test("ensureContextDir creates all subdirectories", () => {
+    handle.ensureContextDir();
+    for (const sub of CONTEXT_SUBDIRS) {
+      expect(existsSync(join(handle.contextDir, sub))).toBe(true);
+    }
+  });
+
+  test("ensureContextDir is idempotent", () => {
+    handle.ensureContextDir();
+    handle.ensureContextDir(); // should not throw
+    for (const sub of CONTEXT_SUBDIRS) {
+      expect(existsSync(join(handle.contextDir, sub))).toBe(true);
+    }
+  });
+
+  // ── Memory ──────────────────────────────────────────────────────
+
+  test("writeMemory + readMemory round-trips", async () => {
+    handle.ensureContextDir();
+    await handle.writeMemory("prefs", { theme: "dark", verbose: true });
+    const mem = await handle.readMemory();
+    expect(mem.prefs).toEqual({ theme: "dark", verbose: true });
+  });
+
+  test("readMemory returns empty on no memory dir", async () => {
+    const mem = await handle.readMemory();
+    expect(mem).toEqual({});
+  });
+
+  test("readMemory reads multiple keys", async () => {
+    handle.ensureContextDir();
+    await handle.writeMemory("key1", "value1");
+    await handle.writeMemory("key2", { nested: true });
+    const mem = await handle.readMemory();
+    expect(mem.key1).toBe("value1");
+    expect(mem.key2).toEqual({ nested: true });
+  });
+
+  // ── Notes ───────────────────────────────────────────────────────
+
+  test("appendNote + readNotes round-trips", async () => {
+    handle.ensureContextDir();
+    await handle.appendNote("First learning", "first");
+    await handle.appendNote("Second learning", "second");
+
+    const notes = await handle.readNotes();
+    expect(notes.length).toBe(2);
+    // Most recent first
+    expect(notes[0]).toContain("Second learning");
+    expect(notes[1]).toContain("First learning");
+  });
+
+  test("readNotes with limit", async () => {
+    handle.ensureContextDir();
+    await handle.appendNote("Note 1", "n1");
+    await handle.appendNote("Note 2", "n2");
+    await handle.appendNote("Note 3", "n3");
+
+    const notes = await handle.readNotes(2);
+    expect(notes.length).toBe(2);
+  });
+
+  test("readNotes returns empty on no notes", async () => {
+    const notes = await handle.readNotes();
+    expect(notes).toEqual([]);
+  });
+
+  // ── Todos ───────────────────────────────────────────────────────
+
+  test("writeTodos + readTodos round-trips", async () => {
+    handle.ensureContextDir();
+    await handle.writeTodos(["Fix bug #123", "Review PR #456"]);
+    const todos = await handle.readTodos();
+    expect(todos).toEqual(["Fix bug #123", "Review PR #456"]);
+  });
+
+  test("readTodos returns empty on no file", async () => {
+    const todos = await handle.readTodos();
+    expect(todos).toEqual([]);
+  });
+});
+
+// ── AgentRegistry ─────────────────────────────────────────────────
+
+describe("AgentRegistry", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("loadFromDisk discovers agents", () => {
+    const agentsDir = join(dir, ".agents");
+    mkdirSync(agentsDir, { recursive: true });
+    writeYaml(
+      agentsDir,
+      "alice.yaml",
+      `
+name: alice
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system: Alice agent
+`,
+    );
+
+    const registry = new AgentRegistry(dir);
+    registry.loadFromDisk();
+
+    expect(registry.size).toBe(1);
+    expect(registry.has("alice")).toBe(true);
+    const handle = registry.get("alice")!;
+    expect(handle.name).toBe("alice");
+    expect(handle.definition.prompt.system).toBe("Alice agent");
+  });
+
+  test("create writes YAML and creates context dir", () => {
+    const registry = new AgentRegistry(dir);
+    const handle = registry.create({
+      name: "bob",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Bob agent" },
+    });
+
+    // YAML file exists
+    expect(existsSync(join(dir, ".agents", "bob.yaml"))).toBe(true);
+
+    // Context dir + subdirs exist
+    for (const sub of CONTEXT_SUBDIRS) {
+      expect(existsSync(join(handle.contextDir, sub))).toBe(true);
+    }
+
+    // Registered in memory
+    expect(registry.has("bob")).toBe(true);
+    expect(registry.get("bob")).toBe(handle);
+  });
+
+  test("create throws on duplicate", () => {
+    const registry = new AgentRegistry(dir);
+    registry.create({
+      name: "alice",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Alice" },
+    });
+
+    expect(() =>
+      registry.create({
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        prompt: { system: "Another Alice" },
+      }),
+    ).toThrow("already exists");
+  });
+
+  test("delete removes YAML + context + unregisters", () => {
+    const registry = new AgentRegistry(dir);
+    const handle = registry.create({
+      name: "temp",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Temporary" },
+    });
+
+    const yamlPath = join(dir, ".agents", "temp.yaml");
+    const contextDir = handle.contextDir;
+
+    expect(existsSync(yamlPath)).toBe(true);
+    expect(existsSync(contextDir)).toBe(true);
+
+    const deleted = registry.delete("temp");
+    expect(deleted).toBe(true);
+    expect(registry.has("temp")).toBe(false);
+    expect(existsSync(yamlPath)).toBe(false);
+    expect(existsSync(contextDir)).toBe(false);
+  });
+
+  test("delete returns false for nonexistent agent", () => {
+    const registry = new AgentRegistry(dir);
+    expect(registry.delete("nonexistent")).toBe(false);
+  });
+
+  test("list returns all handles", () => {
+    const registry = new AgentRegistry(dir);
+    registry.create({
+      name: "a1",
+      model: "m1",
+      prompt: { system: "A1" },
+    });
+    registry.create({
+      name: "a2",
+      model: "m2",
+      prompt: { system: "A2" },
+    });
+
+    const list = registry.list();
+    expect(list.length).toBe(2);
+    const names = list.map((h) => h.name).sort();
+    expect(names).toEqual(["a1", "a2"]);
+  });
+
+  test("custom context.dir is respected", () => {
+    const registry = new AgentRegistry(dir);
+    const handle = registry.registerDefinition({
+      name: "custom",
+      model: "anthropic/claude-sonnet-4-5",
+      prompt: { system: "Custom" },
+      context: { dir: "data/agents/custom" },
+    });
+
+    expect(handle.contextDir).toBe(join(dir, "data/agents/custom"));
+    for (const sub of CONTEXT_SUBDIRS) {
+      expect(existsSync(join(handle.contextDir, sub))).toBe(true);
+    }
+  });
+
+  test("loadFromDisk creates context dirs", () => {
+    const agentsDir = join(dir, ".agents");
+    mkdirSync(agentsDir, { recursive: true });
+    writeYaml(
+      agentsDir,
+      "loader.yaml",
+      `
+name: loader
+model: anthropic/claude-sonnet-4-5
+prompt:
+  system: Loader agent
+`,
+    );
+
+    const registry = new AgentRegistry(dir);
+    registry.loadFromDisk();
+
+    const handle = registry.get("loader")!;
+    for (const sub of CONTEXT_SUBDIRS) {
+      expect(existsSync(join(handle.contextDir, sub))).toBe(true);
+    }
+  });
+
+  test("registerDefinition overwrites existing", () => {
+    const registry = new AgentRegistry(dir);
+    registry.registerDefinition({
+      name: "alice",
+      model: "model-v1",
+      prompt: { system: "V1" },
+    });
+    registry.registerDefinition({
+      name: "alice",
+      model: "model-v2",
+      prompt: { system: "V2" },
+    });
+
+    expect(registry.size).toBe(1);
+    expect(registry.get("alice")!.definition.model).toBe("model-v2");
+  });
+});

--- a/packages/agent-worker/test/unit/agent-ref.test.ts
+++ b/packages/agent-worker/test/unit/agent-ref.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Tests for Phase 2: Workflow Agent References
+ *
+ * Covers:
+ *   - AgentEntry discriminated union (RefAgentEntry | InlineAgentEntry)
+ *   - isRefAgentEntry type guard
+ *   - Validation of ref vs inline agents
+ *   - Ref agent resolution (registry lookup, field mapping, prompt.append)
+ *   - parseWorkflowFile with mixed ref + inline agents
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import {
+  isRefAgentEntry,
+  type RefAgentEntry,
+  type InlineAgentEntry,
+  type AgentEntry,
+} from "@/workflow/types.ts";
+import { validateWorkflow, parseWorkflowFile } from "@/workflow/parser.ts";
+import { AgentRegistry } from "@/agent/agent-registry.ts";
+import type { AgentDefinition } from "@/agent/definition.ts";
+
+function tmpDir(): string {
+  const dir = join(tmpdir(), `agent-ref-test-${randomUUID().slice(0, 8)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ── isRefAgentEntry ──────────────────────────────────────────────────
+
+describe("isRefAgentEntry", () => {
+  test("returns true for ref entries", () => {
+    const entry: AgentEntry = { ref: "alice" };
+    expect(isRefAgentEntry(entry)).toBe(true);
+  });
+
+  test("returns true for ref entries with prompt.append", () => {
+    const entry: AgentEntry = {
+      ref: "alice",
+      prompt: { append: "Focus on auth." },
+    };
+    expect(isRefAgentEntry(entry)).toBe(true);
+  });
+
+  test("returns false for inline entries", () => {
+    const entry: AgentEntry = {
+      model: "anthropic/claude-sonnet-4-5",
+      system_prompt: "You are helpful.",
+    };
+    expect(isRefAgentEntry(entry)).toBe(false);
+  });
+
+  test("returns false for inline entries with no model (CLI backend)", () => {
+    const entry: AgentEntry = {
+      backend: "claude",
+    };
+    expect(isRefAgentEntry(entry)).toBe(false);
+  });
+});
+
+// ── Validation: ref agents ──────────────────────────────────────────
+
+describe("validateWorkflow — ref agents", () => {
+  test("accepts shorthand ref entry { ref: name }", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: { ref: "alice" },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts ref entry with prompt.append", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          prompt: { append: "Focus on performance." },
+        },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts ref entry with runtime overrides", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          max_tokens: 4000,
+          max_steps: 10,
+        },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects ref entry with system_prompt", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          system_prompt: "Not allowed",
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("system_prompt"))).toBe(true);
+  });
+
+  test("rejects ref entry with model", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          model: "not-allowed",
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("model"))).toBe(true);
+  });
+
+  test("rejects ref entry with backend", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          backend: "claude",
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("backend"))).toBe(true);
+  });
+
+  test("rejects ref entry with provider", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          provider: "anthropic",
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("provider"))).toBe(true);
+  });
+
+  test("rejects ref entry with tools", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          tools: ["read"],
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("tools"))).toBe(true);
+  });
+
+  test("rejects ref entry with non-string prompt.append", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          prompt: { append: 123 },
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("prompt.append"))).toBe(true);
+  });
+});
+
+// ── Validation: mixed ref + inline ──────────────────────────────────
+
+describe("validateWorkflow — mixed ref + inline", () => {
+  test("accepts workflow with both ref and inline agents", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: { ref: "alice" },
+        helper: {
+          model: "anthropic/claude-haiku-4-5",
+          system_prompt: "You help with lookups.",
+        },
+      },
+      kickoff: "@alice Review. @helper Check.",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("inline validation still works alongside ref", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: { ref: "alice" },
+        bad: { backend: "default" }, // missing model for default backend
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.path === "agents.bad.model")).toBe(true);
+  });
+});
+
+// ── Ref resolution ──────────────────────────────────────────────────
+
+describe("parseWorkflowFile — ref agent resolution", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function setupRegistry(agents: AgentDefinition[]): AgentRegistry {
+    const registry = new AgentRegistry(dir);
+    for (const def of agents) {
+      registry.registerDefinition(def);
+    }
+    return registry;
+  }
+
+  function writeWorkflow(filename: string, content: string): string {
+    const path = join(dir, filename);
+    writeFileSync(path, content);
+    return path;
+  }
+
+  test("resolves ref agent from registry", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        prompt: { system: "You are Alice, a code reviewer." },
+      },
+    ]);
+
+    const path = writeWorkflow(
+      "review.yml",
+      `agents:
+  alice: { ref: alice }
+kickoff: "@alice Start reviewing."
+`,
+    );
+
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+    const alice = workflow.agents.alice!;
+    expect(alice.model).toBe("anthropic/claude-sonnet-4-5");
+    expect(alice.resolvedSystemPrompt).toBe("You are Alice, a code reviewer.");
+    expect(alice.isRef).toBe(true);
+    expect(alice.handle).toBeDefined();
+    expect(alice.handle!.definition.name).toBe("alice");
+  });
+
+  test("applies prompt.append to ref agent", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        prompt: { system: "You are Alice." },
+      },
+    ]);
+
+    const path = writeWorkflow(
+      "review.yml",
+      `agents:
+  alice:
+    ref: alice
+    prompt:
+      append: Focus on security issues.
+`,
+    );
+
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+    const alice = workflow.agents.alice!;
+    expect(alice.resolvedSystemPrompt).toBe(
+      "You are Alice.\n\nFocus on security issues.",
+    );
+    // system_prompt holds the base prompt
+    expect(alice.system_prompt).toBe("You are Alice.");
+  });
+
+  test("applies runtime overrides to ref agent", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        prompt: { system: "Alice." },
+        max_tokens: 8000,
+        max_steps: 20,
+      },
+    ]);
+
+    const path = writeWorkflow(
+      "review.yml",
+      `agents:
+  alice:
+    ref: alice
+    max_tokens: 4000
+    max_steps: 5
+`,
+    );
+
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+    const alice = workflow.agents.alice!;
+    // Overrides take precedence
+    expect(alice.max_tokens).toBe(4000);
+    expect(alice.max_steps).toBe(5);
+  });
+
+  test("maps backend 'sdk' to 'default'", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        backend: "sdk",
+        prompt: { system: "Alice." },
+      },
+    ]);
+
+    const path = writeWorkflow("review.yml", `agents:\n  alice: { ref: alice }\n`);
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+    expect(workflow.agents.alice!.backend).toBe("default");
+  });
+
+  test("preserves non-sdk backends as-is", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        backend: "claude",
+        prompt: { system: "Alice." },
+      },
+    ]);
+
+    const path = writeWorkflow("review.yml", `agents:\n  alice: { ref: alice }\n`);
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+    expect(workflow.agents.alice!.backend).toBe("claude");
+  });
+
+  test("inherits schedule from agent definition", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        prompt: { system: "Alice." },
+        schedule: { wakeup: "5m", prompt: "Check inbox" },
+      },
+    ]);
+
+    const path = writeWorkflow("review.yml", `agents:\n  alice: { ref: alice }\n`);
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+    expect(workflow.agents.alice!.schedule).toEqual({
+      wakeup: "5m",
+      prompt: "Check inbox",
+    });
+  });
+
+  test("throws for ref without registry", async () => {
+    const path = writeWorkflow("review.yml", `agents:\n  alice: { ref: alice }\n`);
+    await expect(parseWorkflowFile(path)).rejects.toThrow("requires an AgentRegistry");
+  });
+
+  test("throws for ref to unknown agent", async () => {
+    const registry = setupRegistry([]);
+    const path = writeWorkflow("review.yml", `agents:\n  alice: { ref: alice }\n`);
+    await expect(
+      parseWorkflowFile(path, { agentRegistry: registry }),
+    ).rejects.toThrow('not found in registry');
+  });
+
+  test("inline agents still work alongside ref agents", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        prompt: { system: "You are Alice." },
+      },
+    ]);
+
+    const path = writeWorkflow(
+      "review.yml",
+      `agents:
+  alice: { ref: alice }
+  helper:
+    model: anthropic/claude-haiku-4-5
+    system_prompt: You help with lookups.
+kickoff: "@alice Review. @helper Check."
+`,
+    );
+
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+
+    // Ref agent
+    const alice = workflow.agents.alice!;
+    expect(alice.isRef).toBe(true);
+    expect(alice.handle).toBeDefined();
+    expect(alice.model).toBe("anthropic/claude-sonnet-4-5");
+
+    // Inline agent
+    const helper = workflow.agents.helper!;
+    expect(helper.isRef).toBe(false);
+    expect(helper.handle).toBeUndefined();
+    expect(helper.model).toBe("anthropic/claude-haiku-4-5");
+    expect(helper.resolvedSystemPrompt).toBe("You help with lookups.");
+  });
+
+  test("maps provider from agent definition", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "claude-sonnet-4-5",
+        provider: { name: "anthropic", base_url: "https://custom.api.com" },
+        prompt: { system: "Alice." },
+      },
+    ]);
+
+    const path = writeWorkflow("review.yml", `agents:\n  alice: { ref: alice }\n`);
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+    expect(workflow.agents.alice!.provider).toEqual({
+      name: "anthropic",
+      base_url: "https://custom.api.com",
+    });
+  });
+
+  test("prompt.append with empty base prompt", async () => {
+    const registry = setupRegistry([
+      {
+        name: "alice",
+        model: "anthropic/claude-sonnet-4-5",
+        prompt: { system: "" },
+      },
+    ]);
+
+    const path = writeWorkflow(
+      "review.yml",
+      `agents:
+  alice:
+    ref: alice
+    prompt:
+      append: Focus on auth.
+`,
+    );
+
+    const workflow = await parseWorkflowFile(path, { agentRegistry: registry });
+    expect(workflow.agents.alice!.resolvedSystemPrompt).toBe("Focus on auth.");
+  });
+});

--- a/packages/agent-worker/test/unit/agent-ref.test.ts
+++ b/packages/agent-worker/test/unit/agent-ref.test.ts
@@ -165,6 +165,32 @@ describe("validateWorkflow — ref agents", () => {
     expect(result.errors.some((e) => e.message.includes("tools"))).toBe(true);
   });
 
+  test("rejects ref entry with wakeup", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          wakeup: "5m",
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("wakeup"))).toBe(true);
+  });
+
+  test("rejects ref entry with timeout", () => {
+    const result = validateWorkflow({
+      agents: {
+        alice: {
+          ref: "alice",
+          timeout: 30000,
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.message.includes("timeout"))).toBe(true);
+  });
+
   test("rejects ref entry with non-string prompt.append", () => {
     const result = validateWorkflow({
       agents: {

--- a/packages/agent-worker/test/unit/wired-loop-model.test.ts
+++ b/packages/agent-worker/test/unit/wired-loop-model.test.ts
@@ -10,7 +10,7 @@ import { describe, test, expect } from "bun:test";
 import { createWiredLoop, type RuntimeContext } from "../../src/workflow/factory.ts";
 import { createMemoryContextProvider } from "../../src/workflow/context/memory-provider.ts";
 import { EventLog } from "../../src/workflow/context/event-log.ts";
-import type { ResolvedAgent } from "../../src/workflow/types.ts";
+import type { ResolvedWorkflowAgent } from "../../src/workflow/types.ts";
 
 /** Minimal runtime context for testing (no HTTP server needed) */
 function createTestRuntime(): RuntimeContext {
@@ -33,7 +33,7 @@ describe("createWiredLoop model resolution", () => {
     savedKey = process.env.AI_GATEWAY_API_KEY;
     process.env.AI_GATEWAY_API_KEY = savedKey || "test-key";
     try {
-      const agent: ResolvedAgent = {
+      const agent: ResolvedWorkflowAgent = {
         model: "auto",
         system_prompt: "test",
         resolvedSystemPrompt: "test",
@@ -63,7 +63,7 @@ describe("createWiredLoop model resolution", () => {
     savedKey = process.env.AI_GATEWAY_API_KEY;
     process.env.AI_GATEWAY_API_KEY = savedKey || "test-key";
     try {
-      const agent: ResolvedAgent = {
+      const agent: ResolvedWorkflowAgent = {
         model: "auto",
         system_prompt: "test",
         resolvedSystemPrompt: "test",
@@ -88,14 +88,14 @@ describe("createWiredLoop model resolution", () => {
   });
 
   test("non-auto model passes through unchanged", () => {
-    const agent: ResolvedAgent = {
+    const agent: ResolvedWorkflowAgent = {
       model: "deepseek/deepseek-chat",
       system_prompt: "test",
       resolvedSystemPrompt: "test",
     };
 
     // Track what agent config the backend factory receives
-    let receivedAgent: ResolvedAgent | undefined;
+    let receivedAgent: ResolvedWorkflowAgent | undefined;
     createWiredLoop({
       name: "test-agent",
       agent,

--- a/packages/agent-worker/test/workflow-mock-backend.test.ts
+++ b/packages/agent-worker/test/workflow-mock-backend.test.ts
@@ -14,7 +14,7 @@ import { createMemoryContextProvider } from '../src/workflow/context/memory-prov
 import { createAgentLoop, checkWorkflowIdle } from '../src/workflow/loop/loop.ts'
 import type { AgentLoop } from '../src/workflow/loop/types.ts'
 import type { Backend } from '../src/backends/types.ts'
-import type { ResolvedAgent } from '../src/workflow/types.ts'
+import type { ResolvedWorkflowAgent } from '../src/workflow/types.ts'
 import type { ContextProvider } from '../src/workflow/context/provider.ts'
 
 // ==================== Helpers ====================
@@ -95,14 +95,14 @@ describe('Alice-Bob workflow with mock backends', () => {
     loops.length = 0
   })
 
-  const aliceAgent: ResolvedAgent = {
+  const aliceAgent: ResolvedWorkflowAgent = {
     backend: 'cursor',
     model: 'sonnet-4.5',
     system_prompt: 'You are Alice. You like to ask questions and are curious about everything.',
     resolvedSystemPrompt: 'You are Alice. You like to ask questions and are curious about everything.',
   }
 
-  const bobAgent: ResolvedAgent = {
+  const bobAgent: ResolvedWorkflowAgent = {
     backend: 'claude',
     system_prompt: 'You are Bob. You are knowledgeable and patient. You answer questions clearly and concisely.',
     resolvedSystemPrompt:

--- a/packages/agent-worker/test/workflow-simulation.test.ts
+++ b/packages/agent-worker/test/workflow-simulation.test.ts
@@ -13,7 +13,7 @@ import { createProposalManager } from '../src/workflow/context/proposals.js'
 import { MemoryStorage } from '../src/workflow/context/storage.js'
 import type { AgentLoop } from '../src/workflow/loop/types.js'
 import type { Backend } from '../src/backends/types.js'
-import type { ResolvedAgent } from '../src/workflow/types.js'
+import type { ResolvedWorkflowAgent } from '../src/workflow/types.js'
 import type { ContextProvider } from '../src/workflow/context/provider.js'
 
 // ==================== Test Helpers ====================
@@ -30,7 +30,7 @@ function getInboxSection(prompt: string): string {
   return end === -1 ? prompt.slice(start) : prompt.slice(start, end)
 }
 
-const mockAgent: ResolvedAgent = {
+const mockAgent: ResolvedWorkflowAgent = {
   model: 'mock',
   system_prompt: 'Test agent',
   resolvedSystemPrompt: 'Test agent',


### PR DESCRIPTION
- Remove global workspace concept; agents use personal context when idle
- DM sends directly to agent (no workspace channel), workspace messages
  use explicit @workspace @agent syntax
- "Standalone" is now an agent state (idle), not a type
- Add conversations/ to agent personal context for DM history
- Update Phase 3 to include DM code path and remove global workspace
- Record ADR: 2026-02-26-drop-global-workspace.md

https://claude.ai/code/session_017ej4ynheQhUeuWB1Bg6MEX