### PR TITLE
feat: Phase 5 — Priority Queue + Cooperative Preemption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ test-skills.ts
 test-skills-cli.ts
 test-skills-with-mock.ts
 .agents/
+
+# Workflow templates (local, user-specific)
+.workflows/

--- a/.memory/context.md
+++ b/.memory/context.md
@@ -4,28 +4,9 @@
 
 ## 当前焦点
 
-**Three-Package Split** — 将 `packages/agent-worker/` 拆分为三个独立包：`@moniro/agent`（Worker）、`@moniro/workflow`（Orchestration）、`agent-worker`（System）。设计已完成，待实施。
+**Phase 5 PR 待合并** — Priority Queue + Cooperative Preemption（PR #110）。三包架构已完成（Phase 4），代码库稳定。
 
-详细设计：`packages/agent-worker/docs/architecture/PACKAGE-SPLIT.md`
-
-## 阶段总览
-
-| 阶段 | 状态 | 内容 | 关键产物 |
-|------|------|------|----------|
-| Phase 0 | done | 预备清理：类型重命名、config 解耦、生命周期测试 | `WorkflowAgentDef`, `DaemonState.loops` |
-| Phase 1 | done | Agent 定义 + Context：YAML、Registry、CLI | `.agents/*.yaml`, `AgentHandle`, `AgentRegistry` |
-| Phase 2 | done | Workflow Agent References：`ref:` 引用 | `AgentEntry` 联合类型, prompt assembly |
-| Phase 3a | done | Event Log 基础设施：结构化日志替代 console.* | `EventSink`, `DaemonEventLog`, `Logger` |
-| Phase 3b | done | Daemon Registry + Workspace | `Workspace`, `WorkspaceRegistry`, `AgentHandle.loop` |
-| Phase 3c | done | Conversation Model：ThinThread + ConversationLog | `ConversationLog`, `ThinThread`, `thinThreadSection` |
-| **Phase 4** | **next** | **Three-Package Split** | `@moniro/agent`, `@moniro/workflow`, `agent-worker` |
-| Phase 5 | future | Priority Queue + Preemption | AgentLoop → 3-lane queue, cooperative yield |
-| Phase 6 | future | Agent Context in Prompt + Personal Context Tools | recall tools, auto-memory |
-| Phase 7 | future | CLI + Project Config | `moniro.yaml`, improved CLI |
-
-## Phase 4: Three-Package Split
-
-**目标**: 三个包，三种用途，严格向下依赖。
+## 架构概览
 
 ```
 @moniro/agent        ← Worker: 用完即丢的 agent 执行
@@ -38,33 +19,42 @@ agent-worker ────────┘  ← System: 持久化 daemon 服务
                          daemon + AgentHandle + CLI + conversation
 ```
 
-实施步骤：
-- [ ] Step 1: Barrel exports — 在现有包内验证三层边界
-- [ ] Step 2: Extract `@moniro/agent` — worker + backends + skills + personal context
-- [ ] Step 3: Extract `@moniro/workflow` — loop + context + tools
-- [ ] Step 4: Clean up `agent-worker` — 只留 daemon + persistence + CLI
+## 阶段总览
 
-关键设计决策：
-- **Personal context 在 Agent 层**（可选 toolkit），System 层只负责 wiring 到持久化路径
-- **Shared context 在 Workflow 层**，personal context 和 shared context 永不重叠
-- **Tool infra + skills 在 Agent 层**，具体 tool 实现（bash、feedback）在 Workflow 层
-- System 层可以同时直接依赖 Agent 和 Workflow
+| 阶段 | 状态 | 内容 | 关键产物 |
+|------|------|------|----------|
+| Phase 0 | done | 预备清理：类型重命名、config 解耦 | `WorkflowAgentDef`, `DaemonState.loops` |
+| Phase 1 | done | Agent 定义 + Context：YAML、Registry、CLI | `.agents/*.yaml`, `AgentHandle`, `AgentRegistry` |
+| Phase 2 | done | Workflow Agent References：`ref:` 引用 | `AgentEntry` 联合类型, prompt assembly |
+| Phase 3a | done | Event Log 基础设施 | `EventSink`, `DaemonEventLog`, `Logger` |
+| Phase 3b | done | Daemon Registry + Workspace | `Workspace`, `WorkspaceRegistry` |
+| Phase 3c | done | Conversation Model | `ConversationLog`, `ThinThread` |
+| Phase 4 | done | Three-Package Split | `@moniro/agent`, `@moniro/workflow`, `agent-worker` |
+| **Phase 5** | **PR #110** | **Priority Queue + Cooperative Preemption** | `InstructionQueue`, `PreemptionError` |
+| Phase 6 | future | Agent Context in Prompt + Personal Context Tools | recall tools, auto-memory |
+| Phase 7 | future | CLI + Project Config | `moniro.yaml`, improved CLI |
 
-**依赖**: Phase 3c（done）。
+## Phase 5 要点
+
+- 三 lane 优先级队列：`immediate > normal > background`
+- 协作式抢占：LLM step 间检查 `shouldYield()`，高优先级到达时 yield
+- `PreemptionError` throw-to-exit，loop 重新入队 + `InstructionProgress` 恢复上下文
+- `AgentHandle.send()`/`sendMessage()` — 类型化指令路由
+- Scheduled wakeup 直接入队为 `background`，不再写 synthetic channel message
+- 1047 tests pass
 
 ## 已知风险 & 开放问题
 
-- Test splitting: 1014 tests 如何分配到三个包
+- `send` CLI target 解析（DM / @workspace / agent@workspace）— Phase 3b 遗留
 - Personal context schema 是否过于 opinionated（当前判断：作为默认实现 ship，storage 接口允许替代）
-- Skills tool 放 Workflow 还是 Agent（当前判断：Workflow，因为 skill 调用可能需要 workspace 感知）
 
 ## 关键文件
 
 | 文件 | 用途 |
 |------|------|
-| `packages/agent-worker/docs/architecture/PACKAGE-SPLIT.md` | 三包拆分设计（权威） |
+| `packages/agent-worker/docs/architecture/PACKAGE-SPLIT.md` | 三包拆分设计 |
 | `packages/agent-worker/docs/architecture/AGENT-TOP-LEVEL.md` | Agent 顶层实体设计 |
-| `packages/agent-worker/ARCHITECTURE.md` | 模块结构参考 |
+| `packages/workflow/src/loop/priority-queue.ts` | 优先级队列实现 |
+| `packages/workflow/src/loop/sdk-runner.ts` | SDK runner + PreemptionError |
 | `.memory/decisions/` | ADR 记录 |
 | `.memory/todos/index.md` | 活跃任务 |
-| `.memory/notes/` | Session 反思与发现 |

--- a/.memory/todos/index.md
+++ b/.memory/todos/index.md
@@ -6,14 +6,13 @@
 
 | 优先级 | 任务 | 状态 | 备注 |
 |--------|------|------|------|
