### PR TITLE
fix: add privatePackages config for changeset validation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,5 +5,6 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main"
+  "baseBranch": "main",
+  "privatePackages": { "version": true, "tag": false }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@moniro/agent-loop",
+  "version": "0.0.0",
   "description": "Agent execution layer — worker, backends, tools, skills",
   "repository": {
     "type": "git",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@moniro/agent-worker",
+  "version": "0.0.0",
   "description": "Personal agent layer — identity, memory, prompt assembly, personal tools",
   "repository": {
     "type": "git",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@moniro/workspace",
+  "version": "0.0.0",
   "description": "Workflow orchestration layer — multi-agent coordination, shared context, MCP",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Add `privatePackages: { version: true, tag: false }` to changeset config.

Changeset skips private packages by default, then rejects published packages (`agent-worker`) that depend on skipped ones. This is the [official workaround](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md) — private packages participate in version calculations without being published or tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)