### PR TITLE
fix: remove preserveSymlinks causing duplicate type resolution in CI

### DIFF
--- a/packages/agent-worker/tsconfig.json
+++ b/packages/agent-worker/tsconfig.json
@@ -30,8 +30,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
-    "preserveSymlinks": true
   },
   "include": ["src"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
 }

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -25,8 +25,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
-    "preserveSymlinks": true
   },
   "include": ["src"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
 }

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -25,8 +25,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
-    "preserveSymlinks": true
   },
   "include": ["src"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
 }

--- a/packages/workspace/tsconfig.json
+++ b/packages/workspace/tsconfig.json
@@ -25,8 +25,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
-    "preserveSymlinks": true
   },
   "include": ["src"],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
 }


### PR DESCRIPTION
## Summary

- Remove `preserveSymlinks: true` from all 4 package tsconfigs
- Root cause: with internal packages now exporting source TS (not dist), tsgo sees workspace symlinks as two different paths to the same module, creating incompatible duplicate types
- Without `preserveSymlinks`, tsgo resolves symlinks to their real path and sees one canonical module

## Test plan

- [x] `bun run --filter='*' typecheck` — all 4 packages pass
- [x] `bun run build` — clean
- [x] `bun test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)