+| high | Phase 5 PR 合并 (#110) | in-progress | Priority Queue + Cooperative Preemption |
 | medium | `send` CLI target 解析（DM / @workspace / agent@workspace） | todo | Phase 3b 遗留，见 ADR |
 
-## 未来任务（Phase 5+）
+## 未来任务（Phase 6+）
 
 | 优先级 | 任务 | 阶段 | 备注 |
 |--------|------|------|------|
-| high | AgentLoop → priority queue（3 lanes） | Phase 5 | 在 System 层实现 |
-| high | AgentInstruction 类型 + cooperative preemption | Phase 5 | 在 System 层实现 |
 | medium | Personal context tools 实现（memory/notes/todos） | Phase 6 | 在 Agent 层，pluggable storage |
 | medium | Agent context in prompt（recall tools, auto-memory） | Phase 6 | |
 | low | CLI + Project Config（moniro.yaml） | Phase 7 | |
@@ -33,6 +32,7 @@
 | Three-Package Split 设计 | 2026-03-02 | PACKAGE-SPLIT.md |
 | Phase 4: Three-Package Split 实施 | 2026-03-04 | @moniro/agent + @moniro/workflow 提取, 1012 tests |
 | CI 更新: 三包构建顺序 | 2026-03-04 | test.yml, agent-workflow.yml, changeset-agent.yml |
+| Phase 5: Priority Queue + Cooperative Preemption | 2026-03-04 | PR #110, 1047 tests |
 
 ## 使用约定
 

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "@types/bun": "latest",
         "@types/node": ">=22",
         "@typescript/native-preview": "^7.0.0-dev.20260203.1",
+        "ai": "^6.0.69",
         "oxfmt": "^0.28.0",
         "oxlint": "^1.43.0",
         "tsdown": "^0.20.1",
@@ -93,7 +94,7 @@
 
     "@ai-sdk/deepseek": ["@ai-sdk/deepseek@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NiKjvqXI/96e/7SjZGgQH141PBqggsF7fNbjGTv4RgVWayMXp9mj0Ou2NjAUGwwxJwj/qseY0gXiDCYaHWFBkw=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.32", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7clZRr07P9rpur39t1RrbIe7x8jmwnwUWI8tZs+BvAfX3NFgdSVGGIaT7bTz2pb08jmLXzTSDbrOTqAQ7uBkBQ=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.63", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.17", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-0jwdkN3elC4Q9aT2ALxjXtGGVoye15zYgof6GfvuH1a9QKx9Rj4Wi2vy6SyyLvtSA/lB786dTZgC+cGwe6vzmA=="],
 
     "@ai-sdk/google": ["@ai-sdk/google@1.2.22", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw=="],
 
@@ -289,7 +290,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -319,7 +320,7 @@
 
     "agent-worker": ["agent-worker@workspace:packages/agent-worker"],
 
-    "ai": ["ai@6.0.69", "", { "dependencies": { "@ai-sdk/gateway": "3.0.32", "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zIURMSnNroaVvu47Bm3XhC2y3LRsm8jmkwBgupxF+N7q/s6MpIiv04w1ltlnWqC8+T2PT2rN+f0sUhF+vArkwg=="],
+    "ai": ["ai@6.0.111", "", { "dependencies": { "@ai-sdk/gateway": "3.0.63", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-K5aikNm4JGfJkzwIr3yA/qhOYIOIvOqjCxSQjQQ7bWWqm0uuPO2/qgdXL23gYJdTLPPYfvi2TTS+bg2Yp+r2Lw=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -357,7 +358,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -875,6 +876,10 @@
 
     "@ai-sdk/deepseek/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
 
+    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.17", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg=="],
+
     "@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
     "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
@@ -921,11 +926,13 @@
 
     "@quansync/fs/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
+    "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.17", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oyCeFINTYK0B8ZGUBiQc05G5vytPlKSmTTtm19xfJuUgoi8zkvvRcoPQci4mSnyfpPn2XSFFDfsALG8uGcapfg=="],
+
     "argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "bash-tool/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "bun-types/@types/node": ["@types/node@25.2.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w=="],
 
     "compressjs/commander": ["commander@2.8.1", "", { "dependencies": { "graceful-readlink": ">= 1.0.0" } }, "sha512-+pJLBFVk+9ZZdlAOB5WuIElVPPth47hILFkmGym57aq8kwxsowvByvB0DHs1vQAhyMZzdcpTtF0VDKGkSDR4ZQ=="],
 
@@ -952,8 +959,6 @@
     "@ai-sdk/xai/@ai-sdk/provider-utils/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@changesets/parse/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -51,6 +51,7 @@
     "@types/bun": "latest",
     "@types/node": ">=22",
     "@typescript/native-preview": "^7.0.0-dev.20260203.1",
+    "ai": "^6.0.69",
     "oxfmt": "^0.28.0",
     "oxlint": "^1.43.0",
     "tsdown": "^0.20.1"

--- a/packages/agent-worker/src/agent/agent-handle.ts
+++ b/packages/agent-worker/src/agent/agent-handle.ts
@@ -15,7 +15,8 @@ import { join, basename } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import type { AgentDefinition, Logger } from "@moniro/agent";
 import { CONTEXT_SUBDIRS, ConversationLog, ThinThread, DEFAULT_THIN_THREAD_SIZE } from "@moniro/agent";
-import type { AgentLoop } from "@moniro/workflow";
+import type { AgentLoop, AgentInstruction } from "@moniro/workflow";
+import { generateInstructionId } from "@moniro/workflow";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -100,6 +101,41 @@ export class AgentHandle {
         : new ThinThread(maxMessages);
     }
     return this._thinThread;
+  }
+
+  // ── Instruction Routing ─────────────────────────────────────────
+
+  /**
+   * Send a typed instruction to this agent's loop.
+   *
+   * Convenience method that creates an AgentInstruction and enqueues it.
+   * The loop must exist (call ensureAgentLoop first for standalone agents).
+   *
+   * @throws if no loop is attached
+   */
+  send(instruction: AgentInstruction): void {
+    if (!this.loop) {
+      throw new Error(`Agent "${this.name}" has no loop — call ensureAgentLoop first`);
+    }
+    this.loop.enqueue(instruction);
+  }
+
+  /**
+   * Send a simple message with auto-classified priority.
+   *
+   * Shorthand for creating an AgentInstruction from a raw message string.
+   */
+  sendMessage(
+    message: string,
+    options: { priority?: AgentInstruction["priority"]; source?: AgentInstruction["source"] } = {},
+  ): void {
+    this.send({
+      id: generateInstructionId(),
+      message,
+      source: options.source ?? "mention",
+      priority: options.priority ?? "immediate",
+      queuedAt: new Date().toISOString(),
+    });
   }
 
   // ── Context Directory ───────────────────────────────────────────

--- a/packages/agent-worker/src/agent/agent-handle.ts
+++ b/packages/agent-worker/src/agent/agent-handle.ts
@@ -14,7 +14,12 @@ import { mkdirSync, existsSync } from "node:fs";
 import { join, basename } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import type { AgentDefinition, Logger } from "@moniro/agent";
-import { CONTEXT_SUBDIRS, ConversationLog, ThinThread, DEFAULT_THIN_THREAD_SIZE } from "@moniro/agent";
+import {
+  CONTEXT_SUBDIRS,
+  ConversationLog,
+  ThinThread,
+  DEFAULT_THIN_THREAD_SIZE,
+} from "@moniro/agent";
 import type { AgentLoop, AgentInstruction } from "@moniro/workflow";
 import { generateInstructionId } from "@moniro/workflow";
 

--- a/packages/agent-worker/src/cli/commands/send.ts
+++ b/packages/agent-worker/src/cli/commands/send.ts
@@ -2,10 +2,7 @@ import type { Command } from "commander";
 import { mkdirSync } from "node:fs";
 import { outputJson } from "../output.ts";
 import { listAgents, isDaemonActive } from "../client.ts";
-import {
-  createFileContextProvider,
-  getDefaultContextDir,
-} from "@moniro/workflow";
+import { createFileContextProvider, getDefaultContextDir } from "@moniro/workflow";
 import { DEFAULT_WORKFLOW, parseTarget } from "../target.ts";
 
 /**

--- a/packages/agent-worker/src/daemon/registry.ts
+++ b/packages/agent-worker/src/daemon/registry.ts
@@ -17,7 +17,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { BackendType } from "@moniro/agent";
+import type { BackendType, ScheduleConfig } from "@moniro/agent";
 
 export const CONFIG_DIR = join(homedir(), ".agent-worker");
 export const SESSIONS_DIR = join(CONFIG_DIR, "sessions");

--- a/packages/agent-worker/test/unit/agent-definition.test.ts
+++ b/packages/agent-worker/test/unit/agent-definition.test.ts
@@ -509,6 +509,64 @@ describe("AgentHandle", () => {
     const todos = await handle.readTodos();
     expect(todos).toEqual([]);
   });
+
+  // ── Instruction Routing ────────────────────────────────────────
+
+  test("send() throws when no loop attached", () => {
+    expect(() =>
+      handle.send({
+        id: "test-1",
+        message: "hello",
+        source: "mention",
+        priority: "immediate",
+        queuedAt: new Date().toISOString(),
+      }),
+    ).toThrow("has no loop");
+  });
+
+  test("send() delegates to loop.enqueue()", () => {
+    const enqueued: any[] = [];
+    // Attach a mock loop with enqueue
+    handle.loop = {
+      enqueue: (instr: any) => enqueued.push(instr),
+    } as any;
+
+    const instr = {
+      id: "test-2",
+      message: "urgent task",
+      source: "dm" as const,
+      priority: "immediate" as const,
+      queuedAt: new Date().toISOString(),
+    };
+    handle.send(instr);
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]).toBe(instr);
+  });
+
+  test("sendMessage() creates instruction with defaults", () => {
+    const enqueued: any[] = [];
+    handle.loop = {
+      enqueue: (instr: any) => enqueued.push(instr),
+    } as any;
+
+    handle.sendMessage("do this");
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].message).toBe("do this");
+    expect(enqueued[0].priority).toBe("immediate");
+    expect(enqueued[0].source).toBe("mention");
+    expect(enqueued[0].id).toMatch(/^instr_/);
+  });
+
+  test("sendMessage() respects custom priority and source", () => {
+    const enqueued: any[] = [];
+    handle.loop = {
+      enqueue: (instr: any) => enqueued.push(instr),
+    } as any;
+
+    handle.sendMessage("bg task", { priority: "background", source: "schedule" });
+    expect(enqueued[0].priority).toBe("background");
+    expect(enqueued[0].source).toBe("schedule");
+  });
 });
 
 // ── AgentRegistry ─────────────────────────────────────────────────

--- a/packages/agent-worker/test/unit/preemption.test.ts
+++ b/packages/agent-worker/test/unit/preemption.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Preemption Tests
+ *
+ * Tests for cooperative preemption: PreemptionError, shouldYield wiring,
+ * and re-queue with progress in processInstruction.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  InstructionQueue,
+  generateInstructionId,
+  type AgentInstruction,
+  type InstructionProgress,
+  type AgentRunResult,
+} from "@moniro/workflow";
+
+// Import PreemptionError directly from sdk-runner
+// (it's not re-exported from index since it's an internal throw-to-exit mechanism)
+import { PreemptionError } from "../../node_modules/@moniro/workflow/src/loop/sdk-runner.ts";
+
+// ==================== PreemptionError ====================
+
+describe("PreemptionError", () => {
+  test("captures steps completed and work summary", () => {
+    const err = new PreemptionError(3, "Step 1: bash(ls)\nStep 2: bash(cat)");
+    expect(err.name).toBe("PreemptionError");
+    expect(err.stepsCompleted).toBe(3);
+    expect(err.completedWork).toBe("Step 1: bash(ls)\nStep 2: bash(cat)");
+    expect(err.message).toBe("Preempted after 3 steps");
+  });
+
+  test("is instanceof Error", () => {
+    const err = new PreemptionError(1, "work");
+    expect(err instanceof Error).toBe(true);
+    expect(err instanceof PreemptionError).toBe(true);
+  });
+
+  test("zero steps", () => {
+    const err = new PreemptionError(0, "");
+    expect(err.stepsCompleted).toBe(0);
+    expect(err.completedWork).toBe("");
+  });
+});
+
+// ==================== Queue + Preemption Integration ====================
+
+function makeInstruction(
+  priority: AgentInstruction["priority"],
+  message: string = "test",
+  progress?: InstructionProgress,
+): AgentInstruction {
+  return {
+    id: generateInstructionId(),
+    message,
+    source: "mention",
+    priority,
+    queuedAt: new Date().toISOString(),
+    progress,
+  };
+}
+
+describe("Queue preemption support", () => {
+  test("hasHigherPriority enables shouldYield for background instructions", () => {
+    const queue = new InstructionQueue();
+
+    // Background instruction is being processed
+    const bgInstruction = makeInstruction("background", "long task");
+
+    // Simulate: shouldYield = () => queue.hasHigherPriority(bgInstruction.priority)
+    const shouldYield = () => queue.hasHigherPriority(bgInstruction.priority);
+
+    // Initially no higher priority
+    expect(shouldYield()).toBe(false);
+
+    // DM arrives → immediate instruction enqueued
+    queue.enqueue(makeInstruction("immediate", "urgent DM"));
+
+    // Now shouldYield returns true
+    expect(shouldYield()).toBe(true);
+  });
+
+  test("hasHigherPriority: normal instruction not preempted by another normal", () => {
+    const queue = new InstructionQueue();
+    const shouldYield = () => queue.hasHigherPriority("normal");
+
+    queue.enqueue(makeInstruction("normal", "another normal task"));
+    expect(shouldYield()).toBe(false);
+  });
+
+  test("hasHigherPriority: immediate instruction never preempted", () => {
+    const queue = new InstructionQueue();
+    const shouldYield = () => queue.hasHigherPriority("immediate");
+
+    queue.enqueue(makeInstruction("immediate", "another immediate"));
+    expect(shouldYield()).toBe(false);
+  });
+
+  test("re-queue instruction with progress after preemption", () => {
+    const queue = new InstructionQueue();
+
+    // Simulate preemption: background instruction was running, got preempted
+    const original = makeInstruction("background", "long task");
+    const preemptResult: AgentRunResult = {
+      success: true,
+      preempted: true,
+      completedWork: "Step 1: bash(ls)\nStep 2: bash(cat)",
+      duration: 5000,
+      steps: 2,
+    };
+
+    // Re-queue with progress (same logic as loop.ts)
+    const preemptCount = (original.progress?.preemptCount ?? 0) + 1;
+    queue.enqueue({
+      ...original,
+      progress: {
+        resumeFromStep: preemptResult.steps ?? 0,
+        completedWork: preemptResult.completedWork ?? "",
+        preemptCount,
+        queuedAt: original.progress?.queuedAt ?? original.queuedAt,
+      },
+    });
+
+    // Verify the re-queued instruction
+    const requeued = queue.dequeue()!;
+    expect(requeued.message).toBe("long task");
+    expect(requeued.priority).toBe("background");
+    expect(requeued.progress).toBeDefined();
+    expect(requeued.progress!.resumeFromStep).toBe(2);
+    expect(requeued.progress!.completedWork).toBe("Step 1: bash(ls)\nStep 2: bash(cat)");
+    expect(requeued.progress!.preemptCount).toBe(1);
+    expect(requeued.progress!.queuedAt).toBe(original.queuedAt);
+  });
+
+  test("multiple preemptions increment preemptCount", () => {
+    const queue = new InstructionQueue();
+
+    // First preemption
+    const original = makeInstruction("background", "long task");
+    const progress1: InstructionProgress = {
+      resumeFromStep: 2,
+      completedWork: "Step 1-2",
+      preemptCount: 1,
+      queuedAt: original.queuedAt,
+    };
+
+    // Second preemption — instruction already has progress from first
+    const resumed = { ...original, progress: progress1 };
+    const preemptCount2 = (resumed.progress?.preemptCount ?? 0) + 1;
+    queue.enqueue({
+      ...resumed,
+      progress: {
+        resumeFromStep: 5,
+        completedWork: "Step 1-2\nStep 3-5",
+        preemptCount: preemptCount2,
+        queuedAt: resumed.progress?.queuedAt ?? resumed.queuedAt,
+      },
+    });
+
+    const requeued = queue.dequeue()!;
+    expect(requeued.progress!.preemptCount).toBe(2);
+    expect(requeued.progress!.resumeFromStep).toBe(5);
+    // Original queuedAt is preserved through multiple preemptions
+    expect(requeued.progress!.queuedAt).toBe(original.queuedAt);
+  });
+
+  test("preempted instruction resumes at correct priority", () => {
+    const queue = new InstructionQueue();
+
+    // Background instruction preempted, re-queued
+    queue.enqueue(
+      makeInstruction("background", "resumed bg task", {
+        resumeFromStep: 3,
+        completedWork: "steps 1-3",
+        preemptCount: 1,
+        queuedAt: new Date().toISOString(),
+      }),
+    );
+
+    // Normal instruction also queued
+    queue.enqueue(makeInstruction("normal", "normal task"));
+
+    // Normal should be dequeued first (higher priority)
+    expect(queue.dequeue()!.message).toBe("normal task");
+    // Then the resumed background instruction
+    const resumed = queue.dequeue()!;
+    expect(resumed.message).toBe("resumed bg task");
+    expect(resumed.progress!.preemptCount).toBe(1);
+  });
+});
+
+// ==================== AgentRunResult preemption fields ====================
+
+describe("AgentRunResult preemption", () => {
+  test("normal success has no preemption fields", () => {
+    const result: AgentRunResult = {
+      success: true,
+      duration: 1000,
+      steps: 5,
+      toolCalls: 3,
+    };
+    expect(result.preempted).toBeUndefined();
+    expect(result.completedWork).toBeUndefined();
+  });
+
+  test("preempted result has success=true and preemption data", () => {
+    const result: AgentRunResult = {
+      success: true,
+      preempted: true,
+      completedWork: "Step 1: channel_send\nStep 2: bash(git status)",
+      duration: 3000,
+      steps: 2,
+    };
+    expect(result.success).toBe(true);
+    expect(result.preempted).toBe(true);
+    expect(result.completedWork).toContain("channel_send");
+  });
+});

--- a/packages/agent-worker/test/unit/priority-queue.test.ts
+++ b/packages/agent-worker/test/unit/priority-queue.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Priority Queue Tests
+ *
+ * Tests for InstructionQueue, priority classification, and instruction ID generation.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  InstructionQueue,
+  generateInstructionId,
+  classifyInboxPriority,
+  type AgentInstruction,
+  type InstructionPriority,
+} from "@moniro/workflow";
+
+function makeInstruction(
+  priority: InstructionPriority,
+  message: string = "test",
+  source: AgentInstruction["source"] = "mention",
+): AgentInstruction {
+  return {
+    id: generateInstructionId(),
+    message,
+    source,
+    priority,
+    queuedAt: new Date().toISOString(),
+  };
+}
+
+describe("InstructionQueue", () => {
+  test("empty queue returns null on dequeue", () => {
+    const q = new InstructionQueue();
+    expect(q.dequeue()).toBeNull();
+    expect(q.peek()).toBeNull();
+    expect(q.isEmpty).toBe(true);
+    expect(q.size).toBe(0);
+  });
+
+  test("single instruction enqueue and dequeue", () => {
+    const q = new InstructionQueue();
+    const instr = makeInstruction("normal", "hello");
+    q.enqueue(instr);
+    expect(q.size).toBe(1);
+    expect(q.isEmpty).toBe(false);
+    expect(q.dequeue()).toBe(instr);
+    expect(q.isEmpty).toBe(true);
+  });
+
+  test("dequeue returns immediate before normal", () => {
+    const q = new InstructionQueue();
+    const normal = makeInstruction("normal", "normal msg");
+    const immediate = makeInstruction("immediate", "urgent msg");
+
+    q.enqueue(normal);
+    q.enqueue(immediate);
+
+    expect(q.dequeue()!.message).toBe("urgent msg");
+    expect(q.dequeue()!.message).toBe("normal msg");
+  });
+
+  test("dequeue returns normal before background", () => {
+    const q = new InstructionQueue();
+    const bg = makeInstruction("background", "bg msg");
+    const normal = makeInstruction("normal", "normal msg");
+
+    q.enqueue(bg);
+    q.enqueue(normal);
+
+    expect(q.dequeue()!.message).toBe("normal msg");
+    expect(q.dequeue()!.message).toBe("bg msg");
+  });
+
+  test("full priority ordering: immediate > normal > background", () => {
+    const q = new InstructionQueue();
+
+    q.enqueue(makeInstruction("background", "bg"));
+    q.enqueue(makeInstruction("normal", "normal"));
+    q.enqueue(makeInstruction("immediate", "imm"));
+
+    expect(q.dequeue()!.message).toBe("imm");
+    expect(q.dequeue()!.message).toBe("normal");
+    expect(q.dequeue()!.message).toBe("bg");
+    expect(q.dequeue()).toBeNull();
+  });
+
+  test("FIFO within same priority lane", () => {
+    const q = new InstructionQueue();
+
+    q.enqueue(makeInstruction("normal", "first"));
+    q.enqueue(makeInstruction("normal", "second"));
+    q.enqueue(makeInstruction("normal", "third"));
+
+    expect(q.dequeue()!.message).toBe("first");
+    expect(q.dequeue()!.message).toBe("second");
+    expect(q.dequeue()!.message).toBe("third");
+  });
+
+  test("peek does not remove", () => {
+    const q = new InstructionQueue();
+    const instr = makeInstruction("normal", "peek me");
+    q.enqueue(instr);
+
+    expect(q.peek()).toBe(instr);
+    expect(q.size).toBe(1);
+    expect(q.peek()).toBe(instr);
+  });
+
+  test("peek returns highest priority", () => {
+    const q = new InstructionQueue();
+
+    q.enqueue(makeInstruction("background", "bg"));
+    q.enqueue(makeInstruction("immediate", "imm"));
+
+    expect(q.peek()!.message).toBe("imm");
+  });
+
+  test("hasHigherPriority: nothing higher than immediate", () => {
+    const q = new InstructionQueue();
+    q.enqueue(makeInstruction("immediate"));
+    expect(q.hasHigherPriority("immediate")).toBe(false);
+  });
+
+  test("hasHigherPriority: immediate is higher than normal", () => {
+    const q = new InstructionQueue();
+    q.enqueue(makeInstruction("immediate"));
+    expect(q.hasHigherPriority("normal")).toBe(true);
+  });
+
+  test("hasHigherPriority: immediate and normal are higher than background", () => {
+    const q = new InstructionQueue();
+    q.enqueue(makeInstruction("normal"));
+    expect(q.hasHigherPriority("background")).toBe(true);
+  });
+
+  test("hasHigherPriority: empty queue has nothing higher", () => {
+    const q = new InstructionQueue();
+    expect(q.hasHigherPriority("background")).toBe(false);
+    expect(q.hasHigherPriority("normal")).toBe(false);
+    expect(q.hasHigherPriority("immediate")).toBe(false);
+  });
+
+  test("size tracks all lanes", () => {
+    const q = new InstructionQueue();
+    q.enqueue(makeInstruction("immediate"));
+    q.enqueue(makeInstruction("normal"));
+    q.enqueue(makeInstruction("background"));
+    expect(q.size).toBe(3);
+
+    q.dequeue();
+    expect(q.size).toBe(2);
+  });
+
+  test("clear empties all lanes", () => {
+    const q = new InstructionQueue();
+    q.enqueue(makeInstruction("immediate"));
+    q.enqueue(makeInstruction("normal"));
+    q.enqueue(makeInstruction("background"));
+    expect(q.size).toBe(3);
+
+    q.clear();
+    expect(q.size).toBe(0);
+    expect(q.isEmpty).toBe(true);
+    expect(q.dequeue()).toBeNull();
+  });
+
+  test("interleaved enqueue/dequeue respects priority", () => {
+    const q = new InstructionQueue();
+
+    q.enqueue(makeInstruction("normal", "n1"));
+    q.enqueue(makeInstruction("background", "b1"));
+    expect(q.dequeue()!.message).toBe("n1");
+
+    // Add immediate while background is still queued
+    q.enqueue(makeInstruction("immediate", "i1"));
+    expect(q.dequeue()!.message).toBe("i1");
+    expect(q.dequeue()!.message).toBe("b1");
+  });
+});
+
+describe("generateInstructionId", () => {
+  test("generates unique IDs", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateInstructionId());
+    }
+    expect(ids.size).toBe(100);
+  });
+
+  test("IDs start with instr_ prefix", () => {
+    const id = generateInstructionId();
+    expect(id.startsWith("instr_")).toBe(true);
+  });
+});
+
+describe("classifyInboxPriority", () => {
+  test("DMs are always immediate", () => {
+    expect(classifyInboxPriority("normal", true)).toBe("immediate");
+    expect(classifyInboxPriority("high", true)).toBe("immediate");
+  });
+
+  test("high inbox priority maps to immediate", () => {
+    expect(classifyInboxPriority("high", false)).toBe("immediate");
+  });
+
+  test("normal inbox priority maps to normal", () => {
+    expect(classifyInboxPriority("normal", false)).toBe("normal");
+  });
+});

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -57,7 +57,13 @@ export type { CronFields } from "./cron.ts";
 export { createBackend, checkBackends, listBackends } from "./backends/index.ts";
 export type { Backend, BackendType, BackendConfig, BackendResponse } from "./backends/types.ts";
 export type { BackendOptions } from "./backends/index.ts";
-export { parseModel, normalizeBackendType, getModelForBackend, resolveModelAlias, BACKEND_DEFAULT_MODELS } from "./backends/model-maps.ts";
+export {
+  parseModel,
+  normalizeBackendType,
+  getModelForBackend,
+  resolveModelAlias,
+  BACKEND_DEFAULT_MODELS,
+} from "./backends/model-maps.ts";
 export { SdkBackend } from "./backends/sdk.ts";
 export type { SdkBackendOptions } from "./backends/sdk.ts";
 export { ClaudeCodeBackend } from "./backends/claude-code.ts";

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -58,11 +58,18 @@ export type {
   AgentLoop,
   AgentLoopConfig,
   AgentState,
+  AgentInstruction,
+  InstructionPriority,
+  InstructionSource,
+  InstructionProgress,
   AgentRunContext,
   AgentRunResult,
   WorkflowIdleState,
 } from "./loop/types.ts";
 export { LOOP_DEFAULTS } from "./loop/types.ts";
+
+// ── Priority Queue ─────────────────────────────────────────────
+export { InstructionQueue, generateInstructionId, classifyInboxPriority } from "./loop/priority-queue.ts";
 
 // ── Prompt ──────────────────────────────────────────────────────
 export {

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -15,11 +15,7 @@ export {
 } from "./factory.ts";
 
 // ── Runner ──────────────────────────────────────────────────────
-export {
-  runWorkflow,
-  runWorkflowWithLoops,
-  shutdownLoops,
-} from "./runner.ts";
+export { runWorkflow, runWorkflowWithLoops, shutdownLoops } from "./runner.ts";
 
 // ── Parser ──────────────────────────────────────────────────────
 export {
@@ -53,7 +49,12 @@ export type {
 export { isRefAgentEntry } from "./types.ts";
 
 // ── Loop ────────────────────────────────────────────────────────
-export { createAgentLoop, checkWorkflowIdle, isWorkflowComplete, buildWorkflowIdleState } from "./loop/loop.ts";
+export {
+  createAgentLoop,
+  checkWorkflowIdle,
+  isWorkflowComplete,
+  buildWorkflowIdleState,
+} from "./loop/loop.ts";
 export type {
   AgentLoop,
   AgentLoopConfig,
@@ -69,7 +70,11 @@ export type {
 export { LOOP_DEFAULTS } from "./loop/types.ts";
 
 // ── Priority Queue ─────────────────────────────────────────────
-export { InstructionQueue, generateInstructionId, classifyInboxPriority } from "./loop/priority-queue.ts";
+export {
+  InstructionQueue,
+  generateInstructionId,
+  classifyInboxPriority,
+} from "./loop/priority-queue.ts";
 
 // ── Prompt ──────────────────────────────────────────────────────
 export {
@@ -86,11 +91,7 @@ export {
 export { getBackendByType, getBackendForModel } from "./loop/backend.ts";
 
 // ── Send ────────────────────────────────────────────────────────
-export {
-  parseSendTarget,
-  formatUserSender,
-  sendToWorkflowChannel,
-} from "./loop/send.ts";
+export { parseSendTarget, formatUserSender, sendToWorkflowChannel } from "./loop/send.ts";
 export type { SendTargetType, ParsedSendTarget, SendResult } from "./loop/send.ts";
 
 // ── Mock runner ─────────────────────────────────────────────────
@@ -145,14 +146,17 @@ export type {
 } from "./context/stores/index.ts";
 
 // ── Context MCP Server ──────────────────────────────────────────
-export {
-  createContextMCPServer,
-  type ContextMCPServerOptions,
-} from "./context/mcp/server.ts";
+export { createContextMCPServer, type ContextMCPServerOptions } from "./context/mcp/server.ts";
 export { runWithHttp, type HttpMCPServer } from "./context/http-transport.ts";
 
 // ── Proposals ───────────────────────────────────────────────────
-export { ProposalManager, createProposalManager, PROPOSAL_DEFAULTS, formatProposal, formatProposalList } from "./context/proposals.ts";
+export {
+  ProposalManager,
+  createProposalManager,
+  PROPOSAL_DEFAULTS,
+  formatProposal,
+  formatProposalList,
+} from "./context/proposals.ts";
 export type { ProposalManagerOptions, Proposal } from "./context/proposals.ts";
 
 // ── Event Log ───────────────────────────────────────────────────
@@ -175,7 +179,13 @@ export type { PrettyDisplayConfig, PrettyDisplayWatcher } from "./display-pretty
 export { WorkflowFileSchema } from "./schema.ts";
 
 // ── Interpolation ───────────────────────────────────────────────
-export { interpolate, hasVariables, extractVariables, createContext, evaluateCondition } from "./interpolate.ts";
+export {
+  interpolate,
+  hasVariables,
+  extractVariables,
+  createContext,
+  evaluateCondition,
+} from "./interpolate.ts";
 export type { VariableContext } from "./interpolate.ts";
 
 // ── Source ──────────────────────────────────────────────────────
@@ -204,8 +214,4 @@ export {
 } from "./tools/bash.ts";
 export type { BashToolkit, BashToolsOptions, CreateBashToolOptions } from "./tools/bash.ts";
 export { createFeedbackTool, FEEDBACK_PROMPT } from "./tools/feedback.ts";
-export type {
-  FeedbackEntry,
-  FeedbackToolOptions,
-  FeedbackToolResult,
-} from "./tools/feedback.ts";
+export type { FeedbackEntry, FeedbackToolOptions, FeedbackToolResult } from "./tools/feedback.ts";

--- a/packages/workflow/src/logger.ts
+++ b/packages/workflow/src/logger.ts
@@ -11,7 +11,7 @@
 
 import type { ContextProvider } from "./context/provider.ts";
 import type { EventSink } from "./context/stores/timeline.ts";
-import { formatArg, type LogLevel } from "@moniro/agent";
+import { formatArg, type LogLevel, type Logger } from "@moniro/agent";
 
 // Re-export from canonical source (@moniro/agent)
 export { createSilentLogger, formatArg, type Logger, type LogLevel } from "@moniro/agent";

--- a/packages/workflow/src/logger.ts
+++ b/packages/workflow/src/logger.ts
@@ -115,4 +115,3 @@ export function createConsoleSink(): EventSink {
     },
   };
 }
-

--- a/packages/workflow/src/loop/loop.ts
+++ b/packages/workflow/src/loop/loop.ts
@@ -19,7 +19,11 @@ import type {
   WorkflowIdleState,
 } from "./types.ts";
 import { LOOP_DEFAULTS } from "./types.ts";
-import { InstructionQueue, generateInstructionId, classifyInboxPriority } from "./priority-queue.ts";
+import {
+  InstructionQueue,
+  generateInstructionId,
+  classifyInboxPriority,
+} from "./priority-queue.ts";
 import { buildAgentPrompt } from "./prompt.ts";
 import { generateWorkflowMCPConfig } from "./mcp-config.ts";
 import { resolveSchedule, msUntilNextCron } from "@moniro/agent";
@@ -153,7 +157,9 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
     // Log inbox summary (always visible) and details (debug only)
     if (inbox.length > 0) {
       const senders = inbox.map((m) => m.entry.from);
-      infoLog(`Inbox: ${inbox.length} message(s) from [${senders.join(", ")}] [${instruction.priority}]`);
+      infoLog(
+        `Inbox: ${inbox.length} message(s) from [${senders.join(", ")}] [${instruction.priority}]`,
+      );
       for (const msg of inbox) {
         const preview =
           msg.entry.content.length > 120

--- a/packages/workflow/src/loop/loop.ts
+++ b/packages/workflow/src/loop/loop.ts
@@ -13,15 +13,18 @@ import type {
   AgentLoop,
   AgentLoopConfig,
   AgentState,
+  AgentInstruction,
   AgentRunContext,
   AgentRunResult,
   WorkflowIdleState,
 } from "./types.ts";
 import { LOOP_DEFAULTS } from "./types.ts";
+import { InstructionQueue, generateInstructionId, classifyInboxPriority } from "./priority-queue.ts";
 import { buildAgentPrompt } from "./prompt.ts";
 import { generateWorkflowMCPConfig } from "./mcp-config.ts";
 import { resolveSchedule, msUntilNextCron } from "@moniro/agent";
 import type { ScheduleConfig, ConversationMessage } from "@moniro/agent";
+import type { InboxMessage } from "../context/types.ts";
 
 /** Check if loop should continue running */
 function shouldContinue(state: AgentState): boolean {
@@ -74,6 +77,9 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
   let _hasFailures = false;
   let _lastError: string | undefined;
 
+  // Priority queue: three lanes (immediate > normal > background)
+  const queue = new InstructionQueue();
+
   // Schedule support: resolve agent's wakeup config into a typed schedule.
   // Validate eagerly so invalid cron expressions fail at creation, not at runtime.
   const scheduleConfig: ScheduleConfig | undefined = agent.schedule;
@@ -102,10 +108,192 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
   }
 
   /**
-   * Main poll loop
+   * Convert inbox messages to instructions and enqueue them by priority.
+   */
+  function enqueueInbox(inbox: InboxMessage[]): void {
+    // Group all inbox messages into a single instruction.
+    // The agent processes the full batch — priority determines ordering
+    // relative to other instructions (e.g., externally enqueued ones).
+    if (inbox.length === 0) return;
+
+    // Classify priority: highest priority message wins for the batch
+    let batchPriority: "immediate" | "normal" | "background" = "background";
+    for (const msg of inbox) {
+      const isDm = !!msg.entry.to;
+      const instrPriority = classifyInboxPriority(msg.priority, isDm);
+      if (instrPriority === "immediate") {
+        batchPriority = "immediate";
+        break;
+      }
+      if (instrPriority === "normal") {
+        batchPriority = "normal";
+      }
+    }
+
+    // Determine source from first message
+    const first = inbox[0]!;
+    const source = first.entry.to ? "dm" : "mention";
+
+    queue.enqueue({
+      id: generateInstructionId(),
+      message: inbox.map((m) => m.entry.content).join("\n"),
+      source,
+      priority: batchPriority,
+      queuedAt: new Date().toISOString(),
+      inboxMessages: inbox,
+    } satisfies AgentInstruction);
+  }
+
+  /**
+   * Process a single instruction: run agent with retry logic.
+   */
+  async function processInstruction(instruction: AgentInstruction): Promise<void> {
+    const inbox = instruction.inboxMessages ?? [];
+
+    // Log inbox summary (always visible) and details (debug only)
+    if (inbox.length > 0) {
+      const senders = inbox.map((m) => m.entry.from);
+      infoLog(`Inbox: ${inbox.length} message(s) from [${senders.join(", ")}] [${instruction.priority}]`);
+      for (const msg of inbox) {
+        const preview =
+          msg.entry.content.length > 120
+            ? msg.entry.content.slice(0, 120) + "..."
+            : msg.entry.content;
+        log(`  from @${msg.entry.from}: ${preview}`);
+      }
+    } else {
+      infoLog(`Processing instruction [${instruction.priority}/${instruction.source}]`);
+    }
+
+    // Get latest message ID for acknowledgment
+    const latestId = inbox.length > 0 ? inbox[inbox.length - 1]!.entry.id : undefined;
+
+    // Mark inbox as seen (loop picked it up, now processing)
+    if (latestId) {
+      await contextProvider.markInboxSeen(name, latestId);
+    }
+
+    // Run agent with retry
+    let attempt = 0;
+    let lastResult: AgentRunResult | null = null;
+
+    while (attempt < retryConfig.maxAttempts && shouldContinue(state)) {
+      attempt++;
+      state = "running";
+
+      // Update status to running
+      await contextProvider.setAgentStatus(name, { state: "running" });
+
+      infoLog(`Running (attempt ${attempt}/${retryConfig.maxAttempts})`);
+
+      // Build run context
+      const runContext: AgentRunContext = {
+        name,
+        agent,
+        inbox,
+        recentChannel: await contextProvider.readChannel({
+          limit: LOOP_DEFAULTS.recentChannelLimit,
+          agent: name,
+        }),
+        documentContent: await contextProvider.readDocument(),
+        mcpUrl,
+        workspaceDir,
+        projectDir,
+        retryAttempt: attempt,
+        provider: contextProvider,
+        eventLog,
+        feedback,
+        // Cooperative preemption: yield if higher-priority instruction arrives
+        shouldYield: () => queue.hasHigherPriority(instruction.priority),
+        // Resume from previous progress if this instruction was preempted before
+        resumeProgress: instruction.progress,
+      };
+
+      // Orchestrate: build prompt → configure workspace → send
+      lastResult = await runAgent(backend, runContext, log, infoLog);
+
+      // Handle preemption: re-queue with progress, break to process higher-priority
+      if (lastResult.preempted) {
+        const preemptCount = (instruction.progress?.preemptCount ?? 0) + 1;
+        infoLog(`Preempted after ${lastResult.steps ?? 0} steps (count: ${preemptCount})`);
+        queue.enqueue({
+          ...instruction,
+          progress: {
+            resumeFromStep: lastResult.steps ?? 0,
+            completedWork: lastResult.completedWork ?? "",
+            preemptCount,
+            queuedAt: instruction.progress?.queuedAt ?? instruction.queuedAt,
+          },
+        });
+        // Don't ack inbox — instruction will be resumed
+        break;
+      }
+
+      if (lastResult.success) {
+        const detail = lastResult.steps
+          ? `${lastResult.steps} steps, ${lastResult.toolCalls} tool calls, ${lastResult.duration}ms`
+          : `${lastResult.duration}ms`;
+        infoLog(`DONE ${detail}`);
+
+        // Write agent's final response to channel (so it's visible to user)
+        if (lastResult.content) {
+          await contextProvider.appendChannel(name, lastResult.content);
+        }
+
+        // Acknowledge inbox on success
+        if (latestId) {
+          await contextProvider.ackInbox(name, latestId);
+        }
+
+        // Reset schedule timer on activity
+        lastActivityTime = Date.now();
+
+        // Update status to idle after successful completion
+        await contextProvider.setAgentStatus(name, { state: "idle" });
+
+        break;
+      }
+
+      errorLog(`ERROR ${lastResult.error}`);
+
+      // Retry with backoff (unless last attempt)
+      if (attempt < retryConfig.maxAttempts && shouldContinue(state)) {
+        const delay = retryConfig.backoffMs * Math.pow(retryConfig.backoffMultiplier, attempt - 1);
+        log(`Retrying in ${delay}ms...`);
+        await sleep(delay);
+      }
+    }
+
+    // If all retries exhausted, still acknowledge to prevent infinite loop
+    if (lastResult && !lastResult.success) {
+      _hasFailures = true;
+      _lastError = lastResult.error;
+      errorLog(`ERROR max retries exhausted, acknowledging to prevent loop`);
+      if (latestId) {
+        await contextProvider.ackInbox(name, latestId);
+      }
+    }
+
+    // Notify completion
+    if (lastResult && onRunComplete) {
+      onRunComplete(lastResult);
+    }
+  }
+
+  /**
+   * Main poll loop — polls inbox, classifies into instructions, processes by priority.
    */
   async function runLoop(): Promise<void> {
     while (shouldContinue(state)) {
+      // Process any queued instructions first (from external enqueue())
+      if (!queue.isEmpty && !directRunning) {
+        const instruction = queue.dequeue()!;
+        await processInstruction(instruction);
+        state = "idle";
+        await contextProvider.setAgentStatus(name, { state: "idle" });
+        continue;
+      }
+
       // Wait for poll interval or wake
       await waitForWakeOrPoll();
 
@@ -114,6 +302,9 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
 
       // Skip if a sendDirect call is in progress
       if (directRunning) continue;
+
+      // Check externally enqueued instructions first
+      if (!queue.isEmpty) continue;
 
       // Check inbox
       const inbox = await contextProvider.getInbox(name);
@@ -143,9 +334,16 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
             const wakeupPrompt =
               resolvedSchedule.prompt ?? "Scheduled wakeup. Check for any pending work or updates.";
             log(`Schedule wakeup triggered for ${name}`);
-            await contextProvider.appendChannel("system", `@${name} ${wakeupPrompt}`);
+            // Enqueue directly as background priority (skip synthetic channel message)
+            queue.enqueue({
+              id: generateInstructionId(),
+              message: wakeupPrompt,
+              source: "schedule",
+              priority: "background",
+              queuedAt: new Date().toISOString(),
+            });
             lastActivityTime = now;
-            // Re-check inbox — the wakeup message should now be there
+            // Process the queued instruction on next iteration
             continue;
           }
         }
@@ -156,104 +354,12 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
         continue;
       }
 
-      // Log inbox summary (always visible) and details (debug only)
-      const senders = inbox.map((m) => m.entry.from);
-      infoLog(`Inbox: ${inbox.length} message(s) from [${senders.join(", ")}]`);
-      for (const msg of inbox) {
-        const preview =
-          msg.entry.content.length > 120
-            ? msg.entry.content.slice(0, 120) + "..."
-            : msg.entry.content;
-        log(`  from @${msg.entry.from}: ${preview}`);
-      }
+      // Classify inbox messages into instructions and enqueue
+      enqueueInbox(inbox);
 
-      // Get latest message ID for acknowledgment
-      const latestId = inbox[inbox.length - 1]!.entry.id;
-
-      // Mark inbox as seen (loop picked it up, now processing)
-      await contextProvider.markInboxSeen(name, latestId);
-
-      // Run agent with retry
-      let attempt = 0;
-      let lastResult: AgentRunResult | null = null;
-
-      while (attempt < retryConfig.maxAttempts && shouldContinue(state)) {
-        attempt++;
-        state = "running";
-
-        // Update status to running
-        await contextProvider.setAgentStatus(name, { state: "running" });
-
-        infoLog(`Running (attempt ${attempt}/${retryConfig.maxAttempts})`);
-
-        // Build run context
-        const runContext: AgentRunContext = {
-          name,
-          agent,
-          inbox,
-          recentChannel: await contextProvider.readChannel({
-            limit: LOOP_DEFAULTS.recentChannelLimit,
-            agent: name,
-          }),
-          documentContent: await contextProvider.readDocument(),
-          mcpUrl,
-          workspaceDir,
-          projectDir,
-          retryAttempt: attempt,
-          provider: contextProvider,
-          eventLog,
-          feedback,
-        };
-
-        // Orchestrate: build prompt → configure workspace → send
-        lastResult = await runAgent(backend, runContext, log, infoLog);
-
-        if (lastResult.success) {
-          const detail = lastResult.steps
-            ? `${lastResult.steps} steps, ${lastResult.toolCalls} tool calls, ${lastResult.duration}ms`
-            : `${lastResult.duration}ms`;
-          infoLog(`DONE ${detail}`);
-
-          // Write agent's final response to channel (so it's visible to user)
-          if (lastResult.content) {
-            await contextProvider.appendChannel(name, lastResult.content);
-          }
-
-          // Acknowledge inbox on success
-          await contextProvider.ackInbox(name, latestId);
-
-          // Reset schedule timer on activity
-          lastActivityTime = Date.now();
-
-          // Update status to idle after successful completion
-          await contextProvider.setAgentStatus(name, { state: "idle" });
-
-          break;
-        }
-
-        errorLog(`ERROR ${lastResult.error}`);
-
-        // Retry with backoff (unless last attempt)
-        if (attempt < retryConfig.maxAttempts && shouldContinue(state)) {
-          const delay =
-            retryConfig.backoffMs * Math.pow(retryConfig.backoffMultiplier, attempt - 1);
-          log(`Retrying in ${delay}ms...`);
-          await sleep(delay);
-        }
-      }
-
-      // If all retries exhausted, still acknowledge to prevent infinite loop
-      if (lastResult && !lastResult.success) {
-        _hasFailures = true;
-        _lastError = lastResult.error;
-        errorLog(`ERROR max retries exhausted, acknowledging to prevent loop`);
-        await contextProvider.ackInbox(name, latestId);
-      }
-
-      // Notify completion
-      if (lastResult && onRunComplete) {
-        onRunComplete(lastResult);
-      }
+      // Process the highest-priority instruction
+      const instruction = queue.dequeue()!;
+      await processInstruction(instruction);
 
       state = "idle";
       // Update status after completing work
@@ -343,6 +449,13 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
         wakeResolver();
         wakeResolver = null;
       }
+    },
+
+    enqueue(instruction: AgentInstruction) {
+      queue.enqueue(instruction);
+      log(`Enqueued instruction [${instruction.priority}/${instruction.source}]`);
+      // Wake the poll loop so it processes the instruction immediately
+      this.wake();
     },
 
     async sendDirect(message: string): Promise<AgentRunResult> {

--- a/packages/workflow/src/loop/mock-runner.ts
+++ b/packages/workflow/src/loop/mock-runner.ts
@@ -16,6 +16,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { AgentRunContext, AgentRunResult } from "./types.ts";
 import { buildAgentPrompt } from "./prompt.ts";
 import { createTool } from "@moniro/agent";
+import { PreemptionError } from "./sdk-runner.ts";
 
 // ==================== MCP Tool Bridge ====================
 
@@ -121,8 +122,14 @@ export async function runMockAgent(
     });
 
     // 3. Build prompt and run
-    const prompt = buildAgentPrompt(ctx);
+    let prompt = buildAgentPrompt(ctx);
+    if (ctx.resumeProgress?.completedWork) {
+      prompt += `\n\n## Resume Context\nYou were preempted after completing ${ctx.resumeProgress.resumeFromStep} steps. Here's what you already did:\n${ctx.resumeProgress.completedWork}\n\nContinue from where you left off.`;
+    }
     log(`Prompt (${prompt.length} chars)`);
+
+    let _stepNum = 0;
+    const stepLog: string[] = [];
 
     const result = await generateText({
       model: mockModel,
@@ -130,7 +137,20 @@ export async function runMockAgent(
       prompt,
       system: ctx.agent.resolvedSystemPrompt,
       stopWhen: stepCountIs(3),
-      // Tool calls are logged by MCP server with tool_call type
+      onStepFinish: (step) => {
+        _stepNum++;
+        if (step.toolCalls?.length) {
+          for (const tc of step.toolCalls) {
+            stepLog.push(`Step ${_stepNum}: ${tc.toolName}(...)`);
+          }
+        }
+
+        // Cooperative preemption
+        if (ctx.shouldYield?.()) {
+          log(`Yielding after step ${_stepNum}`);
+          throw new PreemptionError(_stepNum, stepLog.join("\n"));
+        }
+      },
     });
 
     const totalToolCalls = result.steps.reduce((n, s) => n + s.toolCalls.length, 0);
@@ -143,6 +163,15 @@ export async function runMockAgent(
       toolCalls: totalToolCalls,
     };
   } catch (error) {
+    if (error instanceof PreemptionError) {
+      return {
+        success: true,
+        preempted: true,
+        completedWork: error.completedWork,
+        duration: Date.now() - startTime,
+        steps: error.stepsCompleted,
+      };
+    }
     const errorMsg = error instanceof Error ? error.message : String(error);
     return { success: false, error: errorMsg, duration: Date.now() - startTime };
   }

--- a/packages/workflow/src/loop/priority-queue.ts
+++ b/packages/workflow/src/loop/priority-queue.ts
@@ -1,0 +1,91 @@
+/**
+ * Three-lane priority queue for AgentInstructions.
+ *
+ * Lanes are processed in order: immediate > normal > background.
+ * Within each lane, FIFO order is preserved.
+ */
+
+import type { AgentInstruction, InstructionPriority } from "./types.ts";
+
+/** Priority order — lower index = higher priority */
+const PRIORITY_ORDER: InstructionPriority[] = ["immediate", "normal", "background"];
+
+export class InstructionQueue {
+  private lanes: Record<InstructionPriority, AgentInstruction[]> = {
+    immediate: [],
+    normal: [],
+    background: [],
+  };
+
+  /** Add an instruction to the appropriate lane */
+  enqueue(instruction: AgentInstruction): void {
+    this.lanes[instruction.priority].push(instruction);
+  }
+
+  /** Remove and return the highest-priority instruction, or null if empty */
+  dequeue(): AgentInstruction | null {
+    for (const priority of PRIORITY_ORDER) {
+      const lane = this.lanes[priority];
+      if (lane.length > 0) {
+        return lane.shift()!;
+      }
+    }
+    return null;
+  }
+
+  /** Peek at the highest-priority instruction without removing it */
+  peek(): AgentInstruction | null {
+    for (const priority of PRIORITY_ORDER) {
+      const lane = this.lanes[priority];
+      if (lane.length > 0) {
+        return lane[0]!;
+      }
+    }
+    return null;
+  }
+
+  /** Check if queue has an instruction with higher priority than the given level */
+  hasHigherPriority(than: InstructionPriority): boolean {
+    const thanIndex = PRIORITY_ORDER.indexOf(than);
+    for (let i = 0; i < thanIndex; i++) {
+      if (this.lanes[PRIORITY_ORDER[i]!]!.length > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Total number of queued instructions */
+  get size(): number {
+    return this.lanes.immediate.length + this.lanes.normal.length + this.lanes.background.length;
+  }
+
+  /** Whether the queue is empty */
+  get isEmpty(): boolean {
+    return this.size === 0;
+  }
+
+  /** Clear all lanes */
+  clear(): void {
+    this.lanes.immediate = [];
+    this.lanes.normal = [];
+    this.lanes.background = [];
+  }
+}
+
+/** Generate a unique instruction ID */
+export function generateInstructionId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 8);
+  return `instr_${timestamp}${random}`;
+}
+
+/** Map inbox priority ("normal" | "high") to instruction priority */
+export function classifyInboxPriority(
+  inboxPriority: "normal" | "high",
+  isDm: boolean,
+): InstructionPriority {
+  if (isDm) return "immediate";
+  if (inboxPriority === "high") return "immediate";
+  return "normal";
+}

--- a/packages/workflow/src/loop/sdk-runner.ts
+++ b/packages/workflow/src/loop/sdk-runner.ts
@@ -104,6 +104,32 @@ function createBashTool() {
   });
 }
 
+// ==================== Preemption ====================
+
+/**
+ * Error thrown when an agent is preempted by a higher-priority instruction.
+ * Not a real error — signals that the agent should yield and resume later.
+ */
+export class PreemptionError extends Error {
+  /** Number of steps completed before preemption */
+  readonly stepsCompleted: number;
+  /** Summary of completed work */
+  readonly completedWork: string;
+
+  constructor(stepsCompleted: number, completedWork: string) {
+    super(`Preempted after ${stepsCompleted} steps`);
+    this.name = "PreemptionError";
+    this.stepsCompleted = stepsCompleted;
+    this.completedWork = completedWork;
+  }
+}
+
+/** Summarize completed steps for resume context */
+function summarizeSteps(stepLog: string[]): string {
+  if (stepLog.length === 0) return "";
+  return stepLog.join("\n");
+}
+
 // ==================== SDK Agent Runner ====================
 
 /**
@@ -114,6 +140,9 @@ function createBashTool() {
  * 1. Connects to MCP server for context tools (channel, document)
  * 2. Adds bash tool for shell access
  * 3. Runs generateText with full tool loop
+ *
+ * Supports cooperative preemption: between LLM steps, checks ctx.shouldYield()
+ * and throws PreemptionError if a higher-priority instruction is waiting.
  */
 export async function runSdkAgent(
   ctx: AgentRunContext,
@@ -137,11 +166,17 @@ export async function runSdkAgent(
     // 3. Assemble tools: MCP context + bash
     const tools = { ...mcp.tools, bash: createBashTool() };
 
-    // 4. Build prompt and run
-    const prompt = buildAgentPrompt(ctx);
+    // 4. Build prompt (with resume context if resuming)
+    let prompt = buildAgentPrompt(ctx);
+    if (ctx.resumeProgress?.completedWork) {
+      prompt += `\n\n## Resume Context\nYou were preempted after completing ${ctx.resumeProgress.resumeFromStep} steps. Here's what you already did:\n${ctx.resumeProgress.completedWork}\n\nContinue from where you left off.`;
+    }
     log(`Prompt (${prompt.length} chars) → sdk with ${Object.keys(tools).length} tools`);
 
+    // 5. Track steps for preemption
     let _stepNum = 0;
+    const stepLog: string[] = [];
+
     const result = await generateText({
       model,
       tools,
@@ -152,13 +187,23 @@ export async function runSdkAgent(
       stopWhen: stepCountIs(ctx.agent.max_steps ?? 200),
       onStepFinish: (step) => {
         _stepNum++;
-        if (step.toolCalls?.length && ctx.eventLog) {
+
+        // Log tool calls
+        if (step.toolCalls?.length) {
           for (const tc of step.toolCalls) {
-            // Only log non-MCP tools (like bash) — MCP tools are logged by MCP server
-            if (tc.toolName === "bash") {
+            stepLog.push(`Step ${_stepNum}: ${formatToolCall(tc)}`);
+            if (ctx.eventLog && tc.toolName === "bash") {
               ctx.eventLog.toolCall(ctx.name, tc.toolName, formatToolCall(tc), "sdk");
             }
           }
+        } else if (step.text) {
+          stepLog.push(`Step ${_stepNum}: (text output)`);
+        }
+
+        // Cooperative preemption: check if higher-priority work is waiting
+        if (ctx.shouldYield?.()) {
+          log(`Yielding after step ${_stepNum} (higher-priority instruction waiting)`);
+          throw new PreemptionError(_stepNum, summarizeSteps(stepLog));
         }
       },
     });
@@ -187,6 +232,16 @@ export async function runSdkAgent(
       toolCalls: totalToolCalls,
     };
   } catch (error) {
+    // Preemption is not a failure — return partial result
+    if (error instanceof PreemptionError) {
+      return {
+        success: true,
+        preempted: true,
+        completedWork: error.completedWork,
+        duration: Date.now() - startTime,
+        steps: error.stepsCompleted,
+      };
+    }
     const errorMsg = formatError(error);
     return { success: false, error: errorMsg, duration: Date.now() - startTime };
   }

--- a/packages/workflow/src/loop/types.ts
+++ b/packages/workflow/src/loop/types.ts
@@ -51,6 +51,16 @@ export interface AgentLoop {
    * a logical lock so the two paths don't race.
    */
   sendDirect(message: string): Promise<AgentRunResult>;
+
+  /**
+   * Enqueue an instruction for priority-based processing.
+   *
+   * Instructions are processed in priority order: immediate > normal > background.
+   * Within the same priority lane, FIFO order is preserved.
+   *
+   * If the loop is idle, it will be woken immediately.
+   */
+  enqueue(instruction: AgentInstruction): void;
 }
 
 /** Retry configuration */
@@ -131,6 +141,10 @@ export interface AgentRunContext {
   feedback?: boolean;
   /** Recent conversation messages (thin thread for continuity) */
   thinThread?: ConversationMessage[];
+  /** Check if a higher-priority instruction is waiting (for cooperative preemption) */
+  shouldYield?: () => boolean;
+  /** Previous progress to resume from (if this is a resumed instruction) */
+  resumeProgress?: InstructionProgress;
 }
 
 /** Result of an agent run */
@@ -147,6 +161,51 @@ export interface AgentRunResult {
   steps?: number;
   /** Number of tool calls (SDK/mock backends) */
   toolCalls?: number;
+  /** Whether the run was preempted (yielded to higher-priority instruction) */
+  preempted?: boolean;
+  /** Summary of completed work before preemption */
+  completedWork?: string;
+}
+
+// ==================== Priority Queue ====================
+
+/** Instruction priority — modeled after React Fiber lanes */
+export type InstructionPriority =
+  | "immediate" // DM, @mention — process next
+  | "normal" // workspace direct send — FIFO within lane
+  | "background"; // non-@ channel, scheduled wakeup — yield to higher
+
+/** Source of an instruction */
+export type InstructionSource = "dm" | "mention" | "channel" | "schedule" | "workspace";
+
+/** Instruction delivered to an agent's loop */
+export interface AgentInstruction {
+  /** Unique instruction ID */
+  id: string;
+  /** The message content */
+  message: string;
+  /** Source of the instruction */
+  source: InstructionSource;
+  /** Processing priority */
+  priority: InstructionPriority;
+  /** ISO timestamp when queued */
+  queuedAt: string;
+  /** Associated inbox messages (for ack tracking) */
+  inboxMessages?: InboxMessage[];
+  /** Progress marker for resumed instructions (after preemption yield) */
+  progress?: InstructionProgress;
+}
+
+/** Saved progress for a yielded instruction */
+export interface InstructionProgress {
+  /** Step number to resume from */
+  resumeFromStep: number;
+  /** Summary of completed work (text representation of previous steps) */
+  completedWork: string;
+  /** How many times this instruction has been preempted */
+  preemptCount: number;
+  /** When this instruction was first queued */
+  queuedAt: string;
 }
 
 // ==================== Idle Detection ====================

--- a/packages/workflow/src/parser.ts
+++ b/packages/workflow/src/parser.ts
@@ -216,7 +216,10 @@ async function resolveInlineAgent(
  * Resolve a ref agent entry — load from AgentRegistry, map to WorkflowAgentDef,
  * apply workflow overrides (prompt.append, max_tokens, max_steps).
  */
-function resolveRefAgent(entry: RefAgentEntry, registry?: AgentRegistryLike): ResolvedWorkflowAgent {
+function resolveRefAgent(
+  entry: RefAgentEntry,
+  registry?: AgentRegistryLike,
+): ResolvedWorkflowAgent {
   if (!registry) {
     throw new Error(
       `Agent ref "${entry.ref}" requires an AgentRegistry. ` +


### PR DESCRIPTION
## Summary

- Three-lane priority queue (`immediate > normal > background`) replaces FIFO inbox processing in the agent loop
- Cooperative preemption: agents yield between LLM steps when higher-priority instructions arrive, preserving progress for seamless resume
- `AgentHandle.send()`/`sendMessage()` convenience methods for typed instruction routing
- Scheduled wakeups enqueue directly as `background` priority instead of writing synthetic channel messages

## Changes

**Phase 5a — Priority Queue + Types** (`priority-queue.ts`, `types.ts`)
- `InstructionQueue` class with three FIFO lanes
- `AgentInstruction`, `InstructionPriority`, `InstructionSource`, `InstructionProgress` types
- `classifyInboxPriority()`: DM → immediate, high → immediate, normal → normal
- Loop refactored: inbox → classify → enqueue → dequeue highest → process

**Phase 5b — Cooperative Preemption** (`sdk-runner.ts`, `mock-runner.ts`, `loop.ts`)
- `PreemptionError` throw-to-exit in `onStepFinish` callbacks
- `shouldYield` callback wired through `AgentRunContext`
- Loop re-queues preempted instructions with `InstructionProgress` (step count, completed work summary, preempt count)
- Resume context appended to prompt on re-invocation

**Phase 5c — Routing Integration** (`agent-handle.ts`, `loop.ts`)
- `AgentHandle.send(instruction)` and `sendMessage(msg, opts)` delegate to `loop.enqueue()`
- Scheduled wakeups bypass synthetic channel messages, enqueue directly as background

## Test plan

- [x] 31 new tests (priority queue ordering, preemption, re-queue with progress, AgentHandle.send)
- [x] Full suite: 1047 pass, 0 fail, 0 regressions
- [x] Build succeeds for all three packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)