### PR TITLE
fix: remove changeset ignore list causing validation error

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,5 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
-  "ignore": ["@moniro/agent-loop", "@moniro/agent-worker", "@moniro/workspace"]
+  "baseBranch": "main"
 }


### PR DESCRIPTION
## Summary

Remove `ignore` list from `.changeset/config.json`. Changeset doesn't allow a published package (`agent-worker`) to depend on ignored packages — it throws a validation error.

Private packages (`private: true`) are already skipped by `changeset publish` automatically, so explicit `ignore` is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)